### PR TITLE
Remove leftover shortcodes

### DIFF
--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -149,6 +149,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		 */
 		public static function clean_string( $string ) {
 			$string = do_shortcode( $string );
+			$string = preg_replace("~(?:\[/?)[^/\]]+/?\]~s", '', $string);
 			$string = str_replace( array( '&amp%3B', '&amp;' ), '&', $string );
 			$string = str_replace( array( "\r", '&nbsp;', "\t" ), ' ', $string );
 			$string = wp_strip_all_tags( $string, false ); // true == remove line breaks


### PR DESCRIPTION
This is related to issue #493 

The clean_string function seems to be used before some plugins have registered their shortcodes, so they don't get rendered by do_shortcode and are left in the description.

This removes anything within square brackets that are left in the description without removing the inner content (Using strip_shortcodes removes inner content).
