### PR TITLE
Improve Performance of Facebook for WC google_product_category function

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -79,6 +79,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/** @var \SkyVerge\WooCommerce\Facebook\Commerce commerce handler */
 		private $commerce_handler;
 
+		/** @var \SkyVerge\WooCommerce\Facebook\Google_Categories google categories handler */
+		private $google_categories_handler;
+
 
 		/**
 		 * Constructs the plugin.
@@ -129,17 +132,19 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				require_once __DIR__ . '/includes/fbproductfeed.php';
 				require_once __DIR__ . '/facebook-commerce-messenger-chat.php';
 				require_once __DIR__ . '/includes/Commerce.php';
+				require_once __DIR__ . '/includes/Google_Categories.php';
 				require_once __DIR__ . '/includes/Events/Event.php';
 				require_once __DIR__ . '/includes/Events/Normalizer.php';
 				require_once __DIR__ . '/includes/Events/AAMSettings.php';
 				require_once __DIR__ . '/includes/Utilities/Shipment.php';
 
-				$this->product_feed            = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
-				$this->products_stock_handler  = new \SkyVerge\WooCommerce\Facebook\Products\Stock();
-				$this->products_sync_handler   = new \SkyVerge\WooCommerce\Facebook\Products\Sync();
-				$this->sync_background_handler = new \SkyVerge\WooCommerce\Facebook\Products\Sync\Background();
-				$this->commerce_handler        = new \SkyVerge\WooCommerce\Facebook\Commerce();
-				$this->fb_categories 					 = new \SkyVerge\WooCommerce\Facebook\Products\FBCategories();
+				$this->product_feed              = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
+				$this->products_stock_handler    = new \SkyVerge\WooCommerce\Facebook\Products\Stock();
+				$this->products_sync_handler     = new \SkyVerge\WooCommerce\Facebook\Products\Sync();
+				$this->sync_background_handler   = new \SkyVerge\WooCommerce\Facebook\Products\Sync\Background();
+				$this->commerce_handler          = new \SkyVerge\WooCommerce\Facebook\Commerce();
+				$this->google_categories_handler = new \SkyVerge\WooCommerce\Facebook\Google_Categories();
+				$this->fb_categories             = new \SkyVerge\WooCommerce\Facebook\Products\FBCategories();
 
 				if ( is_ajax() ) {
 					$this->ajax = new \SkyVerge\WooCommerce\Facebook\AJAX();

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -732,6 +732,20 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			return $this->commerce_handler;
 		}
 
+
+		/**
+		 * Gets Google categories handler instance.
+		 *
+		 * @since 2.2.1-dev.1
+		 *
+		 * @return \SkyVerge\WooCommerce\Facebook\Google_Categories Google categories handler instance
+		 */
+		public function get_google_categories_handler() {
+
+			return $this->google_categories_handler;
+		}
+
+
 		/**
 		 * Gets the settings page URL.
 		 *

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -74,7 +74,7 @@ class Google_Product_Category_Field {
 
 		if ( ! empty( $response_body ) ) {
 
-			$categories = Google_Categories::parse_categories_response_body( $categories_response['body'] );
+			$categories = Google_Categories::parse_categories_response_body( $response_body );
 		}
 
 		return $categories;

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -50,6 +50,8 @@ class Google_Product_Category_Field {
 	 * Gets the full categories list from Google and stores it.
 	 *
 	 * @since 2.1.0
+	 *
+	 * @return array
 	 */
 	public function get_categories() {
 

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -51,30 +51,7 @@ class Google_Product_Category_Field {
 	 */
 	public function get_categories() {
 
-		// only fetch again if not fetched less than one hour ago
-		$categories = get_transient( self::OPTION_GOOGLE_PRODUCT_CATEGORIES );
-
-		if ( empty ( $categories ) ) {
-
-			// fetch from the URL
-			$categories_response = wp_remote_get( 'https://www.google.com/basepages/producttype/taxonomy-with-ids.en-US.txt' );
-
-			$categories = $this->parse_categories_response( $categories_response );
-
-			if ( ! empty( $categories ) ) {
-
-				set_transient( self::OPTION_GOOGLE_PRODUCT_CATEGORIES, $categories, WEEK_IN_SECONDS );
-				update_option( self::OPTION_GOOGLE_PRODUCT_CATEGORIES, $categories );
-			}
-		}
-
-		if ( empty( $categories ) ) {
-
-			// get the categories from the saved option
-			$categories = get_option( self::OPTION_GOOGLE_PRODUCT_CATEGORIES, [] );
-		}
-
-		return $categories;
+		return facebook_for_woocommerce()->get_google_categories_handler()->get_categories();
 	}
 
 

--- a/includes/Google_Categories.php
+++ b/includes/Google_Categories.php
@@ -137,8 +137,10 @@ class Google_Categories {
 		$this->empty_db_table();
 
 		foreach ( $categories as $category_id => $category ) {
-
-			$this->store_item( $category_id, $category['label'], $category['parent'] );
+			// make sure to store the item if both label and parent keys defined
+			if ( isset( $category['label'], $category['parent'] ) ) {
+				$this->store_item( $category_id, $category['label'], $category['parent'] );
+			}
 		}
 	}
 

--- a/includes/Google_Categories.php
+++ b/includes/Google_Categories.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * Base handler for loading the list of defined Google categories.
+ *
+ * @since 2.2.1-dev.1
+ */
+class Google_Categories {
+
+
+	/**
+	 * Commerce handler constructor.
+	 *
+	 * @since 2.1.1-dev.1
+	 */
+	public function __construct() {
+
+	}
+
+}

--- a/includes/Google_Categories.php
+++ b/includes/Google_Categories.php
@@ -212,7 +212,7 @@ class Google_Categories {
 			return new \WP_Error( 'wc_facebook_google_categories_empty_response', __( 'Google categories response is empty.', 'facebook-for-woocommerce' ) );
 		}
 
-		return $this->parse_categories_response( $response_body );
+		return self::parse_categories_response_body( $response_body );
 	}
 
 
@@ -224,7 +224,7 @@ class Google_Categories {
 	 * @param string $response_body categories response body from Google
 	 * @return array
 	 */
-	protected function parse_categories_response( $response_body ) {
+	public static function parse_categories_response_body( $response_body ) {
 
 		$categories        = [];
 		$categories_body   = explode( "\n", $response_body );

--- a/includes/Google_Categories.php
+++ b/includes/Google_Categories.php
@@ -76,22 +76,23 @@ class Google_Categories {
 
 		$categories = [];
 
+		// structure all categories semi-flat
 		foreach ( $raw_categories_items as $category_item ) {
-
-			$category_id        = (int) $category_item['id'];
-			$parent_category_id = (int) $category_item['parent_id'];
-
-			$category = [
+			$categories[ (int) $category_item['id'] ] = [
 				'label'   => $category_item['label'],
 				'options' => [],
-				'parent'  => $parent_category_id,
+				'parent'  => (int) $category_item['parent_id'],
 			];
+		}
+
+		// then insert sub-categories as options
+		foreach ( $raw_categories_items as $category_item ) {
+
+			$parent_category_id = (int) $category_item['parent_id'];
 
 			if ( isset( $categories[ $parent_category_id ] ) ) {
-				$categories[ $parent_category_id ]['options'][ $category_id ] = $category['label'];
+				$categories[ $parent_category_id ]['options'][ (int) $category_item['id'] ] = $category_item['label'];
 			}
-
-			$categories[ $category_id ] = $category;
 		}
 
 		return $categories;
@@ -109,7 +110,7 @@ class Google_Categories {
 
 		global $wpdb;
 
-		return (array) $wpdb->get_results( 'SELECT * FROM ' . self::get_table_name(), ARRAY_A );
+		return (array) $wpdb->get_results( 'SELECT * FROM ' . self::get_table_name() . ' ORDER BY id ASC', ARRAY_A );
 	}
 
 

--- a/includes/Google_Categories.php
+++ b/includes/Google_Categories.php
@@ -39,11 +39,12 @@ class Google_Categories {
 		if ( empty ( $categories ) ) {
 
 			// fetch from the URL
-			$categories = $this->fetch_categories_list_from_url();
+			// $categories = $this->fetch_categories_list_from_url();
 
-			if ( ! empty( $categories ) ) {
-				set_transient( self::OPTION_GOOGLE_PRODUCT_CATEGORIES, $categories, WEEK_IN_SECONDS );
-			}
+
+			//			if ( ! empty( $categories ) ) {
+			//				set_transient( self::OPTION_GOOGLE_PRODUCT_CATEGORIES, $categories, WEEK_IN_SECONDS );
+			//			}
 		}
 
 		return $categories;
@@ -160,6 +161,46 @@ class Google_Categories {
 		 * @param array $categories_list_url Google categories list URL
 		 */
 		return (string) apply_filters( 'wc_facebook_google_categories_list_url', 'https://www.google.com/basepages/producttype/taxonomy-with-ids.en-US.txt' );
+	}
+
+
+	/**
+	 * Gets the table name used for storing categories.
+	 *
+	 * @since 2.2.1-dev.1
+	 *
+	 * @return string table name
+	 */
+	public static function get_table_name() {
+
+		global $wpdb;
+
+		return $wpdb->prefix . 'wc_facebook_google_categories';
+	}
+
+
+	/**
+	 * Returns the database schema needed to create the table.
+	 *
+	 * @since 2.2.1-dev.1
+	 *
+	 * @return string database schema
+	 */
+	public static function get_table_schema() {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+		$collate    = $collate = $wpdb->has_cap( 'collation' ) ? $wpdb->get_charset_collate() : '';
+
+		return "CREATE TABLE {$table_name} (
+  id BIGINT(20) unsigned NOT NULL auto_increment,
+  parent_id BIGINT(20) NOT NULL default 0,
+  label VARCHAR(200) NOT NULL default '',
+  PRIMARY KEY (id ASC),
+  KEY parent_id (parent_id ASC)
+) $collate;
+		";
 	}
 
 }

--- a/includes/Google_Categories.php
+++ b/includes/Google_Categories.php
@@ -19,14 +19,82 @@ defined( 'ABSPATH' ) or exit;
  */
 class Google_Categories {
 
+	/** @var string the WordPress option name where the full categories list is stored */
+	const OPTION_GOOGLE_PRODUCT_CATEGORIES = 'wc_facebook_google_product_categories';
+
 
 	/**
-	 * Commerce handler constructor.
+	 * Gets the categories list.
 	 *
-	 * @since 2.1.1-dev.1
+	 * @since 2.2.1-dev.1
+	 *
+	 * @return array
 	 */
-	public function __construct() {
+	public function get_categories() {
 
+		// only fetch again if not fetched less than one week ago
+		// $categories = get_transient( self::OPTION_GOOGLE_PRODUCT_CATEGORIES );
+		$categories = '';
+
+		if ( empty ( $categories ) ) {
+
+			// fetch from the URL
+			$categories = $this->fetch_categories_list_from_url();
+
+			if ( ! empty( $categories ) ) {
+				set_transient( self::OPTION_GOOGLE_PRODUCT_CATEGORIES, $categories, WEEK_IN_SECONDS );
+			}
+		}
+
+		return $categories;
+	}
+
+
+	/**
+	 * Fetches the full categories list from Google.
+	 *
+	 * @since 2.2.1-dev.1
+	 *
+	 * @return array|\WP_Error
+	 */
+	private function fetch_categories_list_from_url() {
+
+		$url = $this->get_categories_list_url();
+
+		// fail if URL is empty or undefined
+		if ( empty( $url ) ) {
+			return new \WP_Error( 'wc_facebook_google_categories_missing_url', __( 'Google categories URL is missing.', 'facebook-for-woocommerce' ) );
+		}
+
+		// fetch from the URL
+		$response = wp_remote_get( $url );
+
+		// fail if response is not OK
+		$response_code = (int) wp_remote_retrieve_response_code( $response );
+		if ( 200 !== $response_code ) {
+			return new \WP_Error( 'wc_facebook_google_categories_response_error', __( 'Google categories URL returned error.', 'facebook-for-woocommerce' ), [
+				'response_code'       => $response_code,
+				'categories_list_url' => $url,
+			] );
+		}
+
+		return wp_remote_retrieve_body( $response );
+	}
+
+
+	/**
+	 * @return string
+	 */
+	private function get_categories_list_url() {
+
+		/**
+		 * Filters the Google categories list URL.
+		 *
+		 * @since 2.2.1-dev.1
+		 *
+		 * @param array $categories_list_url Google categories list URL
+		 */
+		return (string) apply_filters( 'wc_facebook_google_categories_list_url', 'https://www.google.com/basepages/producttype/taxonomy-with-ids.en-US.txt' );
 	}
 
 }

--- a/includes/Google_Categories.php
+++ b/includes/Google_Categories.php
@@ -260,17 +260,32 @@ class Google_Categories {
 		// example: 7385 - Animals & Pet Supplies > Pet Supplies > Bird Supplies > Bird Cage Accessories
 		foreach ( $categories_body as $category_line ) {
 
+			// not a category, skip it
 			if ( strpos( $category_line, ' - ' ) === false ) {
-
-				// not a category, skip it
 				continue;
 			}
 
 			list( $category_id, $category_tree ) = explode( ' - ', $category_line );
 
-			$category_id    = (string) trim( $category_id );
-			$category_tree  = explode( ' > ', $category_tree );
+			// bail if category ID ot tree missing
+			if ( empty( $category_id ) || empty( $category_tree ) ) {
+				continue;
+			}
+
+			$category_id   = (string) trim( $category_id );
+			$category_tree = explode( ' > ', $category_tree );
+
+			// bail if category tree can't be split
+			if ( empty( $category_tree ) ) {
+				continue;
+			}
+
 			$category_label = end( $category_tree );
+
+			// bail if category label isn't set or empty for some reason
+			if ( empty( $category_label ) ) {
+				continue;
+			}
 
 			$categories_labels[ $category_label ] = $category_id;
 

--- a/includes/Google_Categories.php
+++ b/includes/Google_Categories.php
@@ -319,6 +319,8 @@ class Google_Categories {
 	/**
 	 * Gets Google categories list URL.
 	 *
+	 * TODO maybe provide localized categories list, see https://support.google.com/merchants/answer/6324436?hl=en {NM 2020-12-11}
+	 *
 	 * @since 2.2.1-dev.1
 	 *
 	 * @return string

--- a/includes/Google_Categories.php
+++ b/includes/Google_Categories.php
@@ -22,6 +22,9 @@ class Google_Categories {
 	/** @var string the WordPress option name where the last time the full categories list get updated is stored */
 	const OPTION_GOOGLE_PRODUCT_CATEGORIES_UPDATED = 'wc_facebook_google_product_categories_update';
 
+	/** @var array 2nd level of cache for loading Google categories list */
+	private $categories_list;
+
 
 	/**
 	 * Gets the categories list.
@@ -32,6 +35,10 @@ class Google_Categories {
 	 */
 	public function get_categories() {
 
+		if ( ! empty( $this->categories_list ) ) {
+			return $this->categories_list;
+		}
+
 		// only fetch again if not fetched less than one week ago
 		$last_updated = get_transient( self::OPTION_GOOGLE_PRODUCT_CATEGORIES_UPDATED );
 
@@ -40,7 +47,7 @@ class Google_Categories {
 			// fetch from the URL
 			$categories = $this->fetch_categories_list_from_url();
 
-			if ( ! empty( $categories ) ) {
+			if ( ! empty( $categories ) && ! is_wp_error( $categories ) ) {
 
 				// store into database for later use
 				$this->store_categories_list( $categories );
@@ -54,6 +61,8 @@ class Google_Categories {
 			$categories = $this->get_cached_categories_list();
 
 		}
+
+		$this->categories_list = $categories;
 
 		return $categories;
 	}

--- a/includes/Google_Categories.php
+++ b/includes/Google_Categories.php
@@ -47,7 +47,7 @@ class Google_Categories {
 		// only fetch again if not fetched less than one week ago
 		$last_updated = get_transient( self::OPTION_GOOGLE_PRODUCT_CATEGORIES_UPDATED );
 
-		if ( empty ( $last_updated ) ) {
+		if ( empty( $last_updated ) ) {
 
 			$categories = [];
 
@@ -81,11 +81,11 @@ class Google_Categories {
 				// mark when it's stored
 				set_transient( self::OPTION_GOOGLE_PRODUCT_CATEGORIES_UPDATED, current_time( 'mysql' ), WEEK_IN_SECONDS );
 			}
+
 		} else {
 
 			// load from database/cached
 			$categories = $this->get_cached_categories_list();
-
 		}
 
 		$this->categories_list = $categories;

--- a/includes/Google_Categories.php
+++ b/includes/Google_Categories.php
@@ -31,6 +31,9 @@ class Google_Categories {
 	/**
 	 * Gets the categories list.
 	 *
+	 * TODO we need to figure out a way to of load the long loading time or
+	 *      re-kickstart the process of the merchant reloaded the page {NM 2020-12-11}
+	 *
 	 * @since 2.2.1-dev.1
 	 *
 	 * @return array

--- a/includes/Google_Categories.php
+++ b/includes/Google_Categories.php
@@ -145,6 +145,8 @@ class Google_Categories {
 
 		global $wpdb;
 
+		self::maybe_create_table();
+
 		return (array) $wpdb->get_results( 'SELECT * FROM ' . self::get_table_name() . ' ORDER BY id ASC', ARRAY_A );
 	}
 
@@ -375,6 +377,49 @@ class Google_Categories {
   KEY parent_id (parent_id ASC)
 ) $collate;
 		";
+	}
+
+
+	/**
+	 * Validates that the table required by Google Categories is present in the database.
+	 *
+	 * @internal
+	 *
+	 * @since 2.2.1-dev.1
+	 *
+	 * @return bool true if all are found, false if not
+	 */
+	public static function is_table_exists() {
+
+		global $wpdb;
+
+		$table_name = self::get_table_name();
+
+		return $table_name === $wpdb->get_var( "SHOW TABLES LIKE '{$table_name}'" );
+	}
+
+
+	/**
+	 * Creates the table required by Google Categories is present in the database.
+	 *
+	 * @internal
+	 *
+	 * @since 2.2.1-dev.1
+	 */
+	public static function maybe_create_table() {
+
+		global $wpdb;
+
+		// nothing to create if we're already there
+		if ( self::is_table_exists() ) {
+			return;
+		}
+
+		$wpdb->hide_errors();
+
+		require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
+
+		dbDelta( self::get_table_schema() );
 	}
 
 }

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -351,7 +351,7 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 
 		self::remove_google_categories_from_options();
 
-		self::create_google_categories_table();
+		Google_Categories::maybe_create_table();
 	}
 
 
@@ -367,42 +367,5 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 		delete_transient( Google_Product_Category_Field::OPTION_GOOGLE_PRODUCT_CATEGORIES );
 	}
 
-	/**
-	 * Creates the table required by Google Categories is present in the database.
-	 *
-	 * @since 2.2.1-dev.1
-	 */
-	private static function create_google_categories_table() {
-
-		global $wpdb;
-
-		// nothing to create if we're already there
-		if ( self::validate_google_categories_table() ) {
-			return;
-		}
-
-		$wpdb->hide_errors();
-
-		require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
-
-		dbDelta( Google_Categories::get_table_schema() );
-	}
-
-
-	/**
-	 * Validates that the table required by Google Categories is present in the database.
-	 *
-	 * @since 2.2.1-dev.1
-	 *
-	 * @return bool true if all are found, false if not
-	 */
-	private static function validate_google_categories_table() {
-
-		global $wpdb;
-
-		$table_name = Google_Categories::get_table_name();
-
-		return $table_name === $wpdb->get_var( "SHOW TABLES LIKE '{$table_name}'" );
-	}
 
 }

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -10,6 +10,7 @@
 
 namespace SkyVerge\WooCommerce\Facebook;
 
+use SkyVerge\WooCommerce\Facebook\Admin\Google_Product_Category_Field;
 use SkyVerge\WooCommerce\PluginFramework\v5_10_0 as Framework;
 
 defined( 'ABSPATH' ) or exit;
@@ -348,6 +349,31 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 	 */
 	protected function upgrade_to_2_2_1() {
 
+		self::remove_google_categories_from_options();
+
+		self::create_google_categories_table();
+	}
+
+
+	/**
+	 * Removes Google Categories from options table.
+	 *
+	 * @since 2.2.1-dev.1
+	 */
+	private static function remove_google_categories_from_options() {
+
+		delete_option( Google_Product_Category_Field::OPTION_GOOGLE_PRODUCT_CATEGORIES );
+
+		delete_transient( Google_Product_Category_Field::OPTION_GOOGLE_PRODUCT_CATEGORIES );
+	}
+
+	/**
+	 * Creates the table required by Google Categories is present in the database.
+	 *
+	 * @since 2.2.1-dev.1
+	 */
+	private static function create_google_categories_table() {
+
 		global $wpdb;
 
 		// nothing to create if we're already there
@@ -362,6 +388,7 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 		dbDelta( Google_Categories::get_table_schema() );
 	}
 
+
 	/**
 	 * Validates that the table required by Google Categories is present in the database.
 	 *
@@ -369,7 +396,8 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 	 *
 	 * @return bool true if all are found, false if not
 	 */
-	public static function validate_google_categories_table() {
+	private static function validate_google_categories_table() {
+
 		global $wpdb;
 
 		$table_name = Google_Categories::get_table_name();

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -62,6 +62,9 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 
 			$this->upgrade( '1.9.15' );
 		}
+
+		// Versions prior to 2.2.1-dev.1 did not have Google categories custom table, so the upgrade method needs to be called manually.
+		$this->upgrade( '2.2.1-dev.1' );
 	}
 
 

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -42,6 +42,7 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 			'2.0.0',
 			'2.0.3',
 			'2.0.4',
+			'2.2.1',
 		];
 	}
 
@@ -336,5 +337,41 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 		}
 	}
 
+
+	/**
+	 * Upgrades to version 2.2.1
+	 *
+	 * @since 2.2.1-dev.1
+	 */
+	protected function upgrade_to_2_2_1() {
+
+		global $wpdb;
+
+		// nothing to create if we're already there
+		if ( self::validate_google_categories_table() ) {
+			return;
+		}
+
+		$wpdb->hide_errors();
+
+		require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
+
+		dbDelta( Google_Categories::get_table_schema() );
+	}
+
+	/**
+	 * Validates that the table required by Google Categories is present in the database.
+	 *
+	 * @since 2.2.1-dev.1
+	 *
+	 * @return bool true if all are found, false if not
+	 */
+	public static function validate_google_categories_table() {
+		global $wpdb;
+
+		$table_name = Google_Categories::get_table_name();
+
+		return $table_name === $wpdb->get_var( "SHOW TABLES LIKE '{$table_name}'" );
+	}
 
 }


### PR DESCRIPTION
# Summary

Merchants are finding that the wc_facebook_google_product_categories field is making their options table too large. Some merchants have recounted performance issues, others CRITICAL errors, and some even said their hosting provider was threatening fees.

### Story: [CH 67779](https://app.clubhouse.io/skyverge/story/67779)
### Release: #1720 

## Note

I am gonna need some assistance refactoring the `GoogleProductCategoryFieldTest` tests to test the new data storage method.

## UI Changes

N/A

## QA

### Setup

- Install and configure Facebook for WooCommerce from this PR.

### Steps

- [x] After plugin installed or upgraded from previous versions, a new DB custom table called `{table_prefix}wc_facebook_google_categories` created in the database.
- Head out to Admin Dashboard > Marketing > Facebook > Product Sync
    - [x] If it's the first time opening the page after the upgrade, it takes few seconds to load while loading the categories list from Google
    - [x] The `wc_facebook_google_categories` filled up with the data from google.
    - [x] A `wc_facebook_google_product_categories_update` transient is set which triggers the list to be updated once every week.
    - [x] The page loads much faster when reloading/refreshing the page.
- [x] Browsing around the website doesn't trigger any errors or slow down as before as there is no more heavy load on the options table.

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version