### PR TITLE
add connection state (boolean) to tracker snapshot

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -88,6 +88,8 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/** @var \SkyVerge\WooCommerce\Facebook\Commerce commerce handler */
 		private $commerce_handler;
 
+		/** @var \SkyVerge\WooCommerce\Facebook\Tracker */
+		private $tracker;
 
 		/**
 		 * Constructs the plugin.
@@ -152,6 +154,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				require_once __DIR__ . '/includes/Events/Normalizer.php';
 				require_once __DIR__ . '/includes/Events/AAMSettings.php';
 				require_once __DIR__ . '/includes/Utilities/Shipment.php';
+				require_once __DIR__ . '/includes/Utilities/Tracker.php';
 
 				$this->product_feed              = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
 				$this->products_stock_handler    = new \SkyVerge\WooCommerce\Facebook\Products\Stock();
@@ -184,6 +187,10 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 				$this->connection_handler = new \SkyVerge\WooCommerce\Facebook\Handlers\Connection( $this );
 				$this->webhook_handler = new \SkyVerge\WooCommerce\Facebook\Handlers\WebHook( $this );
+
+				if ( \WC_Facebookcommerce_Utils::isWoocommerceIntegration() ) {
+					$this->tracker = new \SkyVerge\WooCommerce\Facebook\Utilities\Tracker();
+				}
 
 				// load admin handlers, before admin_init
 				if ( is_admin() ) {

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -188,9 +188,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				$this->connection_handler = new \SkyVerge\WooCommerce\Facebook\Handlers\Connection( $this );
 				$this->webhook_handler = new \SkyVerge\WooCommerce\Facebook\Handlers\WebHook( $this );
 
-				if ( \WC_Facebookcommerce_Utils::isWoocommerceIntegration() ) {
-					$this->tracker = new \SkyVerge\WooCommerce\Facebook\Utilities\Tracker();
-				}
+				$this->tracker = new \SkyVerge\WooCommerce\Facebook\Utilities\Tracker();
 
 				// load admin handlers, before admin_init
 				if ( is_admin() ) {

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -45,8 +45,6 @@ class Tracker {
 
 		$data['extensions']['facebook-for-woocommerce']['is-connected'] = $connection_handler->is_connected();
 
-		wc_get_logger()->debug( print_r( $data, true ) );
-
 		return $data;
 	}
 }

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -41,20 +41,19 @@ class Tracker {
 	 * @since 2.3.4
 	 */
 	public function add_tracker_data( array $data = array() ) {
-		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
-		if ( ! $connection_handler ) {
-			return $data;
-		}
-
 		if ( ! isset( $data['extensions'] ) ) {
 			$data['extensions'] = array();
 		}
 
-		$connection_is_happy = $connection_handler->is_connected() && ! get_transient( 'wc_facebook_connection_invalid' );
+		$connection_is_happy = false;
+		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
+		if ( $connection_handler ) {
+			$connection_is_happy = $connection_handler->is_connected() && ! get_transient( 'wc_facebook_connection_invalid' );
+		}
 		$data['extensions']['facebook-for-woocommerce']['is-connected'] = wc_bool_to_string( $connection_is_happy );
 
 		// Debug logging - remove before merge.
-		facebook_for_woocommerce()->log( 'Added Facebook connection state to tracker snapshot: ' . print_r( $data, true ) );
+		wc_get_logger()->debug( 'Added Facebook connection state to tracker snapshot: ' . print_r( $data, true ) );
 
 		return $data;
 	}

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -52,9 +52,6 @@ class Tracker {
 		}
 		$data['extensions']['facebook-for-woocommerce']['is-connected'] = wc_bool_to_string( $connection_is_happy );
 
-		// Debug logging - remove before merge.
-		wc_get_logger()->debug( 'Added Facebook connection state to tracker snapshot: ' . print_r( $data, true ) );
-
 		return $data;
 	}
 }

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -51,7 +51,10 @@ class Tracker {
 		}
 
 		$connection_is_happy = $connection_handler->is_connected() && ! get_transient( 'wc_facebook_connection_invalid' );
-		$data['extensions']['facebook-for-woocommerce']['is-connected'] = $connection_is_happy;
+		$data['extensions']['facebook-for-woocommerce']['is-connected'] = wc_bool_to_string( $connection_is_happy );
+
+		// Debug logging - remove before merge.
+		facebook_for_woocommerce()->log( 'Added Facebook connection state to tracker snapshot: ' . print_r( $data, true ) );
 
 		return $data;
 	}

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -17,14 +17,14 @@ defined( 'ABSPATH' ) or exit;
  *
  * See https://woocommerce.com/usage-tracking/ for more information.
  *
- * @since %VERSION%
+ * @since 2.3.4
  */
 class Tracker {
 
 	/**
 	 * Constructor.
 	 *
-	 * @since %VERSION%
+	 * @since 2.3.4
 	 */
 	public function __construct() {
 		add_filter(
@@ -38,7 +38,7 @@ class Tracker {
 	 *
 	 * @param array $data The current tracker snapshot data.
 	 * @return array $data Snapshot updated with our data.
-	 * @since %VERSION%
+	 * @since 2.3.4
 	 */
 	public function add_tracker_data( array $data = array() ) {
 		$connection_handler = facebook_for_woocommerce()->get_connection_handler();

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -29,21 +29,29 @@ class Tracker {
 	public function __construct() {
 		add_filter(
 			'woocommerce_tracker_data',
-			[ $this, 'add_tracker_data' ]
+			array( $this, 'add_tracker_data' )
 		);
 	}
 
-	public function add_tracker_data( array $data = [] ) {
+	/**
+	 * Append our tracker properties.
+	 *
+	 * @param array $data The current tracker snapshot data.
+	 * @return array $data Snapshot updated with our data.
+	 * @since %VERSION%
+	 */
+	public function add_tracker_data( array $data = array() ) {
 		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
 		if ( ! $connection_handler ) {
-			return;
+			return $data;
 		}
 
 		if ( ! isset( $data['extensions'] ) ) {
-			$data['extensions'] = [];
+			$data['extensions'] = array();
 		}
 
-		$data['extensions']['facebook-for-woocommerce']['is-connected'] = $connection_handler->is_connected();
+		$connection_is_happy = $connection_handler->is_connected() && ! get_transient( 'wc_facebook_connection_invalid' );
+		$data['extensions']['facebook-for-woocommerce']['is-connected'] = $connection_is_happy;
 
 		return $data;
 	}

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\Utilities;
+
+defined( 'ABSPATH' ) or exit;
+
+/**
+ * Class for adding diagnostic info to WooCommerce Tracker snapshot.
+ *
+ * See https://woocommerce.com/usage-tracking/ for more information.
+ *
+ * @since %VERSION%
+ */
+class Tracker {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since %VERSION%
+	 */
+	public function __construct() {
+		add_filter(
+			'woocommerce_tracker_data',
+			[ $this, 'add_tracker_data' ]
+		);
+	}
+
+	public function add_tracker_data( array $data = [] ) {
+		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
+		if ( ! $connection_handler ) {
+			return;
+		}
+
+		if ( ! isset( $data['extensions'] ) ) {
+			$data['extensions'] = [];
+		}
+
+		$data['extensions']['facebook-for-woocommerce']['is-connected'] = $connection_handler->is_connected();
+
+		wc_get_logger()->debug( print_r( $data, true ) );
+
+		return $data;
+	}
+}


### PR DESCRIPTION
Fixes #1816 

This PR adds a new class to add data about this plugin's state to the [WooCommerce tracker snapshot](https://woocommerce.com/usage-tracking/). Note - tracking is opt-in per store; see `WooCommerce > Settings > Advanced > WooCommerce.com`.

The one new property added in this PR is a boolean value indicating whether the plugin has successfully been connected to facebook. This is stored in `$data[extensions][facebook-for-woocommerce][is-connected]` key, for example:

```
  [extensions] => Array
    (
      [facebook-for-woocommerce] => Array
        (
          [is-connected] => true
        )
    )
```

The goal here is that we can use the tracker data to better understand how many sites are experiencing connection problems. 

#### How to test this PR
The easiest way to test this is to use `wp shell` ([WP-CLI](https://developer.wordpress.org/cli/commands/shell/)) and/or add debug logging messages.

1. Ensure tracking is enabled for your test site: `WooCommerce > Settings > Advanced > WooCommerce.com > Enable tracking`.
2. Add debug code to `Tracker::add_tracker_data()` to log tracker data (see example below).
3. Trigger a sync. One way to do this is to use `wp shell`:
  - `wp shell` to get an interactive shell session
  - Call `WC_Tracker::send_tracking_data( true );` to force a snapshot.
  - Note: this function checks a timestamp ( `woocommerce_tracker_last_send` ) to avoid duplicate requests. You may need to delete this option to ensure the data is regenerated.
5. Repeat tests with different settings, e.g. plugin connected, disconnected, or failed connection. Please test a range of scenarios to ensure there aren't any false positives or vice versa. For example, if the plugin cannot sync and `is-connected=true`, that's probably a bug.

```php
	public function add_tracker_data( array $data = [] ) {
		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
		if ( ! $connection_handler ) {
			return;
		}

		if ( ! isset( $data['extensions'] ) ) {
			$data['extensions'] = [];
		}

		$data['extensions']['facebook-for-woocommerce']['is-connected'] = $connection_handler->is_connected();

		// add logging here  
		wc_get_logger()->debug( print_r( $data, true ) );

		return $data;
	}
```

### Changelog entry

> New: Add connection state to [WooCommerce Usage Tracking](https://woocommerce.com/usage-tracking/)