### PR TITLE
add filter `facebook_for_woocommerce_prepare_product_item_group_id`

### DIFF
--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -268,6 +268,7 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 		// product variations use the parent product's retailer ID as the retailer product group ID
 		// $data['retailer_product_group_id'] = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $parent_product );
 		$data['item_group_id'] = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $parent_product );
+		$data['item_group_id'] = apply_filters( 'facebook_for_woocommerce_prepare_product_item_group_id', $data['item_group_id'], $data, $product );
 
 		return $this->normalize_product_data( $data );
 	}

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -752,7 +752,7 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 				static::get_value_from_product_data( $product_data, 'currency' )
 			) . ',' .
 			static::get_value_from_product_data( $product_data, 'availability' ) . ',' .
-			$item_group_id . ',' .
+			apply_filters( 'facebook_for_woocommerce_prepare_product_item_group_id', $item_group_id, $product_data, $woo_product->woo_product ) . ',' .
 			static::get_value_from_product_data( $product_data, 'checkout_url' ) . ',' .
 			static::format_additional_image_url( static::get_value_from_product_data( $product_data, 'additional_image_urls' ) ) . ',' .
 			static::get_value_from_product_data( $product_data, 'sale_price_start_date' ) . '/' .


### PR DESCRIPTION
I'm trying to make Facebook For WooCommerce compatible with our plugin [Show Single Variations](https://iconicwp.com/products/woocommerce-show-single-variations/). These minor updates will allow us or any other plugin to modify the item_group_id before it is written to the CSV file or sent to Facebook via API. 
 
