### PR TITLE
Check parent category for attributes if current category has none.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,10 +1,11 @@
 *** Facebook for WooCommerce Changelog ***
 
 2021.nn.nn - version 2.3.6
- * Tweak - Improve full sync performance. 
+ * Tweak - Improve full sync performance.
+ * Fix - Fatal error for product categories with missing attributes.
 
 2021.03.31 - version 2.3.5
- * Fix - critical issue for pre 5.0.0 WC sites
+ * Fix - Critical issue for pre 5.0.0 WC sites.
 
 2021.03.30 - version 2.3.4
  * Feature - Add connection state to WooCommerce Usage Tracking.

--- a/includes/Products/FBCategories.php
+++ b/includes/Products/FBCategories.php
@@ -139,12 +139,34 @@ class FBCategories {
 	 * @return null|boolean Null if category was not found or boolean that determines if this is a root category or not.
 	 */
 	public function get_category_with_attrs( $category_id ) {
-		$this->ensure_data_is_loaded( true );
-		if ( $this->is_category( $category_id ) ) {
-			return $this->attributes_data[ $category_id ];
-		} else {
+		$this->ensure_data_is_loaded();
+		if ( ! $this->is_category( $category_id ) ) {
 			return null;
 		}
+
+		if ( isset( $this->attributes_data[ $category_id ] ) ) {
+			return $this->attributes_data[ $category_id ];
+		}
+
+		facebook_for_woocommerce()->log( sprintf( 'Google Product Category to Facebook attributes mapping for category with id: %s not found', $category_id ) );
+		// Category has no attributes entry - it should be add but for now check parent category.
+		if ( $this->is_root_category( $category_id ) ) {
+			return null;
+		}
+
+		$parent_category_id = GoogleProductTaxonomy::TAXONOMY[ $category_id ]['parent'];
+
+		if ( isset( $this->attributes_data[ $parent_category_id ] ) ) {
+			return $this->attributes_data[ $parent_category_id ];
+		}
+
+		/*
+		* We could check further as we have 3 levels of product categories.
+		* This would meant that we have a big problem with mapping - let this fail and log the problem.
+		*/
+		facebook_for_woocommerce()->log( sprintf( 'Google Product Category to Facebook attributes mapping for parent category with id: %s not found', $parent_category_id ) );
+
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Fixes: #1804

This requires and is based on #1810 - if approved before #1810 lands I will merge it there.

In general, if we don't have attributes for the given category we should add them -  but that may be quite problematic. This is a quick workaround that uses the parent category attributes if they are available.

## Changelog
- Fix: Add fallback for missing category attributes.