### PR TITLE
Optimise memory usage for whole catalog sync scenario.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Facebook for WooCommerce Changelog ***
 
+2021.nn.nn - version 2.3.6
+ * Tweak - Improve full sync performance. 
+
 2021.03.31 - version 2.3.5
  * Fix - critical issue for pre 5.0.0 WC sites
 

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -74,48 +74,8 @@ class Sync {
 	 * @since 2.0.0
 	 */
 	public function create_or_update_all_products() {
-
-		// Get all published products ids. This includes parent products of variations.
-		$product_args = array(
-			'fields'         => 'ids',
-			'post_status'    => 'publish',
-			'post_type'      => 'product',
-			'posts_per_page' => -1,
-		);
-		$product_ids  = get_posts( $product_args );
-
-		// Get all variations ids with their parents ids.
-		$variation_args     = array(
-			'fields'         => 'id=>parent',
-			'post_status'    => 'publish',
-			'post_type'      => 'product_variation',
-			'posts_per_page' => -1,
-		);
-		$variation_products = get_posts( $variation_args );
-
-		/*
-		 * Collect all parent products.
-		 * Exclude variations which parents are not 'publish'.
-		 */
-		$parent_product_ids = array();
-		foreach ( $variation_products as $post_id => $parent_id ) {
-			/*
-			 * Keep track of all parents to remove them from the list of products to sync.
-			 * Use key to automatically remove duplicated items.
-			 */
-			$parent_product_ids[ $parent_id ] = true;
-
-			// Include variations with published parents only.
-			if ( in_array( $parent_id, $product_ids ) ) {
-				$product_ids[] = $post_id;
-			}
-		}
-
-		// Remove parent products because those can't be represented as Product Items.
-		$product_ids = array_diff( $product_ids, array_keys( $parent_product_ids ) );
-
 		// Queue up these IDs for sync. they will only be included in the final requests if they should be synced.
-		$this->create_or_update_products( $product_ids );
+		$this->create_or_update_products( \WC_Facebookcommerce_Utils::get_all_product_ids_for_sync() );
 	}
 
 

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -892,6 +892,9 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 		}
 
 		public function get_product_wpid() {
+
+			wc_deprecated_function( __METHOD__, '2.3.6', '\\WC_Facebookcommerce_Utils::get_all_product_ids_for_sync()' );
+
 			$post_ids = WC_Facebookcommerce_Utils::get_wp_posts(
 				null,
 				null,

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -446,29 +446,7 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 		 * @return int[]
 		 */
 		private function get_product_ids() {
-
-			$post_ids = $this->get_product_wpid();
-
-			// remove variations with unpublished parents
-			$post_ids = array_filter( $post_ids,
-				function ( $post_id ) {
-					return ( 'product_variation' !== get_post_type( $post_id )
-					         || 'publish' === get_post( wp_get_post_parent_id( $post_id ) )->post_status );
-				}
-			);
-
-			$all_parent_product = array_map(
-				function( $post_id ) {
-					if ( 'product_variation' === get_post_type( $post_id ) ) {
-						return wp_get_post_parent_id( $post_id );
-					}
-				},
-				$post_ids
-			);
-
-			$all_parent_product = array_filter( array_unique( $all_parent_product ) );
-
-			return array_diff( $post_ids, $all_parent_product );
+			return \WC_Facebookcommerce_Utils::get_all_product_ids_for_sync();
 		}
 
 

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -437,6 +437,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		/**
 		 * Get all products for synchronization tasks.
 		 *
+		 * Warning: While changing this code please make sure that it scales properly.
+		 * Sites with big product catalogs should not experience memory problems.
+		 *
 		 * @return array IDs of all product for synchronization.
 		 */
 		public static function get_all_product_ids_for_sync() {


### PR DESCRIPTION
Partially fixes #1839

This refactors the code that is used to prepare the synchronization of all products to the FaceBook catalog.

### What has been changed.

We split the main query into two queries. One for `product` and one for `product_variation`. For the first, we can optimize the flow and get the `ids` directly. For the second one, the args remain unchanged. What does that give us?

We don't need to test the product for the `product_variation` type - we already have separate arrays for each product type.

We also don't need to test if the parent product is in state `publish` or not. We have all `publish` products from the first query - we need to just check if our variation product parent is in the array.

This significantly reduces the required memory on my machine. For a catalog of ~1000 products and ~6500 variations, the request was originally using around ~110MB. After this change was introduced the request was using ~31MB which is only 2MB higher compared to page load when the mass sync procedure is not triggered.

I have also adjusted the ids generation code in the Feed file. This is the same function but written in a totally different way - very interesting. Now we have the same code responsible for those two places.