### PR TITLE
Use sentence caps instead of title caps for `Product sets` nav item

### DIFF
--- a/includes/Admin/Settings_Screens/Product_Sets.php
+++ b/includes/Admin/Settings_Screens/Product_Sets.php
@@ -30,8 +30,8 @@ class Product_Sets extends Admin\Abstract_Settings_Screen {
 	public function __construct() {
 
 		$this->id    = self::ID;
-		$this->label = __( 'Product Sets', 'facebook-for-woocommerce' );
-		$this->title = __( 'Product Sets', 'facebook-for-woocommerce' );
+		$this->label = __( 'Product sets', 'facebook-for-woocommerce' );
+		$this->title = __( 'Product sets', 'facebook-for-woocommerce' );
 	}
 
 	public function render() {


### PR DESCRIPTION
### Description
PR fixes an inconsistency in how nav titles are cap, should be sentence caps instead of title caps.

### Screenshot
<img width="246" alt="Screen Shot 2021-04-01 at 08 24 24" src="https://user-images.githubusercontent.com/532402/113308743-b487aa80-92c3-11eb-8d6a-f187551e361f.png">
