### PR TITLE
Add tracker props for key features: product sync, messenger

### DIFF
--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -45,12 +45,19 @@ class Tracker {
 			$data['extensions'] = array();
 		}
 
+		// Is the site connected?
 		$connection_is_happy = false;
 		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
 		if ( $connection_handler ) {
 			$connection_is_happy = $connection_handler->is_connected() && ! get_transient( 'wc_facebook_connection_invalid' );
 		}
 		$data['extensions']['facebook-for-woocommerce']['is-connected'] = wc_bool_to_string( $connection_is_happy );
+
+		// What features are enabled on this site?
+		$product_sync_enabled = facebook_for_woocommerce()->get_integration()->is_product_sync_enabled();
+		$data['extensions']['facebook-for-woocommerce']['product-sync-enabled'] = wc_bool_to_string( $product_sync_enabled );
+		$messenger_enabled = facebook_for_woocommerce()->get_integration()->is_messenger_enabled();
+		$data['extensions']['facebook-for-woocommerce']['messenger-enabled'] = wc_bool_to_string( $messenger_enabled );
 
 		return $data;
 	}

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -46,6 +46,7 @@ class Tracker {
 		}
 
 		// Is the site connected?
+		// @since 2.3.4
 		$connection_is_happy = false;
 		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
 		if ( $connection_handler ) {
@@ -54,6 +55,7 @@ class Tracker {
 		$data['extensions']['facebook-for-woocommerce']['is-connected'] = wc_bool_to_string( $connection_is_happy );
 
 		// What features are enabled on this site?
+		// @since %VERSION%
 		$product_sync_enabled = facebook_for_woocommerce()->get_integration()->is_product_sync_enabled();
 		$data['extensions']['facebook-for-woocommerce']['product-sync-enabled'] = wc_bool_to_string( $product_sync_enabled );
 		$messenger_enabled = facebook_for_woocommerce()->get_integration()->is_messenger_enabled();


### PR DESCRIPTION
Fixes #1864

This PR builds on #1816 to add two new tracker props for two key features:

- `extensions_facebook-for-woocommerce_product-sync-enabled` = yes/no
- `extensions_facebook-for-woocommerce_messenger-enabled` = yes/no

The goal here is to understand how sites are using the plugin and to ensure these features are working well for merchants.

### How to test
Similar to #1816, there's no direct way to view the tracker snapshot without adding logging. 

1. Ensure tracking is enabled for your test site: `WooCommerce > Settings > Advanced > WooCommerce.com > Enable tracking`.
2. Add debug code to `Tracker::add_tracker_data()` to log tracker data (see example below).
3. Trigger a sync. One way to do this is to use `wp shell`:
  - `wp shell` to get an interactive shell session
  - Call `WC_Tracker::send_tracking_data( true );` to force a snapshot.
  - Note: this function checks a timestamp ( `woocommerce_tracker_last_send` ) to avoid duplicate requests. You may need to delete this option to ensure the data is regenerated.
4. View the logs and see full snapshot (example below). The new settings will be at the bottom in `[extensions][facebook-for-woocommerce]`.
5. Repeat tests with different settings, e.g. enable/disable product sync or messenger and fiddle with other settings. Please test a range of scenarios to ensure there aren't any false positives or vice versa. 

```php
	public function add_tracker_data( array $data = [] ) {
		// (Tracking code removed for brevity.) 

		// add logging here  before return
		wc_get_logger()->debug( print_r( $data, true ) );
		return $data;
	}
``` 

```
// (earlier tracker snapshot data truncated)
    [extensions] => Array
        (
            [facebook-for-woocommerce] => Array
                (
                    [is-connected] => yes
                    [product-sync-enabled] => yes
                    [messenger-enabled] => no
                )

        )
```

Since this PR is using the same code as #1816 to add these props, we don't need to thoroughly retest to confirm these are getting through to back end correctly. Testing should focus on the values generated for the new props.