### PR TITLE
remove remnant Query Monitor logging hook fire 🧯 

### DIFF
--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -92,8 +92,6 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 			$profiling_logger = facebook_for_woocommerce()->get_profiling_logger();
 			$profiling_logger->start( 'generate_feed' );
 
-			do_action( 'qm/start', 'facebook_for_woocommerce__generate_feed' );
-
 			\WC_Facebookcommerce_Utils::log( 'Generating a fresh product feed file' );
 
 			try {


### PR DESCRIPTION
Accidentally left some query monitor logging in #1845. This PR removes the remnant code.

It's a single innocuous `do_action` for a Query Monitor profiling hook, so this is a low risk change. 

Can be tested by testing the profiling, using same steps from #1845:

- [Ensure profiler logging is enabled](https://github.com/woocommerce/facebook-for-woocommerce/tree/master/includes/Debug) `define( 'FACEBOOK_FOR_WOOCOMMERCE_PROFILING_LOG_ENABLED', true );`. I also had debug mode active: `Marketing > Facebook > Connection tab > Log plugin events for debugging`.
- Go to `Marketing > Facebook > Product sync` tab. 
- Click `Sync products` to trigger a sync.
- View logs, e.g. `WooCommerce > Status > Logs`. There should be a `facebook_for_woocommerce_profiling_*` log.
