### PR TITLE
Fix broken modal JS error when changing product sync or other settings

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1525,6 +1525,7 @@ class Admin {
 			'product',
 			'edit-product',
 			'woocommerce_page_wc-facebook',
+			'marketing_page_wc-facebook',
 			'edit-product_cat',
 			'shop_order',
 		);


### PR DESCRIPTION
Fixes #1725

In the product sync settings page (`Marketing > Facebook > Product sync`), any errors returned from the API should trigger a modal. For example, if you add a product category to `Exclude categories from sync` and click save, there's a warning if some products in that category have already synched:

<img width="1087" alt="Screen Shot 2021-04-12 at 3 15 49 PM" src="https://user-images.githubusercontent.com/4167300/114338113-7da87300-9ba6-11eb-8f0f-51cfeb0b8a40.png">

This modal wasn't displaying. The reason was that the template for the modal wasn't available. It's rendered for specific settings screens only. 

This PR fixes the problem by adding the correct screen ID to the include list. I suspect this bug was introduced when the settings screens moved into `Marketing` in nav (maybe recently).

### How to test
- Ensure your store is connected to Facebook.
- Ensure you have some product categories – `wp-admin > Products > Categories`.
- Ensure that some of your products use categories and are synced (so you trigger the error modal).
- Go to `wp-admin > Marketing > Facebook` and click `Product sync`.
- Click in `Exclude categories from sync` and type/select a category that has some synced products.
- Click `Save`.
- Should see a modal and be able to recover from the situation.

Previously there was a javascript error and no modal.

Note - these test steps don't cover all possible variations of the missing modal template issue - test around this to confirm things are working well. E.g. add exclude tags. May also be some modals on other settings tabs (e.g. messenger).

#### About excluding products from sync
This feature is a little confusing and doesn't work as I expect. So when testing this you may find it tricky to actually exclude a category from sync. The goal of this PR is just to fix the javascript error - there may be other improvements we can make in future.

Essentially, this setting allows you to set defaults for categories. It's not possible to retroactively unsync a category - each relevant product must be set to `Do not sync` manually, and probably also deleted manually in Facebook end. There are other related modals & messages:

<img width="974" alt="Screen Shot 2021-04-12 at 3 32 48 PM" src="https://user-images.githubusercontent.com/4167300/114338975-4e930100-9ba8-11eb-801f-7f8fd65c4b82.png">

<img width="957" alt="Screen Shot 2021-04-12 at 3 34 33 PM" src="https://user-images.githubusercontent.com/4167300/114338986-53f04b80-9ba8-11eb-9162-134d487d37b0.png">

<img width="1103" alt="Screen Shot 2021-04-12 at 3 35 59 PM" src="https://user-images.githubusercontent.com/4167300/114338992-594d9600-9ba8-11eb-9c98-983945a97b9e.png">

#### Follow ups
There are likely other modals in `Marketing > Facebook` that this fixes - we should test extensively to confirm. Could also review the js for uses of modal and ensure that they are all working correctly.