### PR TITLE
Introduce option to disable feed file generation.

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -68,6 +68,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var string the "enable product sync" setting ID */
 	const SETTING_ENABLE_PRODUCT_SYNC = 'wc_facebook_enable_product_sync';
 
+	/** @var string the product description mode setting ID */
+	const SETTING_FEED_FILE_GENERATION_ENABLED = 'wc_facebook_feed_file_generation_enabled';
+
 	/** @var string the excluded product category IDs setting ID */
 	const SETTING_EXCLUDED_PRODUCT_CATEGORY_IDS = 'wc_facebook_excluded_product_category_ids';
 
@@ -3177,6 +3180,17 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 * @param \WC_Facebookcommerce_Integration $integration the integration instance
 		 */
 		return (bool) apply_filters( 'wc_facebook_is_product_sync_enabled', 'yes' === get_option( self::SETTING_ENABLE_PRODUCT_SYNC, 'yes' ), $this );
+	}
+
+	/**
+	 * Determines whether feed file generation is enabled in Sync settings.
+	 *
+	 * @since 2.5.0
+	 *
+	 * @return bool
+	 */
+	public function is_feed_file_generation_enabled() {
+		return (bool) ( 'yes' === get_option( self::SETTING_FEED_FILE_GENERATION_ENABLED, 'yes' ) );
 	}
 
 

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -318,6 +318,27 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 			],
 			[ 'type' => 'sectionend' ],
 
+			[
+				'name' => __( 'Feed File Settings', 'woocommerce' ),
+				'type' => 'title',
+				'id'   => 'feed_file_settings',
+			],
+
+			[
+				'id'      => \WC_Facebookcommerce_Integration::SETTING_FEED_FILE_GENERATION_ENABLED,
+				'title'   => __( 'Enable feed file generation.', 'facebook-for-woocommerce' ),
+				'desc'    => sprintf(
+					/* translators: url to documentation section. */
+					__( 'Feed file is used for cyclic catalog content synchronization. Please check the documentation at %s to learn if this option should be enabled for your store.', 'facebook-for-woocommerce' ),
+					'<a href="' . facebook_for_woocommerce()->get_documentation_url() . '#feed-file-settings">Feed File Settings</a>',
+				),
+				'type'    => 'checkbox',
+				'label'   => ' ',
+				'default' => 'yes',
+			],
+
+			[ 'type' => 'sectionend', 'id' => 'feed_file_settings' ],
+
 		];
 	}
 

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -162,7 +162,7 @@ class Feed {
 		$integration = facebook_for_woocommerce()->get_integration();
 
 		// only schedule if configured
-		if ( ! $integration || ! $integration->is_configured() || ! $integration->is_product_sync_enabled() ) {
+		if ( ! $integration || ! $integration->is_configured() || ! $integration->is_product_sync_enabled() || ! $integration->is_feed_file_generation_enabled() ) {
 			as_unschedule_all_actions( self::GENERATE_FEED_ACTION );
 			return;
 		}


### PR DESCRIPTION
Fixes: #1873.

This PR adds an option to disable feed file generation.﻿
A follow-up to this item will be a documentation update that will describe when to disable or enable feed file generation.

In addition to adding the option, we also track it.

I have not updated the changelog since I target this for 2.5.0
Changelog:

Add - Settings option to disable feed file generation.
Add - Track feed file generation option in the tracker.
