### PR TITLE
use existing / current tab for connection flow `Get Started` button

### DIFF
--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -281,7 +281,7 @@ class Connection extends Admin\Abstract_Settings_Screen {
 
 				<?php else : ?>
 
-					<a href="<?php echo esc_url( facebook_for_woocommerce()->get_connection_handler()->get_connect_url() ); ?>" class="button button-primary" target="_blank">
+					<a href="<?php echo esc_url( facebook_for_woocommerce()->get_connection_handler()->get_connect_url() ); ?>" class="button button-primary">
 						<?php esc_html_e( 'Get Started', 'facebook-for-woocommerce' ); ?>
 					</a>
 


### PR DESCRIPTION
Fixes #1863 

The connection flow is designed to guide merchant through connection settings on Facebook and back to their Woo dashboard.

The `Get Started` currently opens a new tab. At the end of onboarding, the previous tab has stale/old content and could cause confusion.

This PR ensures the button opens in current tab by removing `target="_blank"` attribute.

### How to test
- Disconnect your Woo site from Facebook, or start with a disconnected site.
- Go to `wp-admin > Marketing > Facebook` and click `Get Started` and follow the prompts to connect.

Should not launch a new tab, and at the completion of onboarding, there should be no spare or redundant tabs.

Please also test various user scenarios:

- Using `command` or `control` key to force a new tab anyway (browser/OS dependent) - we should not break this for users that manually override.
- Different browsers or mobile devices.
- Browser settings for new tab/same tab (I think some browsers have a preference/option).
- 