### PR TITLE
Escape commas inside additional attributes value.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Facebook for WooCommerce Changelog ***
 
 2021.nn.nn - version 2.5.0
- * Fix - Attribute values with commas break product sync.
+ *  Ensure variable product attribute values containing , sync correctly to Facebook additional_variant_attribute field.
 
 2021.04.29 - version 2.4.1
  * Fix - PHP<7.1 incompatible code for Google Taxonomy Setting in products.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Facebook for WooCommerce Changelog ***
 
+2021.nn.nn - version 2.5.0
+ * Fix - Attribute values with commas break product sync.
+
 2021.04.29 - version 2.4.1
  * Fix - PHP<7.1 incompatible code for Google Taxonomy Setting in products.
 

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -298,7 +298,7 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 			foreach ( $data['custom_data'] as $key => $val ) {
 				$attribute_value = str_replace(
 					',',
-					apply_filters( 'facebook_for_woocommerce_variant_attribute_comma_replacement', ' ' ),
+					apply_filters( 'facebook_for_woocommerce_variant_attribute_comma_replacement', ' ', $val ),
 					$val
 				);
 				$attributes[]    = $key . ':' . $attribute_value;

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -282,21 +282,26 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param array $data product data
+	 * @param array $data product data.
 	 * @return array
 	 */
 	private function normalize_product_data( $data ) {
 
-		// allowed values are 'refurbished', 'used', and 'new', but the plugin has always used the latter
+		// Allowed values are 'refurbished', 'used', and 'new', but the plugin has always used the latter.
 		$data['condition'] = 'new';
 
-		// attributes other than size, color, pattern, or gender need to be included in the additional_variant_attributes field
+		// Attributes other than size, color, pattern, or gender need to be included in the additional_variant_attributes field.
 		if ( isset( $data['custom_data'] ) && is_array( $data['custom_data'] ) ) {
 
 			$attributes = array();
 
 			foreach ( $data['custom_data'] as $key => $val ) {
-				$attributes[] = $key . ':' . $val;
+				$attribute_value = str_replace(
+					',',
+					apply_filters( 'facebook_for_woocommerce_variant_attribute_comma_replacement', ' ' ),
+					$val
+				);
+				$attributes[]    = $key . ':' . $attribute_value;
 			}
 
 			$data['additional_variant_attribute'] = implode( ',', $attributes );

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -296,6 +296,21 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 			$attributes = array();
 
 			foreach ( $data['custom_data'] as $key => $val ) {
+				/**
+				 * Filter: facebook_for_woocommerce_variant_attribute_comma_replacement
+				 *
+				 * The Facebook API expects a comma-separated list of attributes in `additional_variant_attribute` field.
+				 * https://developers.facebook.com/docs/marketing-api/catalog/reference/
+				 * This means that WooCommerce product attributes included in this field should avoid the comma (`,`) character.
+				 * Facebook for WooCommerce replaces any `,` with a space by default.
+				 * This filter allows a site to provide a different replacement string.
+				 *
+				 * @since 2.5.0
+				 *
+				 * @param string $replacement The default replacement string (`,`).
+				 * @param string $value Attribute value.
+				 * @return string Return the desired replacement string.
+				 */
 				$attribute_value = str_replace(
 					',',
 					apply_filters( 'facebook_for_woocommerce_variant_attribute_comma_replacement', ' ', $val ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Commas inside attribute values are not supported and break the synchronization. The proposed solution is to replace the commas with a space char and add a filter that allows customization of behavior.

Fixes: #1909

### How to test the changes in this Pull Request:

<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create attributes for variations that have commas ( more info inside the #1909 issue ):
![image](https://user-images.githubusercontent.com/17271089/116934161-e09c9f80-ac64-11eb-86bd-0ebf3c4e6a88.png)
2. Create Variations out of the attributes.
3. use Delete product(s) on Facebook from the Facebook box in the product edit page.
4. Click Update the product.
5. Products should be synced correctly ( commas replaced )

Testing the filter:

```PHP
function facebook_for_woocommerce_variant_attribute_comma_replacement_callback( $replacement ) {
	return '.';
}

add_filter( 'facebook_for_woocommerce_variant_attribute_comma_replacement', 'facebook_for_woocommerce_variant_attribute_comma_replacement_callback' );
```


### Changelog entry

 * Fix - Attribute values with commas break product sync.
