### PR TITLE
phpcs: Exclude WordPress class file naming rules

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,7 +16,10 @@
 	<config name="testVersion" value="7.0-" />
 
 	<!-- Rules -->
-	<rule ref="WooCommerce-Core" />
+	<rule ref="WooCommerce-Core">
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
+	</rule>
 
 	<!-- Language domain -->
 	<rule ref="WordPress.WP.I18n">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,6 +17,7 @@
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core">
+		<!-- We use the PSR-4 naming convention rather than the WP one -->
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
 	</rule>


### PR DESCRIPTION
I think this plugin, like Woo's other flagship plugins (WC Admin, WC Blocks), should ignore WP's class file naming rules and follow PSR-4 instead.

### How to test the changes in this Pull Request:

N/A

### Changelog entry

N/A
