### PR TITLE
Set upload schedule on feed creation

### DIFF
--- a/includes/Products/class-fb-feed-generator.php
+++ b/includes/Products/class-fb-feed-generator.php
@@ -586,5 +586,24 @@ class FB_Feed_Generator extends \WC_Product_CSV_Exporter {
 		return $secret;
 	}
 
+	/**
+	 * Function will return the default parameters for the feed's upload schedule
+	 *
+	 * @link https://developers.facebook.com/docs/marketing-api/reference/product-feed-schedule/
+	 */
+	public function get_feed_upload_schedule() {
+		$schedule = new \stdClass();
 
+		$schedule->interval = 'DAILY';
+		$schedule->url      = esc_url_raw( $this->get_feed_uri() );
+		$schedule->hour     = ( new \WC_DateTime( '+1 hour', new \DateTimeZone( 'UTC' ) ) )->date( 'H' );
+		$schedule->timezone = 'UTC';
+
+		/**
+		 * Filters the value of the default feed schedule settings.
+		 *
+		 * @param  \stdClass  $schedule  Object contains the settings to be passed to fbgraph to configure upload schedule.
+		 */
+		return apply_filters( 'facebook_for_woocommerce_feed_upload_schedule_settings', $schedule );
+	}
 }

--- a/includes/Products/class-fb-feed-generator.php
+++ b/includes/Products/class-fb-feed-generator.php
@@ -141,6 +141,17 @@ class FB_Feed_Generator extends \WC_Product_CSV_Exporter {
 	}
 
 	/**
+	 * Returns the feed uri.
+	 *
+	 * @return string
+	 */
+	public function get_feed_uri() {
+		$upload_dir = wp_upload_dir();
+
+		return sprintf( '%s/%s/%s', $upload_dir['baseurl'], 'facebook_for_woocommerce', $this->get_filename() );
+	}
+
+	/**
 	 * Get file path to export to.
 	 *
 	 * @return string

--- a/includes/Products/class-fb-feed-generator.php
+++ b/includes/Products/class-fb-feed-generator.php
@@ -200,7 +200,7 @@ class FB_Feed_Generator extends \WC_Product_CSV_Exporter {
 	private function create_feed() {
 		$result = \WC_Facebookcommerce_Utils::$fbgraph->create_feed(
 			facebook_for_woocommerce()->get_integration()->get_product_catalog_id(),
-			array( 'name' => self::FEED_NAME )
+			array( 'name' => self::FEED_NAME, 'schedule' => $this->get_feed_upload_schedule() )
 		);
 
 		if ( is_wp_error( $result ) || ! isset( $result['body'] ) ) {
@@ -312,7 +312,7 @@ class FB_Feed_Generator extends \WC_Product_CSV_Exporter {
 		if ( ( $settings['page'] * $this->limit ) >= count( $settings['ids'] ) ) {
 			$settings['done'] = true;
 			$settings['end']  = time();
-			
+
 			update_option(
 				self::RUNNING_FEED_SETTINGS,
 				$settings,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

PR sets *upload schedule settings* to feed when this is created. These are the available params for the request https://developers.facebook.com/docs/marketing-api/catalog/guides/scheduled-feeds/

Closes #1903.

### How to test the changes in this Pull Request:
1. Checkout this branch
2. If we already have a `wc_facebook_feed_id` set, we'll need to delete this. If you have `wp-cli` you can run `wp option delete wc_facebook_feed_id`
3. Now from *wp-admin* go to **Marketing > Facebook > Feed Status** (it might take a few seconds to load)
<img width="858" alt="Screen Shot 2021-05-06 at 02 18 04" src="https://user-images.githubusercontent.com/532402/117265298-547bab00-ae11-11eb-9143-9571a241e0cb.png">

4. Now go to **Marketing > Facebook > Feed Status** and go to your *Catalog*
<img width="407" alt="Screen Shot 2021-05-06 at 02 19 52" src="https://user-images.githubusercontent.com/532402/117265599-9f95be00-ae11-11eb-9bda-d6c470229d55.png">

5. From there, go to **Catalog > Data Sources**, a new feed should have ben added (You can compare the ID from *Feed Status* screen) with schedule information
<img width="1636" alt="Screen Shot 2021-05-06 at 02 21 10" src="https://user-images.githubusercontent.com/532402/117265857-e71c4a00-ae11-11eb-98ae-2a7df662e16c.png">


### Changelog entry

> New - Configure update schedule so Facebook refreshes product sync feed regularly.
