### PR TITLE
link out to ideas board in feedback/idea issue template + fix bug template heading

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-Bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-Bug-report.md
@@ -16,7 +16,7 @@ assignees: ''
 ## ✍️ Describe the bug
 <!-- Describe the bug in detail. Feel free to add appropriate screenshots that display the bug! -->
 
-##🚶‍♀️ Steps to reproduce
+## 🚶‍♀️ Steps to reproduce
 <!-- List steps that others can take to consistently reproduce the bug. -->
 
 1. The first step

--- a/.github/ISSUE_TEMPLATE/3-Feedback-idea.md
+++ b/.github/ISSUE_TEMPLATE/3-Feedback-idea.md
@@ -11,6 +11,8 @@ assignees: ''
 
 If you have an idea for how we could improve Facebook for WooCommerce, please let us know by [contacting our support team](https://woocommerce.com/my-account/create-a-ticket/)! We'd love to learn more about the problem you're facing and how Facebook for WooCommerce could help solve it.
 
+Check the [Facebook for WooCommerce ideas board](https://ideas.woocommerce.com/forums/133476-woocommerce?category_id=398356) to see and vote on ideas.
+
 ## Developers
 
 We welcome your contributions. 🙌 Here are a few tips to help us work together:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a link to the ideas board to the enhancement issue template, to raise awareness of ideas board and keep the repo focused more on issues/bugs.

Bonus: fixed the heading in the bug report template - was missing a space, so markdown wasn't rendering as a heading.


### How to test the changes in this Pull Request:

Read the issue template, make sure it's nice and helpful :)

### Changelog entry

n/a - skip