### PR TITLE
add option for disabling existing feed

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -40,6 +40,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var string the WordPress option name where the external merchant settings ID is stored */
 	const OPTION_EXTERNAL_MERCHANT_SETTINGS_ID = 'wc_facebook_external_merchant_settings_id';
 
+	/** @var string Option name for disabling feed. */
+ 	const OPTION_LEGACY_FEED_FILE_GENERATION_ENABLED = 'wc_facebook_legacy_feed_file_generation_enabled';
+
 	/** @var string the WordPress option name where the feed ID is stored */
 	const OPTION_FEED_ID = 'wc_facebook_feed_id';
 
@@ -3174,6 +3177,26 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 */
 		return (bool) apply_filters( 'wc_facebook_is_product_sync_enabled', 'yes' === get_option( self::SETTING_ENABLE_PRODUCT_SYNC, 'yes' ), $this );
 	}
+
+	/**
+ 	 * Return true if (legacy) feed generation is enabled.
+ 	 *
+ 	 * Feed generation for product sync is enabled by default, and generally recommended.
+ 	 * Large stores, or stores running on shared hosting (low resources) may have issues
+ 	 * with feed generation. This option allows those stores to disable generation to
+ 	 * work around the issue.
+ 	 *
+ 	 * Note - this is temporary. In a future release, an improved feed system will be
+ 	 * implemented, which should work well for all stores. This option will not disable
+ 	 * the new improved implementation.
+ 	 *
+ 	 * @since 2.5.0
+ 	 *
+ 	 * @return bool
+ 	 */
+ 	public function is_legacy_feed_file_generation_enabled() {
+ 		return (bool) ( 'yes' === get_option( self::OPTION_LEGACY_FEED_FILE_GENERATION_ENABLED, 'yes' ) );
+ 	}
 
 
 	/**

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -158,10 +158,14 @@ class Feed {
 	 */
 	public function schedule_feed_generation() {
 
-		$integration = facebook_for_woocommerce()->get_integration();
+		$integration   = facebook_for_woocommerce()->get_integration();
+		$configured_ok = $integration && $integration->is_configured();
 
-		// only schedule if configured
-		if ( ! $integration || ! $integration->is_configured() || ! $integration->is_product_sync_enabled() ) {
+		// Only schedule feed job if store has not opted out of product sync.
+		$store_allows_sync = $configured_ok && $integration->is_product_sync_enabled();
+		// Only schedule if has not opted out of feed generation (e.g. large stores).
+		$store_allows_feed = $configured_ok && $integration->is_legacy_feed_file_generation_enabled();
+		if ( ! $store_allows_sync || ! $store_allows_feed ) {
 			as_unschedule_all_actions( self::GENERATE_FEED_ACTION );
 			return;
 		}


### PR DESCRIPTION
Fixes #1873

### Changes proposed in this Pull Request:

This PR, inspired by #1874, adds a new hidden option to allow sites to disable the current feed generation code.

- Option: `wc_facebook_legacy_feed_file_generation_enabled`
- Value: `yes | no` string
- Default: `yes`

#### Feature flag for new feed engine?
This PR is focused tightly on the current issue for larger stores and giving them a targeted option to disable. At the same time, we may want a feature flag to help us ship the new-improved feed engine (work in progress). 

It might be a good idea to consider the feature flag use case (or even implement in this PR) to ensure this remedial/temporary option doesn't impact our ability to ship improvements to larger stores! See code comment for details.

On the other hand, if we end up using a UI or guided process for enabling the new feed engine, the option can be reset/removed as part of running that. E.g. task list item says `you should enable a feed for improved product sync` > merchant clicks `Set it up`, accepts defaults, feed is configured, disable option is removed. 

Reviewers let me know what you think about this :) cc @budzanowski @danielbitzer 

### How to test the changes in this Pull Request:
1. Check out `master`. Confirm that the feed generation job is running:
  - Enable debug logging - `Facebook > Connection > Log events for debugging`.
  - Should see feed profiler logs in `facebook_for_woocommerce_profiling`. 
    - e.g. `2021-05-07T02:27:17+00:00 DEBUG generate_feed - Memory: 23,045.33 KB, time: 2.49s`
  - Should see feed job in `WooCommerce > Status > Scheduled Actions.
    - `wc_facebook_regenerate_feed` 

<img width="1748" alt="Screen Shot 2021-05-07 at 2 31 09 PM" src="https://user-images.githubusercontent.com/4167300/117390762-df0ff780-af42-11eb-9114-f2cf80578db3.png">
<img width="1527" alt="Screen Shot 2021-05-07 at 2 45 51 PM" src="https://user-images.githubusercontent.com/4167300/117390805-ed5e1380-af42-11eb-96ab-7549021d259a.png">

Optional - set up your site with lots of products to reproduce performance issues.

2. Set the option to opt-out of feed. e.g. using wp-cli `wp option set wc_facebook_legacy_feed_file_generation_enabled no`.
3. Confirm that the `wc_facebook_regenerate_feed` is no longer pending and the feed is not regenerated. Previous feed generation interval was every fifteen minutes.
4. Opt back in - set the option to `yes` or delete it. Confirm that the feed starts regenerating again (should happen within ~30 mins?).

### Changelog entry

> New - Add option to allow larger sites to opt-out of current feed generation (product sync)
