### PR TITLE
Add/sync status information to metabox.

### DIFF
--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -91,7 +91,7 @@ class ProductValidator {
 	 * @throws ProductExcludedException If product should not be synced.
 	 */
 	protected function validate_sync_enabled_globally() {
-		if ( $this->integration->is_product_sync_enabled() ) {
+		if ( ! $this->integration->is_product_sync_enabled() ) {
 			throw new ProductExcludedException( 'Product sync is globally disabled.' );
 		}
 	}
@@ -170,7 +170,7 @@ class ProductValidator {
 			foreach ( $this->product->get_children() as $child_id ) {
 				$child_product = wc_get_product( $child_id );
 				if ( $child_product && 'no' !== $child_product->get_meta( self::SYNC_ENABLED_META_KEY ) ) {
-					break;
+					return;
 				}
 			}
 

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -190,8 +190,9 @@ class ProductValidator {
 	 * @throws ProductExcludedException If product should not be synced.
 	 */
 	protected function validate_product_price() {
-		// Permit simple and variable products to have an empty price
-		if ( in_array( $this->product_parent->get_type(), array( 'simple', 'variable' ), true ) ) {
+		// Permit simple and variable products to have an empty price.
+		$product = $this->product->is_type( 'variation' ) ? wc_get_product( $this->product->get_parent_id() ) : $this->product;
+		if ( in_array( $product->get_type(), array( 'simple', 'variable' ), true ) ) {
 			return;
 		}
 

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -92,7 +92,7 @@ class ProductValidator {
 	 */
 	protected function validate_sync_enabled_globally() {
 		if ( ! $this->integration->is_product_sync_enabled() ) {
-			throw new ProductExcludedException( 'Product sync is globally disabled.' );
+			throw new ProductExcludedException( __( 'Product sync is globally disabled.', 'facebook-for-woocommerce' ) );
 		}
 	}
 
@@ -105,7 +105,7 @@ class ProductValidator {
 		$product = $this->product_parent ?: $this->product;
 
 		if ( 'publish' !== $product->get_status() ) {
-			throw new ProductExcludedException( 'Product is not published.' );
+			throw new ProductExcludedException( __( 'Product is not published.', 'facebook-for-woocommerce' ) );
 		}
 	}
 
@@ -116,7 +116,7 @@ class ProductValidator {
 	 */
 	protected function validate_product_stock_status() {
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $this->product->is_in_stock() ) {
-			throw new ProductExcludedException( 'Product must be in stock.' );
+			throw new ProductExcludedException( __( 'Product must be in stock.', 'facebook-for-woocommerce' ) );
 		}
 	}
 
@@ -131,7 +131,7 @@ class ProductValidator {
 		$product = $this->product_parent ?: $this->product;
 
 		if ( 'visible' !== $product->get_catalog_visibility() ) {
-			throw new ProductExcludedException( 'Product is hidden from catalog and search.' );
+			throw new ProductExcludedException( __( 'Product is hidden from catalog and search.', 'facebook-for-woocommerce' ) );
 		}
 	}
 
@@ -146,14 +146,14 @@ class ProductValidator {
 		$excluded_categories = $this->integration->get_excluded_product_category_ids();
 		if ( $excluded_categories ) {
 			if ( ! empty( array_intersect( $product->get_category_ids(), $excluded_categories ) ) ) {
-				throw new ProductExcludedException( 'Product excluded because of categories.' );
+				throw new ProductExcludedException( __( 'Product excluded because of categories.', 'facebook-for-woocommerce' ) );
 			}
 		}
 
 		$excluded_tags = $this->integration->get_excluded_product_tag_ids();
 		if ( $excluded_tags ) {
 			if ( ! empty( array_intersect( $product->get_tag_ids(), $excluded_tags ) ) ) {
-				throw new ProductExcludedException( 'Product excluded because of tags.' );
+				throw new ProductExcludedException( __( 'Product excluded because of tags.', 'facebook-for-woocommerce' ) );
 			}
 		}
 	}
@@ -164,7 +164,7 @@ class ProductValidator {
 	 * @throws ProductExcludedException If product should not be synced.
 	 */
 	public function validate_product_sync_field() {
-		$invalid_exception = new ProductExcludedException( 'Sync disabled in product field.' );
+		$invalid_exception = new ProductExcludedException( __( 'Sync disabled in product field.', 'facebook-for-woocommerce' ) );
 
 		if ( $this->product->is_type( 'variable' ) ) {
 			foreach ( $this->product->get_children() as $child_id ) {
@@ -197,7 +197,7 @@ class ProductValidator {
 		}
 
 		if ( ! Products::get_product_price( $this->product ) ) {
-			throw new ProductExcludedException( 'If product is not simple, variable or variation it must have a price.' );
+			throw new ProductExcludedException( __( 'If product is not simple, variable or variation it must have a price.', 'facebook-for-woocommerce' ) );
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Using code from #1933 take the no-sync reason information and add display it in case the product will not be synced.

Closes # .

### How to test the changes in this Pull Request:

<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Open a product for edit.
2. Disable sync. 
3. Observe metabox.
![image](https://user-images.githubusercontent.com/17271089/117641834-eaebfb80-b186-11eb-9098-e1021ab75853.png)
Or
![image](https://user-images.githubusercontent.com/17271089/117642315-6cdc2480-b187-11eb-85a9-75f056be47cb.png)



### Changelog entry

New - Add no synchronization reason to the product edit screen in the Facebook meta box.
