### PR TITLE
Reorder and document feed fields

### DIFF
--- a/includes/Products/class-fb-feed-generator.php
+++ b/includes/Products/class-fb-feed-generator.php
@@ -157,6 +157,9 @@ class FB_Feed_Generator extends \WC_Product_CSV_Exporter {
 	 *
 	 * @since  3.1.0
 	 * @return array
+	 * @link https://www.facebook.com/business/help/1898524300466211?id=725943027795860
+	 * @link https://www.facebook.com/business/help/120325381656392?id=725943027795860 Required fields for products
+	 * @link https://developers.facebook.com/docs/marketing-api/catalog/reference/#da-commerce full list of optional fields for products
 	 */
 	public function get_default_column_names() {
 		return array(

--- a/includes/Products/class-fb-feed-generator.php
+++ b/includes/Products/class-fb-feed-generator.php
@@ -163,27 +163,30 @@ class FB_Feed_Generator extends \WC_Product_CSV_Exporter {
 	 */
 	public function get_default_column_names() {
 		return array(
+			// Required
 			'id'     => 'id',
 			'title'  => 'title',
 			'description' => 'description',
-			'image_link' => 'image_link',
-			'link' => 'link',
-			'product_type' => 'product_type',
-			'brand' => 'brand',
-			'price' => 'price',
 			'availability' => 'availability',
+			'condition' => 'condition',
+			'price' => 'price',
+			'link' => 'link',
+			'image_link' => 'image_link',
+			'brand' => 'brand',
+			// Optional
 			'item_group_id' => 'item_group_id',
-			'checkout_url' => 'checkout_url',
+			'visibility' => 'visibility',
+			'sale_price' => 'sale_price',
+			'google_product_category' => 'google_product_category',
+			'product_type' => 'product_type',
 			'additional_image_link' => 'additional_image_link',
 			'sale_price_effective_date' => 'sale_price_effective_date',
-			'sale_price' => 'sale_price',
-			'condition' => 'condition',
-			'visibility' => 'visibility',
 			'gender' => 'gender',
 			'color' => 'color',
 			'size' => 'size',
 			'pattern' => 'pattern',
-			'google_product_category' => 'google_product_category',
+			// Not available in graph api
+			'checkout_url' => 'checkout_url',
 			'default_product' => 'default_product',
 			'variant' => 'variant',
 		);
@@ -304,7 +307,7 @@ class FB_Feed_Generator extends \WC_Product_CSV_Exporter {
 		if ( ( $settings['page'] * $this->limit ) >= count( $settings['ids'] ) ) {
 			$settings['done'] = true;
 			$settings['end']  = time();
-			
+
 			update_option(
 				self::RUNNING_FEED_SETTINGS,
 				$settings,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

PR documents and reorder feed columns. Order is based on column priority (required, option, etc). The docs taken in consideration are:

- Required columns
    - https://www.facebook.com/business/help/120325381656392?id=725943027795860
- Optional columns
     - https://developers.facebook.com/docs/marketing-api/catalog/reference/#da-commerce
- Catalog template from Facebook
   - [catalog_products.csv](https://github.com/woocommerce/facebook-for-woocommerce/files/6455143/catalog_products.csv)

Closes #1894.

### Fields not present in graph API
There are a few fields that aren't referenced in the FB docs, these are: `variant`, `default_product`, `checkout_url`, They aren't present in the docs neither the _Catalog template_.

I tested our generated feed file which contains these columns with the [Facebook's Feed Debugger](https://www.facebook.com/products/catalogs/351504439729060/feed_debugger?business_id=1147217665751100) and no warnings, neither if I remove the columns.

<img width="1670" alt="Screen Shot 2021-05-10 at 16 01 05" src="https://user-images.githubusercontent.com/532402/117730036-f7814b80-b1a8-11eb-99fa-7931d44b3d2b.png">

### Changelog
<!-- Add suggested changelog entry here. For example: -->
> Dev - Document feed columns
<!-- See [previous releases](../../releases) for more examples. -->
