### PR TITLE
Move to admin init.

### DIFF
--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -54,7 +54,7 @@ class Feed {
 	private function add_hooks() {
 
 		// schedule the recurring feed generation
-		add_action( 'init', array( $this, 'schedule_feed_generation' ) );
+		add_action( 'admin_init', array( $this, 'schedule_feed_generation' ) );
 
 		// regenerate the product feed
 		add_action( self::GENERATE_FEED_ACTION, array( $this, 'regenerate_feed' ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Using the suggestion from https://github.com/woocommerce/facebook-for-woocommerce/issues/1632#issuecomment-837679022

We are moving to admin_init to reduce the load.

Closes #1632 .

### How to test the changes in this Pull Request:

<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Plugin should operate normally and the feed should still be scheduled.

### Changelog entry

Fix - Move feed scheduling to admin_init from init for better performance.
