### PR TITLE
Delete the job from the options table after the job has finished.

### DIFF
--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -108,7 +108,7 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 	 * @since 2.6.0
 	 *
 	 * @param \stdClass|object|string $job Job instance or ID.
-	 * @return \stdClass|object|false on failure
+	 * @return \stdClass|object|false on failure.
 	 */
 	public function complete_job( $job ) {
 
@@ -126,7 +126,6 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 		$this->delete_job( $job );
 		return $job;
 	}
-
 
 	/**
 	 * Processes multiple items.

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -102,6 +102,31 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 		return $job;
 	}
 
+	/**
+	 * Handles job completion.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @param \stdClass|object|string $job Job instance or ID.
+	 * @return \stdClass|object|false on failure
+	 */
+	public function complete_job( $job ) {
+
+		if ( is_string( $job ) ) {
+			$job = $this->get_job( $job );
+		}
+
+		if ( ! $job ) {
+			return false;
+		}
+
+		$job->status       = 'completed';
+		$job->completed_at = current_time( 'mysql' );
+
+		$this->delete_job( $job );
+		return $job;
+	}
+
 
 	/**
 	 * Processes multiple items.

--- a/includes/Utilities/Background_Handle_Virtual_Products_Variations.php
+++ b/includes/Utilities/Background_Handle_Virtual_Products_Variations.php
@@ -96,6 +96,30 @@ class Background_Handle_Virtual_Products_Variations extends Framework\SV_WP_Back
 		return $job;
 	}
 
+	/**
+	 * Handles job completion.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @param \stdClass|object|string $job Job instance or ID.
+	 * @return \stdClass|object|false on failure.
+	 */
+	public function complete_job( $job ) {
+
+		if ( is_string( $job ) ) {
+			$job = $this->get_job( $job );
+		}
+
+		if ( ! $job ) {
+			return false;
+		}
+
+		$job->status       = 'completed';
+		$job->completed_at = current_time( 'mysql' );
+
+		$this->delete_job( $job );
+		return $job;
+	}
 
 	/**
 	 * Counts the number of virtual products or product variations with sync enabled and visible.

--- a/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
+++ b/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
@@ -80,7 +80,6 @@ class Background_Remove_Duplicate_Visibility_Meta extends Framework\SV_WP_Backgr
 			}
 		}
 
-		// job complete! :)
 		if ( $this->count_remaining_products() === 0 ) {
 
 			update_option( 'wc_facebook_background_remove_duplicate_visibility_meta_complete', 'yes' );
@@ -91,6 +90,30 @@ class Background_Remove_Duplicate_Visibility_Meta extends Framework\SV_WP_Backgr
 		return $job;
 	}
 
+	/**
+	 * Handles job completion.
+	 *
+	 * @since 2.6.0
+	 *
+	 * @param \stdClass|object|string $job Job instance or ID.
+	 * @return \stdClass|object|false on failure.
+	 */
+	public function complete_job( $job ) {
+
+		if ( is_string( $job ) ) {
+			$job = $this->get_job( $job );
+		}
+
+		if ( ! $job ) {
+			return false;
+		}
+
+		$job->status       = 'completed';
+		$job->completed_at = current_time( 'mysql' );
+
+		$this->delete_job( $job );
+		return $job;
+	}
 
 	/**
 	 * Counts the number of virtual products or product variations with sync enabled and visible.


### PR DESCRIPTION
Closes #1943

### Changes proposed in this Pull Request:

After the Background Batch API job is completed the option that was used as the control structure for the process remains in the options table. We have no use for it. IMO we should just delete it.

More information: 
- https://wordpress.org/support/topic/wc_facebook_background_product_sync_job/
- 3974081-zd-woothemes


### How to test the changes in this Pull Request:

<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Open options in the db and look for `wc_facebook_background_product_sync_job_%` where % is a number
2. Start the Sync, wait till the end,
3. Look again for `wc_facebook_background_product_sync_job_%` no new options should be added.
4. Options should not be in the DB.

### Changelog entry

 Fix - Delete the job from the options table after the job has finished.
