### PR TITLE
Reschedule the feed file generation to 24h.

### DIFF
--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -43,6 +43,7 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 			'2.0.3',
 			'2.0.4',
 			'2.4.0',
+			'2.5.0',
 		);
 	}
 
@@ -345,6 +346,20 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 	protected function upgrade_to_2_4_0() {
 		delete_option( 'wc_facebook_google_product_categories' );
 		delete_transient( 'wc_facebook_google_product_categories' );
+	}
+
+	/**
+	 * Upgrades to version 2.5.0
+	 *
+	 * @since 2.5.0
+	 */
+	protected function upgrade_to_2_5_0() {
+		/**
+		 * Since 2.5.0 the feed generation interval is increased to 2.5.0.
+		 * Update procedure just needs to remove all current actions.
+		 * The Feed class will reschedule new generation with proper cadence.
+		 */
+		as_unschedule_all_actions( \SkyVerge\WooCommerce\Facebook\Products\Feed::GENERATE_FEED_ACTION );
 	}
 
 }

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -355,7 +355,7 @@ class Lifecycle extends Framework\Plugin\Lifecycle {
 	 */
 	protected function upgrade_to_2_5_0() {
 		/**
-		 * Since 2.5.0 the feed generation interval is increased to 2.5.0.
+		 * Since 2.5.0 the feed generation interval is increased to 24h.
 		 * Update procedure just needs to remove all current actions.
 		 * The Feed class will reschedule new generation with proper cadence.
 		 */

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -157,8 +157,7 @@ class Feed {
 	 * @since 1.11.0
 	 */
 	public function schedule_feed_generation() {
-
-		$integration   = facebook_for_woocommerce()->get_integration();
+		$integration  = facebook_for_woocommerce()->get_integration();
 		$configured_ok = $integration && $integration->is_configured();
 
 		// Only schedule feed job if store has not opted out of product sync.
@@ -174,10 +173,11 @@ class Feed {
 		 * Filters the frequency with which the product feed data is generated.
 		 *
 		 * @since 1.11.0
+		 * @since 2.5.0 Feed generation interval increased to 24h.
 		 *
 		 * @param int $interval the frequency with which the product feed data is generated, in seconds. Defaults to every 15 minutes.
 		 */
-		$interval = apply_filters( 'wc_facebook_feed_generation_interval', MINUTE_IN_SECONDS * 15 );
+		$interval = apply_filters( 'wc_facebook_feed_generation_interval', DAY_IN_SECONDS );
 
 		if ( ! as_next_scheduled_action( self::GENERATE_FEED_ACTION ) ) {
 			as_schedule_recurring_action( time(), max( 2, $interval ), self::GENERATE_FEED_ACTION, array(), facebook_for_woocommerce()->get_id_dasherized() );

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -157,7 +157,7 @@ class Feed {
 	 * @since 1.11.0
 	 */
 	public function schedule_feed_generation() {
-		$integration  = facebook_for_woocommerce()->get_integration();
+		$integration   = facebook_for_woocommerce()->get_integration();
 		$configured_ok = $integration && $integration->is_configured();
 
 		// Only schedule feed job if store has not opted out of product sync.


### PR DESCRIPTION
### Changes proposed in this Pull Request:
By increasing the feed file generation interval we reduce the load that is put on the sites.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #1941 .

### How to test the changes in this Pull Request:

<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. In wp-content/plugins/facebook-for-woocommerce/class-wc-facebookcommerce.php change the VERSION const to `2.5.0`.
2. Refresh the admin panel.
3. Go to WooCommerce -> Status -> Scheduled Actions
4. Look for `wc_facebook_regenerate_feed`, it should be scheduled to run once a day.
![image](https://user-images.githubusercontent.com/17271089/117821780-33c9b000-b26c-11eb-97af-6580d25708ae.png)


### Changelog entry 

Fix - Change feed generation cadence to 24h. 
