### PR TITLE
add tracks proxy API and some example events for feed/background sync

### DIFF
--- a/includes/Proxies/Tracks.php
+++ b/includes/Proxies/Tracks.php
@@ -1,7 +1,7 @@
 <?php
 declare( strict_types=1 );
 
-namespace Automattic\WooCommerce\Facebook\Proxies;
+namespace SkyVerge\WooCommerce\Facebook\Proxies;
 
 use WC_Site_Tracking;
 use WC_Tracks;

--- a/includes/Proxies/Tracks.php
+++ b/includes/Proxies/Tracks.php
@@ -1,0 +1,36 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Facebook\Proxies;
+
+use WC_Site_Tracking;
+use WC_Tracks;
+
+/**
+ * Wrapper (proxy) class for WC_Tracks from WooCommerce Core.
+ *
+ * Supplies a standard prefix to all events.
+ *
+ * @package Automattic\WooCommerce\Facebook\Proxies
+ */
+class Tracks {
+
+	/**
+	 * Record a tracks event.
+	 *
+	 * @param string $name       The event name to record.
+	 * @param array  $properties Array of properties to include with the event.
+	 */
+	public static function record_event( string $name, array $properties = [] ) {
+		if ( ! class_exists( WC_Tracks::class ) || ! WC_Site_Tracking::is_tracking_enabled() ) {
+			return;
+		}
+
+		$prefix = 'facebook_for_woocommerce_';
+
+		// In future we might want some standard default properties here.
+		// GLA has a more extensive API, not sure if we need that.
+
+		WC_Tracks::record_event( $prefix . $name, $properties );
+	}
+}

--- a/includes/fbbackground.php
+++ b/includes/fbbackground.php
@@ -8,7 +8,7 @@
  * @package FacebookCommerce
  */
 
-use Automattic\WooCommerce\Facebook\Proxies\Tracks as WC_Tracks;
+use SkyVerge\WooCommerce\Facebook\Proxies\Tracks as WC_Tracks;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/includes/fbbackground.php
+++ b/includes/fbbackground.php
@@ -8,6 +8,8 @@
  * @package FacebookCommerce
  */
 
+use Automattic\WooCommerce\Facebook\Proxies\Tracks as WC_Tracks;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -148,6 +150,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_Background_Process' ) ) :
 		 * performed, or, call parent::complete().
 		 */
 		protected function complete() {
+			WC_Tracks::record_event( 'product_sync_background_sync_completed' );
+
 			$commerce = $this->commerce;  // PHP5 compatibility for static access
 			delete_transient( $commerce::FB_SYNC_IN_PROGRESS );
 			delete_transient( $commerce::FB_SYNC_REMAINING );

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -12,11 +12,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use Automattic\WooCommerce\Facebook\Proxies\Tracks as WC_Tracks;
-
 use SkyVerge\WooCommerce\Facebook\Products;
 use SkyVerge\WooCommerce\Facebook\Products\Feed;
 use SkyVerge\WooCommerce\PluginFramework\v5_10_0 as Framework;
+use SkyVerge\WooCommerce\Facebook\Proxies\Tracks as WC_Tracks;
 
 if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -12,6 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\WooCommerce\Facebook\Proxies\Tracks as WC_Tracks;
+
 use SkyVerge\WooCommerce\Facebook\Products;
 use SkyVerge\WooCommerce\Facebook\Products\Feed;
 use SkyVerge\WooCommerce\PluginFramework\v5_10_0 as Framework;
@@ -92,6 +94,8 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 			$profiling_logger = facebook_for_woocommerce()->get_profiling_logger();
 			$profiling_logger->start( 'generate_feed' );
 
+			WC_Tracks::record_event( 'product_sync_feed_generate_started' );
+
 			\WC_Facebookcommerce_Utils::log( 'Generating a fresh product feed file' );
 
 			try {
@@ -106,9 +110,18 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 
 				\WC_Facebookcommerce_Utils::log( 'Product feed file generated' );
 
+				WC_Tracks::record_event(
+					'product_sync_feed_generate_completed',
+					array(
+						'time' => $generation_time,
+					)
+				);
+
 			} catch ( \Exception $exception ) {
 
 				\WC_Facebookcommerce_Utils::log( $exception->getMessage() );
+
+				WC_Tracks::record_event( 'product_sync_feed_generate_feed_error' );
 			}
 
 			$profiling_logger->stop( 'generate_feed' );


### PR DESCRIPTION
Fixes: #1944

### Changes proposed in this Pull Request:

Adds a basic tracks API to record telemetry events. Events will only be recorded for sites that opt in, and are running a supported version of WooCommerce (and Facebook for WooCommerce).

This is an experiment - the events, and the API are all up for discussion. 

### How to test the changes in this Pull Request:

<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1.
2.
3.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
> Fix / Dev / New - Remove duplicate visibility meta entries from postmeta table
<!-- See [previous releases](../../releases) for more examples. -->
