### PR TITLE
Add cron heartbeat to offload some tasks from `init` and `admin_init`

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -13,6 +13,7 @@ use SkyVerge\WooCommerce\Facebook\Lifecycle;
 use SkyVerge\WooCommerce\Facebook\Utilities\Background_Handle_Virtual_Products_Variations;
 use SkyVerge\WooCommerce\Facebook\Utilities\Background_Remove_Duplicate_Visibility_Meta;
 use SkyVerge\WooCommerce\PluginFramework\v5_10_0 as Framework;
+use SkyVerge\WooCommerce\Facebook\Heartbeat;
 
 if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
@@ -94,6 +95,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/** @var \SkyVerge\WooCommerce\Facebook\Jobs\JobRegistry */
 		public $job_registry;
 
+		/** @var Heartbeat */
+		public $heartbeat;
+
 		/**
 		 * Constructs the plugin.
 		 *
@@ -141,6 +145,9 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				require_once __DIR__ . '/includes/fbproductfeed.php';
 				require_once __DIR__ . '/facebook-commerce-messenger-chat.php';
 				require_once __DIR__ . '/includes/Exceptions/ConnectWCAPIException.php';
+
+				$this->heartbeat = new Heartbeat( WC()->queue() );
+				$this->heartbeat->init();
 
 				$this->product_feed              = new \SkyVerge\WooCommerce\Facebook\Products\Feed();
 				$this->products_stock_handler    = new \SkyVerge\WooCommerce\Facebook\Products\Stock();

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -13,7 +13,7 @@ use SkyVerge\WooCommerce\Facebook\Lifecycle;
 use SkyVerge\WooCommerce\Facebook\Utilities\Background_Handle_Virtual_Products_Variations;
 use SkyVerge\WooCommerce\Facebook\Utilities\Background_Remove_Duplicate_Visibility_Meta;
 use SkyVerge\WooCommerce\PluginFramework\v5_10_0 as Framework;
-use SkyVerge\WooCommerce\Facebook\Heartbeat;
+use SkyVerge\WooCommerce\Facebook\Utilities\Heartbeat;
 
 if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 

--- a/includes/Heartbeat.php
+++ b/includes/Heartbeat.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SkyVerge\WooCommerce\Facebook;
+
+use WC_Queue_Interface;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class Heartbeat
+ *
+ * Responsible for scheduling cron heartbeat hooks. Currently there is a single hourly heartbeat:
+ * - `facebook_for_woocommerce_heartbeat_hourly`
+ *
+ * @since x.x.x
+ */
+class Heartbeat {
+
+	/**
+	 * Hook name for hourly heartbeat.
+	 */
+	const HOURLY = 'facebook_for_woocommerce_hourly_heartbeat';
+
+	/**
+	 * @var string
+	 */
+	protected $hourly_cron_name = 'facebook_for_woocommerce_hourly_heartbeat_cron';
+
+	/**
+	 * @var WC_Queue_Interface
+	 */
+	protected $queue;
+
+	/**
+	 * Heartbeat constructor.
+	 *
+	 * @param WC_Queue_Interface $queue WC Action Scheduler proxy.
+	 */
+	public function __construct( WC_Queue_Interface $queue ) {
+		$this->queue = $queue;
+	}
+
+	/**
+	 * Add hooks.
+	 */
+	public function init() {
+		add_action( 'init', array( $this, 'schedule_cron_events' ) );
+		add_action( $this->hourly_cron_name, array( $this, 'schedule_hourly_action' ) );
+	}
+
+	/**
+	 * Schedule heartbeat cron events.
+	 *
+	 * WP Cron events are stored in an auto-loaded option so the performance impact is much lower than checking and
+	 * scheduling an Action Scheduler action.
+	 */
+	public function schedule_cron_events() {
+		if ( ! wp_next_scheduled( $this->hourly_cron_name ) ) {
+			wp_schedule_event( time(), 'hourly', $this->hourly_cron_name );
+		}
+	}
+
+	/**
+	 * Schedule the hourly heartbeat action to run immediately.
+	 *
+	 * Scheduling an action frees up WP Cron to process more jobs in the current request. Action Scheduler has greater
+	 * throughput so running our checks there is better.
+	 */
+	public function schedule_hourly_action() {
+		$this->queue->add( self::HOURLY );
+	}
+
+
+}

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -12,6 +12,7 @@ namespace SkyVerge\WooCommerce\Facebook\Products;
 
 defined( 'ABSPATH' ) or exit;
 
+use SkyVerge\WooCommerce\Facebook\Heartbeat;
 use SkyVerge\WooCommerce\PluginFramework\v5_10_0 as Framework;
 
 /**
@@ -54,7 +55,7 @@ class Feed {
 	private function add_hooks() {
 
 		// schedule the recurring feed generation
-		add_action( 'admin_init', array( $this, 'schedule_feed_generation' ) );
+		add_action( Heartbeat::HOURLY, array( $this, 'schedule_feed_generation' ) );
 
 		// regenerate the product feed
 		add_action( self::GENERATE_FEED_ACTION, array( $this, 'regenerate_feed' ) );

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -12,7 +12,7 @@ namespace SkyVerge\WooCommerce\Facebook\Products;
 
 defined( 'ABSPATH' ) or exit;
 
-use SkyVerge\WooCommerce\Facebook\Heartbeat;
+use SkyVerge\WooCommerce\Facebook\Utilities\Heartbeat;
 use SkyVerge\WooCommerce\PluginFramework\v5_10_0 as Framework;
 
 /**

--- a/includes/Utilities/Heartbeat.php
+++ b/includes/Utilities/Heartbeat.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SkyVerge\WooCommerce\Facebook;
+namespace SkyVerge\WooCommerce\Facebook\Utilities;
 
 use WC_Queue_Interface;
 

--- a/includes/Utilities/Heartbeat.php
+++ b/includes/Utilities/Heartbeat.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
  * Responsible for scheduling cron heartbeat hooks. Currently there is a single hourly heartbeat:
  * - `facebook_for_woocommerce_heartbeat_hourly`
  *
- * @since x.x.x
+ * @since 2.6.0
  */
 class Heartbeat {
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Implement an hourly cron heartbeat where setup tasks can be performed e.g. scheduling important actions. See #1952 for background and proposal.

Closes #1952
Closes #1796

### How to test the changes in this Pull Request:

1. Check out `master` and using Query Monitor check that the **regenerate feed action** is checked on every admin page load:

<img width="1512" alt="Screen Shot 2021-05-13 at 11 22 30 am" src="https://user-images.githubusercontent.com/1892137/118066630-2df3dc00-b3de-11eb-9506-b5ff2754f8c1.png">


2. Check out this branch and that will no longer happen

<img width="1516" alt="Screen Shot 2021-05-13 at 11 22 58 am" src="https://user-images.githubusercontent.com/1892137/118066674-46fc8d00-b3de-11eb-8db9-75d0070ecc0a.png">

3. Delete the `wc_facebook_generate_feed` action via the Action Scheduler UI
4. Install [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) and reschedule the `facebook_for_woocommerce_hourly_heartbeat_cron` task to run now.
5. Head back to the Action Scheduler UI and check the `wc_facebook_generate_feed` was re-added.

### Changelog entry

> Performance - Move scheduling of certain actions to run every hour rather than on every request
