### PR TITLE
Remove duplicate .js file extension in new admin js file

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ module.exports = {
 	...defaultConfig,
 	entry: {
 		// Use admin/index.js for any new React-powered UI
-		'admin/index.js': './assets/js/admin/index.js',
+		'admin/index': './assets/js/admin/index.js',
 		...jQueryUIAdminFileEntries,
 	},
 	output: {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The entry point config should be index (no .js extension); the generated file is `index.js.js`. 

Fixes issue raised here: https://github.com/woocommerce/facebook-for-woocommerce/pull/1826#discussion_r631536945

### How to test the changes in this Pull Request:

1. Run `npm run build:assets`
2. Check there is an `assets/build/admin.index.js` and not an `assets/build/admin.index.js.js` file

### Changelog entry

N/A