### PR TITLE
Release PR: Facebook for WooCommerce 2.5.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,16 @@
 *** Facebook for WooCommerce Changelog ***
 
 2021-xx-xx - version 2.5.0-rc1
- *  Ensure variable product attribute values containing , sync correctly to Facebook additional_variant_attribute field.
+ * New - Option to allow larger sites to opt-out of feed generation (product sync) job #1932
+ * Fix - Reduce default feed generation (product sync) interval to once per day to reduce overhead #1942
+ * Fix - Trigger feed (product sync) job from to `admin_init` to reduce impact on front-end requests #1939
+ * Fix - Ensure variable product attribute values containing comma (`,`) sync correctly #1922
+ * Fix - Use existing / current tab for connection `Get Started` button #1885
+ * Dev - Require PHP version 7.0 or newer #1908
+ * Dev - Adopt Composer autoloader to avoid manually `require`ing PHP class files #1919
+ * Dev - Adopt WooRelease release tool for deploying releases #1947
+ * Dev - Add `phpcs` tooling to help standardise PHP code style #1911
+ * Dev - Add JobRegistry engine for managing periodic background batch jobs #1913
 
 2021.04.29 - version 2.4.1
  * Fix - PHP<7.1 incompatible code for Google Taxonomy Setting in products.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Facebook for WooCommerce Changelog ***
 
+2021-xx-xx - version x.x.x
+
+
 2021-05-19 - version 2.5.0
  * New - Option to allow larger sites to opt-out of feed generation (product sync) job #1932
  * New - Log connection errors to allow easier troubleshooting #1857

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-2021-xx-xx - version 2.5.0-rc1
+2021-xx-xx - version 2.5.0
  * New - Option to allow larger sites to opt-out of feed generation (product sync) job #1932
  * Fix - Reduce default feed generation (product sync) interval to once per day to reduce overhead #1942
  * Fix - Trigger feed (product sync) job from to `admin_init` to reduce impact on front-end requests #1939

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-2021-xx-xx - version 2.5.0
+2021-xx-xx - version 2.5.0-rc1
  *  Ensure variable product attribute values containing , sync correctly to Facebook additional_variant_attribute field.
 
 2021.04.29 - version 2.4.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-2021-xx-xx - version 2.5.0
+2021-xx-xx - version 2.5.0-rc1
  * New - Option to allow larger sites to opt-out of feed generation (product sync) job #1932
  * Fix - Reduce default feed generation (product sync) interval to once per day to reduce overhead #1942
  * Fix - Trigger feed (product sync) job from to `admin_init` to reduce impact on front-end requests #1939

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-2021-xx-xx - version 2.5.0
+2021-05-19 - version 2.5.0
  * New - Option to allow larger sites to opt-out of feed generation (product sync) job #1932
  * New - Log connection errors to allow easier troubleshooting #1857
  * Fix - Reduce default feed generation (product sync) interval to once per day to reduce overhead #1942

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 2021-xx-xx - version 2.5.0-rc1
  * New - Option to allow larger sites to opt-out of feed generation (product sync) job #1932
+ * New - Log connection errors to allow easier troubleshooting #1857
  * Fix - Reduce default feed generation (product sync) interval to once per day to reduce overhead #1942
  * Fix - Trigger feed (product sync) job from to `admin_init` to reduce impact on front-end requests #1939
  * Fix - Ensure variable product attribute values containing comma (`,`) sync correctly #1922
@@ -9,6 +10,7 @@
  * Dev - Require PHP version 7.0 or newer #1908
  * Dev - Adopt Composer autoloader to avoid manually `require`ing PHP class files #1919
  * Dev - Adopt WooRelease release tool for deploying releases #1947
+ * Dev - Use wp-scripts to build assets #1826
  * Dev - Add `phpcs` tooling to help standardise PHP code style #1911
  * Dev - Add JobRegistry engine for managing periodic background batch jobs #1913
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-2021-xx-xx - version 2.5.0-rc1
+2021-xx-xx - version 2.5.0
  * New - Option to allow larger sites to opt-out of feed generation (product sync) job #1932
  * New - Log connection errors to allow easier troubleshooting #1857
  * Fix - Reduce default feed generation (product sync) interval to once per day to reduce overhead #1942

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -31,7 +31,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '2.5.0'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '2.5.0-rc1'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.0.0';

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -31,7 +31,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '2.5.0-rc1'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '2.5.0'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.0.0';

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 2.5.0
+ * Version: 2.6.0-dev
  * Text Domain: facebook-for-woocommerce
  * WC requires at least: 3.5.0
  * WC tested up to: 5.2.2
@@ -31,7 +31,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '2.5.0'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '2.6.0-dev'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.0.0';

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 2.5.0-rc1
+ * Version: 2.5.0
  * Text Domain: facebook-for-woocommerce
  * WC requires at least: 3.5.0
  * WC tested up to: 5.2.2
@@ -31,7 +31,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '2.5.0-rc1'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '2.5.0'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.0.0';

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 2.4.1
+ * Version: 2.5.0-rc1
  * Text Domain: facebook-for-woocommerce
  * WC requires at least: 3.5.0
  * WC tested up to: 5.2.2
@@ -31,7 +31,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '2.4.1'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '2.5.0-rc1'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.0.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.5.0-rc.1",
+  "version": "2.5.0-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.5.0-rc1",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.5.0",
+  "version": "2.6.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.5.0-rc.1",
+  "version": "2.5.0-rc1",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.5.0",
+  "version": "2.6.0-dev",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.5.0-rc1",
+  "version": "2.5.0",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 5.6
-Stable tag: 2.4.1
+Stable tag: 2.5.0-rc1
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= 2.5.0 - 2021-xx-xx =
+= 2.5.0 - 2021-05-19 =
  * Ensure variable product attribute values containing , sync correctly to Facebook additional_variant_attribute field.
 
 = 2021.04.29 - version 2.4.1 =

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 5.6
-Stable tag: 2.5.0
+Stable tag: 2.5.0-rc1
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -40,7 +40,18 @@ When opening a bug on GitHub, please give us as many details as possible.
 == Changelog ==
 
 = 2.5.0 - 2021-05-19 =
- * Ensure variable product attribute values containing , sync correctly to Facebook additional_variant_attribute field.
+ * New - Option to allow larger sites to opt-out of feed generation (product sync) job
+ * New - Log connection errors to allow easier troubleshooting
+ * Fix - Reduce default feed generation (product sync) interval to once per day to reduce overhead
+ * Fix - Trigger feed (product sync) job from to `admin_init` to reduce impact on front-end requests
+ * Fix - Ensure variable product attribute values containing comma (`,`) sync correctly
+ * Fix - Use existing / current tab for connection `Get Started` button
+ * Dev - Require PHP version 7.0 or newer
+ * Dev - Adopt Composer autoloader to avoid manually `require`ing PHP class files
+ * Dev - Adopt WooRelease release tool for deploying releases
+ * Dev - Use wp-scripts to build assets
+ * Dev - Add `phpcs` tooling to help standardise PHP code style
+ * Dev - Add JobRegistry engine for managing periodic background batch jobs
 
 = 2021.04.29 - version 2.4.1 =
  * Fix - PHP<7.1 incompatible code for Google Taxonomy Setting in products.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 5.6
-Stable tag: 2.5.0-rc1
+Stable tag: 2.5.0
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later


### PR DESCRIPTION
### Changes proposed in this Pull Request:
See https://github.com/woocommerce/facebook-for-woocommerce/releases/tag/2.5.0-rc1 changelog for details.

### How to test the changes in this Pull Request:
1. Grab release zip from https://github.com/woocommerce/facebook-for-woocommerce/releases/tag/2.5.0-rc1
2. Install on a test site and broadly test key flows. 
3. Spot-test areas affected by changes in changelog.

If you see anything please log an issue or comment below!
