### PR TITLE
Exclude PHPCS file comment rule

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -21,6 +21,9 @@
 		<!-- We use the PSR-4 naming convention rather than the WP one -->
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
+
+		<!--All PHP files contain a single class with a comment so a file comment is redundant -->
+		<exclude name="Squiz.Commenting.FileComment.Missing"/>
 	</rule>
 
 	<!-- Language domain -->


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since all our PHP files contain a single class which must have a comment having an additional file comment seems very redundant.

E.g: 

<img width="502" alt="Screen Shot 2021-05-14 at 5 08 04 pm" src="https://user-images.githubusercontent.com/1892137/118237931-f6b52600-b4d6-11eb-9944-8e516712060f.png">
