### PR TITLE
Check variation parent status before sync.

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -230,6 +230,11 @@ class Products {
 			$terms_product = null;
 		}
 
+		// Check parent status.
+		if ( null !== $terms_product && 'publish' !== $terms_product->get_status() ) {
+			return false;
+		}
+
 		// allow simple or variable products (and their variations) with zero or empty price - exclude other product types with zero or empty price
 		if ( $should_sync && ( ! $terms_product || ( ! self::get_product_price( $product ) && ! in_array( $terms_product->get_type(), array( 'simple', 'variable' ) ) ) ) ) {
 			$should_sync = false;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Duplicated variable products are duplicated with `publish` status. Only the parent has `draft` status. This caused the sync logic to trigger sync for duplicated variations.

This PR adds a parent status check when we determine if a variation is eligible for synchronization.

Closes #1803 .

### How to test the changes in this Pull Request:

<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Check reproduction instructions in #1803

### Changelog entry

Fix: New variation copies are immediately sent to Facebook Catalog.
