### PR TITLE
Make descriptions translate properly with WP Mulilang plugin

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -77,6 +77,11 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 				$this->fb_use_parent_image = $parent_product->get_use_parent_image();
 				$this->main_description    = $parent_product->get_fb_description();
 			}
+			
+			// Make descriptions translate properly with WP Mulilang plugin
+			if(function_exists('wpm')){
+				$this->main_description = strip_tags( apply_filters('the_content', $parent_product->get_fb_description()) );
+			}
 		}
 
 		public function exists() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Added WP Multilang check for descriptions.

Closes # .

### How to test the changes in this Pull Request:

1. Install WP Multilang plugin
2. Crete products in at least 2 languages and add product data with descriptions on all languages.
3. Sync products to Facebook

### Changelog entry
Fix - Make descriptions translate properly with WP Mulilang plugin
