### PR TITLE
Fix `fb_reset_product is not defined` errors by adding relevant JS functions to `window`

### DIFF
--- a/assets/js/admin/infobanner.js
+++ b/assets/js/admin/infobanner.js
@@ -34,7 +34,7 @@ function ajax(action, payload = null, callback = null, failcallback = null) {
 	);
 }
 
-function fb_woo_infobanner_post_click(){
+window.fb_woo_infobanner_post_click = function (){
 	console.log( "Woo infobanner post tip click!" );
 	return ajax(
 		 'ajax_woo_infobanner_post_click',
@@ -42,9 +42,9 @@ function fb_woo_infobanner_post_click(){
 			 "_ajax_nonce": wc_facebook_infobanner_jsx.nonce
 		 },
 	);
-}
+};
 
-function fb_woo_infobanner_post_xout() {
+window.fb_woo_infobanner_post_xout = function() {
 	console.log( "Woo infobanner post tip xout!" );
 	return ajax(
 			'ajax_woo_infobanner_post_xout',
@@ -52,4 +52,4 @@ function fb_woo_infobanner_post_xout() {
 				"_ajax_nonce": wc_facebook_infobanner_jsx.nonce
 			},
 	);
-}
+};

--- a/assets/js/admin/infobanner.js
+++ b/assets/js/admin/infobanner.js
@@ -37,19 +37,19 @@ function ajax(action, payload = null, callback = null, failcallback = null) {
 window.fb_woo_infobanner_post_click = function (){
 	console.log( "Woo infobanner post tip click!" );
 	return ajax(
-		 'ajax_woo_infobanner_post_click',
-		 {
-			 "_ajax_nonce": wc_facebook_infobanner_jsx.nonce
-		 },
+		'ajax_woo_infobanner_post_click',
+		{
+			"_ajax_nonce": wc_facebook_infobanner_jsx.nonce
+		},
 	);
 };
 
 window.fb_woo_infobanner_post_xout = function() {
 	console.log( "Woo infobanner post tip xout!" );
 	return ajax(
-			'ajax_woo_infobanner_post_xout',
-			{
-				"_ajax_nonce": wc_facebook_infobanner_jsx.nonce
-			},
+		'ajax_woo_infobanner_post_xout',
+		{
+			"_ajax_nonce": wc_facebook_infobanner_jsx.nonce
+		},
 	);
 };

--- a/assets/js/admin/metabox.js
+++ b/assets/js/admin/metabox.js
@@ -35,7 +35,7 @@ function ajax(action, payload = null, cb = null, failcb = null) {
 	);
 }
 
-function fb_reset_product(wp_id) {
+window.fb_reset_product = function(wp_id) {
 	if (confirm(
 		'Resetting Facebook metadata will not remove this product from your shop. ' +
 		'If you have duplicated another product and are trying to publish a new Facebook product, ' +
@@ -55,9 +55,9 @@ function fb_reset_product(wp_id) {
 			}
 		);
 	}
-}
+};
 
-function fb_delete_product(wp_id) {
+window.fb_delete_product = function(wp_id) {
 	if (confirm(
 		'Are you sure you want to delete this product on Facebook? If you only want to "hide" the product, ' +
 		'change the "Facebook sync" setting to "Sync and hide" and hit "Update". If you delete a product on Facebook and hit "Update" after, ' +
@@ -77,4 +77,5 @@ function fb_delete_product(wp_id) {
 			}
 		);
 	}
-}
+};
+


### PR DESCRIPTION
Fixes #1979
 
### Changes proposed in this Pull Request:
This PR tweaks some of our JS to explicitly set global functions on window object (as a module side effect).

##### The problem
Some of our front-end templates/html code relies on global JavaScript functions. For example, see how a call to `fb_reset_product` is rendered directly in this chunk of PHP:

https://github.com/woocommerce/facebook-for-woocommerce/blob/5248ce224a1b03667151313eeb45018541d45fba/facebook-commerce.php#L665-L672

In 2.5 we switched to using webpack to build our JS (from an unknown state - built JS was in the repo) - see #1826. Webpack treats JS files as isolated modules (good 👍) so if you want side effects that affect the DOM or the `window` (i.e. globals) as part of your module, you need to make that happen. 

##### The solution
This PR simply assigns these functions as props of `window` directly. This is consistent with other scripts in this repo, e.g. `` 

I [investigated](https://github.com/woocommerce/facebook-for-woocommerce/tree/fix/legacy-js-broken) an alternative - using `output: { libraryTarget: umd }` and `export`ing the relevant functions. This is inconsistent with other code, more opaque (less obvious), and prevents us from using self-contained modules in future.


### How to test the changes in this Pull Request:
1. Facebook for WooCommerce 2.5.0+
2. Go to `Products` and edit a product. 
3. Scroll down to `Facebook` metabox and click `Reset Facebook metadata`.
3. Ensure it works without errors.
4. Test JS functionality in product edit page (e.g. `Delete product(s) on Facebook`) and elsewhere.

#### Bonus points - review for other potential similar issues
This issue may affect other JS that has been recently `webpack`ed. Please test widely, ideally reference all the code in JS to ensure we can trigger it from UI. There are possibly other issues to fix.


### Changelog entry
> Fix - Reinstate reset and delete functions in `Facebook` metabox on `Edit product` admin screen  
