### PR TITLE
Add placeholder replace paths.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "build": "./bin/build-zip.sh"
   },
   "woorelease": {
-		"version_replace_paths": [
-			"includes",
+    "version_replace_paths": [
+      "includes",
       "class-wc-facebookcommerce.php",
       "facebook-commerce-events-tracker.php",
       "facebook-commerce-messenger-chat.php",

--- a/package.json
+++ b/package.json
@@ -25,5 +25,17 @@
     "start": "wp-scripts start",
     "deploy:sake": "npm run build:assets && npx sake deploy --deployAssets=0",
     "build": "./bin/build-zip.sh"
-  }
+  },
+  "woorelease": {
+		"version_replace_paths": [
+			"includes",
+      "class-wc-facebookcommerce.php",
+      "facebook-commerce-events-tracker.php",
+      "facebook-commerce-messenger-chat.php",
+      "facebook-commerce-pixel-event.php",
+      "facebook-commerce.php",
+      "facebook-config-warmer.php",
+      "facebook-for-woocommerce.php"
+		]
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since WooRelease 2.0.4 versioning placeholders are supported. If we want to use that feature we must add paths that will be evaluated for version replacement.

WooRelease docs: https://github.com/woocommerce/woorelease/blob/develop/README.md#phpdoc-version-placeholder-requirements

This features works only if WooRelease process is started with `--product_version` flag.

WooRelease 2.0.4 is obviously required. 

### How to test the changes in this Pull Request:

The easiest way to test this is:
1.  Create a branch from this branch.
2. Add code with a docblock that contains `@since x.x.x` or `@version x.x.x`.
3. Add a dummy fresh changelog.txt and readme.txt.
4. Push the changes.
5. Run a simulation release ( stop when the plugin starts the build - that part is not necessary ):

```bash
php woorelease.phar simulate --product_version=2.5.1 https://github.com/woocommerce/facebook-for-woocommerce/tree/your-branch
```
6. Inspect temporary folder for changes.


### Changelog entry

No changelog entry needed.
