### PR TITLE
Release PR: Facebook for WooCommerce 2.5.1 (hotfix)

### DIFF
--- a/assets/js/admin/infobanner.js
+++ b/assets/js/admin/infobanner.js
@@ -34,22 +34,22 @@ function ajax(action, payload = null, callback = null, failcallback = null) {
 	);
 }
 
-function fb_woo_infobanner_post_click(){
+window.fb_woo_infobanner_post_click = function (){
 	console.log( "Woo infobanner post tip click!" );
 	return ajax(
-		 'ajax_woo_infobanner_post_click',
-		 {
-			 "_ajax_nonce": wc_facebook_infobanner_jsx.nonce
-		 },
+		'ajax_woo_infobanner_post_click',
+		{
+			"_ajax_nonce": wc_facebook_infobanner_jsx.nonce
+		},
 	);
-}
+};
 
-function fb_woo_infobanner_post_xout() {
+window.fb_woo_infobanner_post_xout = function() {
 	console.log( "Woo infobanner post tip xout!" );
 	return ajax(
-			'ajax_woo_infobanner_post_xout',
-			{
-				"_ajax_nonce": wc_facebook_infobanner_jsx.nonce
-			},
+		'ajax_woo_infobanner_post_xout',
+		{
+			"_ajax_nonce": wc_facebook_infobanner_jsx.nonce
+		},
 	);
-}
+};

--- a/assets/js/admin/metabox.js
+++ b/assets/js/admin/metabox.js
@@ -35,7 +35,7 @@ function ajax(action, payload = null, cb = null, failcb = null) {
 	);
 }
 
-function fb_reset_product(wp_id) {
+window.fb_reset_product = function(wp_id) {
 	if (confirm(
 		'Resetting Facebook metadata will not remove this product from your shop. ' +
 		'If you have duplicated another product and are trying to publish a new Facebook product, ' +
@@ -55,9 +55,9 @@ function fb_reset_product(wp_id) {
 			}
 		);
 	}
-}
+};
 
-function fb_delete_product(wp_id) {
+window.fb_delete_product = function(wp_id) {
 	if (confirm(
 		'Are you sure you want to delete this product on Facebook? If you only want to "hide" the product, ' +
 		'change the "Facebook sync" setting to "Sync and hide" and hit "Update". If you delete a product on Facebook and hit "Update" after, ' +
@@ -77,4 +77,5 @@ function fb_delete_product(wp_id) {
 			}
 		);
 	}
-}
+};
+

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-2021-xx-xx - version x.x.x
+2021-xx-xx - version 2.5.1
 
 
 2021-05-19 - version 2.5.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 2021-xx-xx - version x.x.x
 
+
 2021-05-19 - version 2.5.0
  * New - Option to allow larger sites to opt-out of feed generation (product sync) job #1932
  * New - Log connection errors to allow easier troubleshooting #1857

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-2021-xx-xx - version 2.5.1
+2021-05-28 - version 2.5.1
  * Fix - Reinstate reset and delete functions in Facebook metabox on Edit product admin screen #1980
 
 2021-05-19 - version 2.5.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-2021-xx-xx - version 2.5.0
+2021-05-19 - version 2.5.0
  * New - Option to allow larger sites to opt-out of feed generation (product sync) job #1932
  * New - Log connection errors to allow easier troubleshooting #1857
  * Fix - Reduce default feed generation (product sync) interval to once per day to reduce overhead #1942

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 *** Facebook for WooCommerce Changelog ***
 
 2021-xx-xx - version 2.5.1
-
+ * Fix - Reinstate reset and delete functions in Facebook metabox on Edit product admin screen #1980
 
 2021-05-19 - version 2.5.0
  * New - Option to allow larger sites to opt-out of feed generation (product sync) job #1932

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 2.6.0-dev
+ * Version: 2.5.1
  * Text Domain: facebook-for-woocommerce
  * WC requires at least: 3.5.0
  * WC tested up to: 5.2.2
@@ -31,7 +31,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '2.6.0-dev'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '2.5.1'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.0.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.6.0-dev",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.6.0-dev",
+  "version": "2.5.1",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 5.6
-Stable tag: 2.5.0
+Stable tag: 2.5.1
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later
@@ -39,7 +39,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= x.x.x - 2021-xx-xx =
+= 2.5.1 - 2021-xx-xx =
 
 = 2.5.0 - 2021-05-19 =
  * New - Option to allow larger sites to opt-out of feed generation (product sync) job

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= 2.5.1 - 2021-xx-xx =
+= 2.5.1 - 2021-05-28 =
  * Fix - Reinstate reset and delete functions in Facebook metabox on Edit product admin screen
 
 = 2.5.0 - 2021-05-19 =

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= 2.5.0 - 2021-xx-xx =
+= 2.5.0 - 2021-05-19 =
  * Ensure variable product attribute values containing , sync correctly to Facebook additional_variant_attribute field.
 
 = 2021.04.29 - version 2.4.1 =

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 == Changelog ==
 
 = 2.5.1 - 2021-xx-xx =
+ * Fix - Reinstate reset and delete functions in Facebook metabox on Edit product admin screen
 
 = 2.5.0 - 2021-05-19 =
  * New - Option to allow larger sites to opt-out of feed generation (product sync) job

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,8 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
+= x.x.x - 2021-xx-xx =
+
 = 2.5.0 - 2021-05-19 =
  * New - Option to allow larger sites to opt-out of feed generation (product sync) job
  * New - Log connection errors to allow easier troubleshooting


### PR DESCRIPTION
Hotfix release to fix #1979, introduced in 2.5. See #1979 and #1980 for details and test instructions.