### PR TITLE
Set empty `sale_price` for products that aren't on sale

### DIFF
--- a/includes/Feed/FeedProductFormatter.php
+++ b/includes/Feed/FeedProductFormatter.php
@@ -48,6 +48,18 @@ class FeedProductFormatter {
 		if ( Products::product_should_be_deleted( $fb_product->woo_product ) ) {
 			$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
 		}
+
+		// Sale price, only format if we have a sale price set for the product, else leave as empty ('').
+		$sale_price                = $this->get_value_from_product_data( $product_data, 'sale_price', '' );
+		$sale_price_effective_date = '';
+		if ( is_numeric( $sale_price ) && $sale_price > 0 ) {
+			$sale_price_effective_date = $this->get_value_from_product_data( $product_data, 'sale_price_start_date' ) . '/' . $this->get_value_from_product_data( $product_data, 'sale_price_end_date' );
+			$sale_price                = $this->format_price_for_feed(
+				$sale_price,
+				$this->get_value_from_product_data( $product_data, 'currency' )
+			);
+		}
+
 		$feed_row                              = array();
 		$feed_row['id']                        = $product_data['retailer_id'];
 		$feed_row['title']                     = $fb_product->woo_product->get_title();
@@ -64,11 +76,8 @@ class FeedProductFormatter {
 		$feed_row['item_group_id']             = $item_group_id;
 		$feed_row['checkout_url']              = $this->get_value_from_product_data( $product_data, 'checkout_url' );
 		$feed_row['additional_image_link']     = $this->format_additional_image_url( $this->get_value_from_product_data( $product_data, 'additional_image_urls' ) );
-		$feed_row['sale_price_effective_date'] = $this->get_value_from_product_data( $product_data, 'sale_price_start_date' ) . '/' . $this->get_value_from_product_data( $product_data, 'sale_price_end_date' );
-		$feed_row['sale_price']                = $this->format_price_for_feed(
-			$this->get_value_from_product_data( $product_data, 'sale_price', 0 ),
-			$this->get_value_from_product_data( $product_data, 'currency' )
-		);
+		$feed_row['sale_price_effective_date'] = $sale_price_effective_date;
+		$feed_row['sale_price']                = $sale_price;
 		$feed_row['condition']                 = 'new';
 		$feed_row['visibility']                = $this->get_value_from_product_data( $product_data, 'visibility' );
 		$feed_row['gender']                    = $this->get_value_from_product_data( $product_data, 'gender' );

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -351,6 +351,12 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			return $description;
 		}
 
+		/**
+		 * @param array $product_data
+		 * @param bool $for_items_batch
+		 *
+		 * @return array
+		 */
 		public function add_sale_price( $product_data, $for_items_batch = false ) {
 
 			// initialise sale price

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -358,16 +358,6 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 		 * @return array
 		 */
 		public function add_sale_price( $product_data, $for_items_batch = false ) {
-
-			// initialise sale price
-			if ( $for_items_batch ) {
-				$product_data['sale_price_effective_date'] = self::MIN_DATE_1 . self::MIN_TIME . '/' . self::MIN_DATE_2 . self::MAX_TIME;
-			} else {
-				$product_data['sale_price_start_date'] = self::MIN_DATE_1 . self::MIN_TIME;
-				$product_data['sale_price_end_date']   = self::MIN_DATE_2 . self::MAX_TIME;
-			}
-			$product_data['sale_price'] = $product_data['price'];
-
 			$sale_price = $this->woo_product->get_sale_price();
 
 			// check if sale exist


### PR DESCRIPTION
**Note:  Added blocked status since this is based on #1924 and is not merged to master yet**

### Changes proposed in this Pull Request:

Currently, feed sets `sale_price`  the same as the `price` causing products to be on sale, this PR removes sets default `sale_price` and `sale_price_effective_date` to `''` (empty) when product is not on sale.

Closes #1833 .

### How to test the changes in this Pull Request:

<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout this branch 
2. Make sure you have a few products with _sale price_ set
2. We want to generate a new feed file, this can be accomplished by updating this line and changing `Heartbeat::HOURLY` to `init`

https://github.com/woocommerce/facebook-for-woocommerce/blob/d43600cd5c03fd2ba0a7b047193b18c755d896a6/includes/Feed/FeedScheduler.php#L22

3. Reload site, and go to `https://MYSITE/wp-admin/tools.php?page=action-scheduler&status=pending`. You should have a task called _facebook_for_woocommerce_start_feed_generation_, let's manually run it.

<img width="1480" alt="Screen Shot 2021-06-03 at 01 55 16" src="https://user-images.githubusercontent.com/532402/120608826-da8a1200-c40e-11eb-89ad-ef0209158912.png">

4. Feed file should be generating now, you can validate this by browsing path: _/wp-content/facebook_for_woocommerce/_, there's should be a file with _temp_ word on it. Wait until the file is completed and _temp_ is removed
5. Open it on numbers.app or your text editor, you can validate `sale_price` and `sale_price_effective_date` column are empty for products without a _sale price_
<img width="384" alt="Screen Shot 2021-06-03 at 01 59 54" src="https://user-images.githubusercontent.com/532402/120609504-7582ec00-c40f-11eb-9106-9080a949cf51.png">
6. Now we'll check feed is valid for FB, go to your FB Catalog's settings, and upload the new file manually
<img width="1658" alt="Screen Shot 2021-06-03 at 02 04 47" src="https://user-images.githubusercontent.com/532402/120610367-52a50780-c410-11eb-924a-0197880794e1.png">
<img width="1014" alt="Screen Shot 2021-06-03 at 02 05 36" src="https://user-images.githubusercontent.com/532402/120610373-53d63480-c410-11eb-9494-256203771936.png">

7. Finally, let's valid the product doesn't have the sale price on FB.
<img width="836" alt="Screen Shot 2021-06-03 at 02 07 35" src="https://user-images.githubusercontent.com/532402/120610595-9435b280-c410-11eb-8f7e-945b8c991885.png">


### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
> Fix - Do not set `sale_price` when product is not on sale.
<!-- See [previous releases](../../releases) for more examples. -->
