### PR TITLE
don't delete cached tracker info transients when generating tracker snapshot

### DIFF
--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -109,15 +109,15 @@ class Tracker {
 		 */
 		$feed_generation_time = get_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_TIME );
 		$data['extensions']['facebook-for-woocommerce']['feed-generation-time'] = floatval( $feed_generation_time );
-		delete_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_TIME );
 
 		/**
-		 * Has the feed file been requested recently?
+		 * Has the feed file been requested since the last snapshot?
 		 *
 		 * @since x.x.x
 		 */
 		$feed_file_requested = get_transient( self::TRANSIENT_WCTRACKER_FEED_REQUESTED );
 		$data['extensions']['facebook-for-woocommerce']['feed-file-requested'] = wc_bool_to_string( $feed_file_requested );
+		// Manually delete the transient. This prop tracks if feed has been requested _since last snapshot_.
 		delete_transient( self::TRANSIENT_WCTRACKER_FEED_REQUESTED );
 
 		/**
@@ -128,7 +128,6 @@ class Tracker {
 		$config = get_transient( self::TRANSIENT_WCTRACKER_FBE_BUSINESS_CONFIG );
 		$data['extensions']['facebook-for-woocommerce']['ig-shopping-enabled'] = wc_bool_to_string( $config ?: $config->ig_shopping_enabled );
 		$data['extensions']['facebook-for-woocommerce']['ig-cta-enabled']      = wc_bool_to_string( $config ?: $config->ig_cta_enabled );
-		delete_transient( self::TRANSIENT_WCTRACKER_FBE_BUSINESS_CONFIG );
 
 		/**
 		 * Feed pull / upload settings configured in Facebook UI.
@@ -136,7 +135,6 @@ class Tracker {
 		 * @since x.x.x
 		 */
 		$data['extensions']['facebook-for-woocommerce']['product-feed-config'] = get_transient( self::TRANSIENT_WCTRACKER_FB_FEED_CONFIG );
-		delete_transient( self::TRANSIENT_WCTRACKER_FB_FEED_CONFIG );
 
 		return $data;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1992

This PR removes code to delete cached tracker information when generating the tracker snapshot. This ensures that tracker data is consistent even if snapshots are generated more frequently than the data is updated.

### How to test the changes in this Pull Request:
Note this issue does not affect merchant flows, and is arguably an edge case for tracker snapshot generation. So the testing steps are a little involved.

Basically the idea is to generate snapshots (using CLI command) before the feed config data has a chance to be updated. 

Note also that the first set of steps are to ensure that feed config data is updated (without waiting for `Heartbeat::DAILY`). 

1. Ensure the `DAILY` heartbeat has run recently, or force it to run, to get refresh tracker transients. One way to do this:
   - Hack `Heartbeat.php` `schedule_cron_events()` so that `wp_schedule_event( time(), 'daily', $this->daily_cron_name );` runs every time (comment out `if ( ! wp_next_scheduled…`). This allows us to schedule a daily heartbeat now.
   - Load `WooCommerce > Status > Scheduled Actions`. You should see a pending `facebook_for_woocommerce_daily_heartbeat` action. 
   - Run it.
1. Now confirm the various feed-related config settings are stored in a transients, e.g. via CLI or database.
   - `wordpress wp transient get facebook_for_woocommerce_wctracker_fb_feed_config`
   - `wordpress wp transient get facebook_for_woocommerce_wctracker_feed_generation_time`
1. If you hacked `Heartbeat.php` code to force this, revert it now.
1. Trigger a snapshot manually, e.g. with CLI ([requires current WooCommerce `trunk` branch or 5.5](https://github.com/woocommerce/woocommerce/pull/30010)): `wp wc tracker snapshot --format=yaml`.
1. You should see all the feed tracker props, in particular `extensions.facebook-for-woocommerce.product-feed-config` should have many nested properties (`active-feed`, `feed-count` etc).
1. Trigger another snapshot. Notice that various feed config props are now empty.


### Changelog entry

n/a – this is a bug fix to #1972 which already has changelog entry