### PR TITLE
Switch to use Jetpack autoloader instead of Composer's autoloader

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -136,7 +136,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			add_filter( 'woocommerce_navigation_get_breadcrumbs', array( $this, 'wc_page_breadcrumbs_filter' ), 99 );
 
 			if ( \WC_Facebookcommerce_Utils::isWoocommerceIntegration() ) {
-				require_once __DIR__ . '/vendor/autoload.php';
+				require_once __DIR__ . '/vendor/autoload_packages.php';
 
 				include_once 'facebook-commerce.php';
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "skyverge/wc-plugin-framework": "5.10.0",
     "composer/installers": "~1.0",
     "php": ">=5.6",
-    "woocommerce/action-scheduler-job-framework": "1.0.0"
+    "woocommerce/action-scheduler-job-framework": "1.0.0",
+    "automattic/jetpack-autoloader": "^2.10"
   },
   "require-dev": {
     "woocommerce/woocommerce-sniffs": "0.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,59 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c32509070ea9431cc53627b9dfb22306",
+    "content-hash": "f1b92b22f6b66addefa486170d962a26",
     "packages": [
+        {
+            "name": "automattic/jetpack-autoloader",
+            "version": "v2.10.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-autoloader.git",
+                "reference": "aab966d6f2c8fd6669d6f5b1378d8ced5fd665b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/aab966d6f2c8fd6669d6f5b1378d8ced5fd665b4",
+                "reference": "aab966d6f2c8fd6669d6f5b1378d8ced5fd665b4",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "^1.2",
+                "yoast/phpunit-polyfills": "0.2.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "autotagger": true,
+                "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin",
+                "mirror-repo": "Automattic/jetpack-autoloader",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-autoloader/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "2.10.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/AutoloadGenerator.php"
+                ],
+                "psr-4": {
+                    "Automattic\\Jetpack\\Autoloader\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Creates a custom autoloader for a plugin or theme.",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.10.3"
+            },
+            "time": "2021-05-25T16:35:16+00:00"
+        },
         {
             "name": "composer/installers",
             "version": "v1.11.0",
@@ -9377,5 +9428,5 @@
         "php": ">=5.6"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Because we are going ahead with using a separate [Action Scheduler Job Framework package](https://github.com/woocommerce/action-scheduler-job-framework) we need to ensure that the latest version of the package is loaded into WordPress. [Jetpack Autoloader](https://github.com/Automattic/jetpack-autoloader) was built to solve this problem.

Jetpack autoloader is used also broadly by Woo and Automattic e.g. https://github.com/woocommerce/woocommerce/blob/trunk/composer.json#L17

Closes #1956.

### How to test the changes in this Pull Request:

1. Checkout branch
2. Run `composer install`
3. Load a few Facebook plugin admin pages locally

You can also run something like this to check that various classes are loading. (Copied from https://github.com/woocommerce/facebook-for-woocommerce/pull/1919).

```php
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Locale::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\AJAX::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Handlers\Connection::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Integrations\Integrations::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Product_Categories::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Products::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Commerce::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Products\Feed::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Products\FBCategories::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Products\Stock::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Products\Sync::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Products\Sync\Background::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\ProductSets\Sync::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Debug\ProfilingLogger::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Debug\ProfilingLoggerProcess::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Utilities\Shipment::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Utilities\Tracker::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Events\Event::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Events\Normalizer::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Events\AAMSettings::class ) );
var_dump( class_exists( \Automattic\WooCommerce\ActionSchedulerJobFramework\AbstractJob::class ) );
```

### Changelog entry

> Dev - Replace composer autoloader with Jetpack autoloader

