### PR TITLE
Rename ig to instagram in tracker for better selfdocumentation.

### DIFF
--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -126,8 +126,8 @@ class Tracker {
 		 * @since x.x.x
 		 */
 		$config = get_transient( self::TRANSIENT_WCTRACKER_FBE_BUSINESS_CONFIG );
-		$data['extensions']['facebook-for-woocommerce']['ig-shopping-enabled'] = wc_bool_to_string( $config ?: $config->ig_shopping_enabled );
-		$data['extensions']['facebook-for-woocommerce']['ig-cta-enabled']      = wc_bool_to_string( $config ?: $config->ig_cta_enabled );
+		$data['extensions']['facebook-for-woocommerce']['instagram-shopping-enabled'] = wc_bool_to_string( $config ?: $config->ig_shopping_enabled );
+		$data['extensions']['facebook-for-woocommerce']['instagram-cta-enabled']      = wc_bool_to_string( $config ?: $config->ig_cta_enabled );
 
 		/**
 		 * Feed pull / upload settings configured in Facebook UI.


### PR DESCRIPTION
This is based on the comment made by @deltaWhiskey in https://github.com/woocommerce/facebook-for-woocommerce/pull/1972#pullrequestreview-675721128

The name `ig` is not very obvious on its own. In the context of the Facebook plugin it makes more sense but still just spelling out the full name will make things much easier to understand - especially for someone in the future.

This does not require any testing.