### PR TITLE
Add validation to product feed file generation.

### DIFF
--- a/includes/Jobs/GenerateProductFeed.php
+++ b/includes/Jobs/GenerateProductFeed.php
@@ -93,6 +93,10 @@ class GenerateProductFeed extends AbstractChainedJob {
 		$processed_items = array();
 
 		foreach ( $products as $product ) {
+			// Check if product is enabled for synchronization.
+			if ( ! facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_all_checks() ) {
+				continue;
+			}
 			$processed_items[] = $this->process_item( $product, $args );
 		}
 
@@ -105,6 +109,10 @@ class GenerateProductFeed extends AbstractChainedJob {
 	 * @param array $processed_items Array of product fields to write to the feed file.
 	 */
 	protected function write_processed_items_to_feed( $processed_items ) {
+		// Check if we have any items to write.
+		if ( empty( $processed_items ) ) {
+			return;
+		}
 		$this->feed_file_handler->write_to_temp_file(
 			$this->feed_data_exporter->format_items_for_feed( $processed_items )
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Using the new validator class exclude from the feed file the products that should not be synchronized.

Testing instructions:

0. Inspect `wp-content/uploads/facebook_for_woocommerce` folder and remove any product_catalog_hashnumber.csv files.
1. Create a site with products
2. Set some of the products to not sync ( excluded categories, no sync settings ), do that for simple products and variable products with variations ( variations also have no sync setting ).
3. From: Woocommerce -> Status -> Scheduled Actions -> Pending trigger `facebook_for_woocommerce_start_feed_generation`
4. Wait untill the In Progres section of Scheduled Actions has no more facebook_for_woocommerce/jobs/generate_feed/chain_batch` actions - this means that the generation job has finished.
5. Inspect wp-content/uploads/facebook_for_woocommerce and filnd product_catalog_....csv file. Inspect it and check if the products that were disabled in step 2 are not part of the generated file.

### Changelog entry
No changelog entry for this PR.