### PR TITLE
Add/filter to change batch size

### DIFF
--- a/includes/Jobs/GenerateProductFeed.php
+++ b/includes/Jobs/GenerateProductFeed.php
@@ -197,6 +197,10 @@ class GenerateProductFeed extends AbstractChainedJob {
 		 * Feed batch size filter.
 		 *
 		 * This filter allows modification of how many items will be processed in one batch during the feed file generation.
+		 * Increasing the number of items per batch can potentially speed up processing on some of the sites.
+		 * Bigger number means reducing the number of required batches, but at the same time increase the memory requirements for the process.
+		 * Smaller number of items per batch means that the memory requirements are smaller for the process and the stability of the system is better.
+		 * The number of required batches increases and the the total time for processing may be longer.
 		 * Some, especially big sites with big products catalog, may want to increase this value in order to process the catalog faster.
 		 * This requires careful approach, bumping the value too high may lead to out of memory issues.
 		 *
@@ -204,7 +208,7 @@ class GenerateProductFeed extends AbstractChainedJob {
 		 *
 		 * @param int  $batch_size Size of the feed processing batch.
 		 */
-		return apply_filters( 'facebook_for_woocommerce_feed_batch_size', 15 );
+		return apply_filters( 'facebook_for_woocommerce_feed_generation_num_products_per_batch', 15 );
 	}
 
 }

--- a/includes/Jobs/GenerateProductFeed.php
+++ b/includes/Jobs/GenerateProductFeed.php
@@ -193,7 +193,18 @@ class GenerateProductFeed extends AbstractChainedJob {
 	 * @return int
 	 */
 	protected function get_batch_size(): int {
-		return 15;
+		/**
+		 * Feed batch size filter.
+		 *
+		 * This filter allows modification of how many items will be processed in one batch during the feed file generation.
+		 * Some, especially big sites with big products catalog, may want to increase this value in order to process the catalog faster.
+		 * This requires careful approach, bumping the value too high may lead to out of memory issues.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param int  $batch_size Size of the feed processing batch.
+		 */
+		return apply_filters( 'facebook_for_woocommerce_feed_batch_size', 15 );
 	}
 
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add a simple filter that allows modification of the processed batch size during the feed file generation job.
This will allow some of the sites ( if necessary ) to tweak the speed of the feed generation process.

### How to test the changes in this Pull Request:

<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Add a filter function that modifies the size of the batch.
2. Trigger the action that starts the feed file generation.
3. Use PHP debug to check that the batch size is now modified.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
> New - Add filter that allows modification of the feed batch processing size.
<!-- See [previous releases](../../releases) for more examples. -->
