### PR TITLE
Add feed overview link.

### DIFF
--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -139,6 +139,9 @@ class Connection extends Admin\Abstract_Settings_Screen {
 				'value' => facebook_for_woocommerce()->get_integration()->get_product_catalog_id(),
 				'url'   => 'https://facebook.com/products',
 			),
+			'feed'                          => array(
+				'label' => __( 'Feed', 'facebook-for-woocommerce' ),
+			),
 			'business-manager'              => array(
 				'label' => __( 'Business Manager account', 'facebook-for-woocommerce' ),
 				'value' => facebook_for_woocommerce()->get_connection_handler()->get_business_manager_id(),
@@ -157,8 +160,9 @@ class Connection extends Admin\Abstract_Settings_Screen {
 			),
 		);
 
-		// if the catalog ID is set, update the URL and try to get its name for display
-		if ( $catalog_id = $static_items['catalog']['value'] ) {
+		// If the catalog ID is set, update the URL and try to get its name for display.
+		$catalog_id = $static_items['catalog']['value'];
+		if ( '' !== $catalog_id ) {
 
 			$static_items['catalog']['url'] = "https://facebook.com/products/catalogs/{$catalog_id}";
 
@@ -171,6 +175,15 @@ class Connection extends Admin\Abstract_Settings_Screen {
 				}
 			} catch ( Framework\SV_WC_API_Exception $exception ) {
 			}
+		}
+
+		$feed_id = facebook_for_woocommerce()->get_integration()->get_feed_id();
+		if ( '' !== $catalog_id && '' !== $feed_id ) {
+			$static_items['feed']['url']   = "https://www.facebook.com/commerce/catalogs/{$catalog_id}/feeds/{$feed_id}/overview";
+			// translators: Placeholders %s - numerical feed id.
+			$static_items['feed']['value'] = sprintf( __( '%s - Overview', 'facebook-for-woocommerce' ), $feed_id );
+		} else {
+			$static_items['feed']['value'] = __( 'Feed not connected.', 'facebook-for-woocommerce' );
 		}
 
 		?>

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -140,7 +140,7 @@ class Connection extends Admin\Abstract_Settings_Screen {
 				'url'   => 'https://facebook.com/products',
 			),
 			'feed'                          => array(
-				'label' => __( 'Feed', 'facebook-for-woocommerce' ),
+				'label' => __( 'Product Feed', 'facebook-for-woocommerce' ),
 			),
 			'business-manager'              => array(
 				'label' => __( 'Business Manager account', 'facebook-for-woocommerce' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since the feed synchronization will become the main character in the product sync we need to add feed id information to the main section of the plugin settings. We can also generate a handy link to the overview section of the feed.

![image](https://user-images.githubusercontent.com/17271089/121216721-77bacf80-c881-11eb-896e-5f59c8a2f27b.png)

### How to test the changes in this Pull Request:

<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Open plugin settings.
2. If the feed id is stored in the integration a link with the id is provided.
3. If the feed id is not stored information about the feed not being connected is displayed.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
> New - Feed overview link in main Facebook settings area.
<!-- See [previous releases](../../releases) for more examples. -->
