### PR TITLE
Smart feed generation time.

### DIFF
--- a/includes/Feed/FeedConfigurationDetection.php
+++ b/includes/Feed/FeedConfigurationDetection.php
@@ -8,12 +8,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Error;
 use SkyVerge\WooCommerce\Facebook\Utilities\Heartbeat;
-use SkyVerge\WooCommerce\Facebook\Products\Feed;
 
 /**
  * A class responsible detecting feed configuration.
  */
 class FeedConfigurationDetection {
+
+	const TRANSIENT_ACTIVE_FEED_METADATA = 'wc_facebook_for_woocommerce_active_feed_metadata';
 
 	/**
 	 * Constructor.
@@ -97,6 +98,8 @@ class FeedConfigurationDetection {
 			}
 		}
 
+		// Store the active feed meta data to be used by feed generation scheduling algorithm in FeedScheduler.
+		set_transient( self::TRANSIENT_ACTIVE_FEED_METADATA, $active_feed_metadata, DAY_IN_SECONDS );
 		$active_feed['created-time']  = gmdate( 'Y-m-d H:i:s', strtotime( $active_feed_metadata['created_time'] ) );
 		$active_feed['product-count'] = $active_feed_metadata['product_count'];
 
@@ -137,7 +140,7 @@ class FeedConfigurationDetection {
 			// True if the feed upload url (Facebook side) matches the feed endpoint URL and secret.
 			// If it doesn't match, it's likely it's unused.
 			$upload['url-matches-site-endpoint'] = wc_bool_to_string(
-				Feed::get_feed_data_url() === $upload_metadata['url']
+				FeedFileHandler::get_feed_data_url() === $upload_metadata['url']
 			);
 
 			$info['active-feed']['latest-upload'] = $upload;

--- a/includes/Feed/FeedScheduler.php
+++ b/includes/Feed/FeedScheduler.php
@@ -7,6 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use SkyVerge\WooCommerce\Facebook\Utilities\Heartbeat;
+use SkyVerge\WooCommerce\Facebook\Jobs\GenerateProductFeed;
 
 /**
  * A class responsible for setting up feed generation schedule.
@@ -19,7 +20,7 @@ class FeedScheduler {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( Heartbeat::HOURLY, array( $this, 'maybe_schedule_feed_generation' ) );
+		add_action( 'admin_init', array( $this, 'maybe_schedule_feed_generation' ) );
 		add_action( self::FEED_SCHEDULE_ACTION, array( $this, 'prepare_feed_generation' ) );
 	}
 
@@ -29,11 +30,111 @@ class FeedScheduler {
 	 * @since 2.6.0
 	 */
 	public function maybe_schedule_feed_generation() {
-		if ( false !== as_next_scheduled_action( self::FEED_SCHEDULE_ACTION ) ) {
+		$integration = facebook_for_woocommerce()->get_integration();
+		$feed_id     = $integration->get_feed_id();
+		if ( '' === $feed_id ) {
+			// No feed id, no reason to generate the feed file.
 			return;
 		}
-		$timestamp = strtotime( 'today midnight +1 day' );
-		as_schedule_single_action( $timestamp, self::FEED_SCHEDULE_ACTION );
+		if ( false !== as_next_scheduled_action( self::FEED_SCHEDULE_ACTION ) ) {
+			// Feed generation already scheduled.
+			return;
+		}
+
+		// Default start time.
+		$generation_start_time = strtotime( 'today midnight +1 day' );
+
+		// Calculate better time for the next feed generation.
+		$feed_info = get_transient( FeedConfigurationDetection::TRANSIENT_ACTIVE_FEED_METADATA );
+		if ( false !== $feed_info ) {
+			try {
+				$next_fetch = $this->convert_schedule_to_next_execution_timestamp( $feed_info['schedule'] );
+				$time_spent = $this->get_feed_file_generation_wall_time();
+
+				// Calculate the time when we should start the feed file generation to finish before the next upload request.
+				$generation_start_time = $next_fetch - $time_spent;
+
+				if ( $generation_start_time < time() ) {
+					/*
+					 * The generation time is probably too long. Or the site was idle for some time.
+					 * Moving the generation time even further would not make sense.
+					 * In case when the generation time is too long we would not finish generating before the next cycle should start.
+					 * In case when the site was idle the next scheduled feed generation should be OK.
+					 */
+					facebook_for_woocommerce()->log(
+						__( 'Could not schedule feed generation in advance.', 'facebook-for-woocommerce' )
+					);
+				}
+			} catch ( \Throwable $th ) {
+				facebook_for_woocommerce()->log(
+					__( 'Could not calculate better feed schedule time, using default.', 'facebook-for-woocommerce' )
+				);
+				facebook_for_woocommerce()->log( $th->getMessage() );
+			}
+		}
+
+		as_schedule_single_action( $generation_start_time, self::FEED_SCHEDULE_ACTION );
+	}
+
+	/**
+	 * Get feed generation wall time and adjust for fluctuations.
+	 *
+	 * @since x.x.x
+	 * @return int Feed generation wall time in seconds.
+	 */
+	private function get_feed_file_generation_wall_time() {
+		$time_spent = GenerateProductFeed::feed_file_generation_wall_time();
+		if ( 0 === $time_spent ) {
+			// We have no data yet or there is something wrong. Just guess that it will take 1h.
+			$time_spent = HOUR_IN_SECONDS;
+		}
+		// Adjust for uncertainty by 1.5 factor.
+		$time_spent = (int) ( $time_spent * 1.5 );
+
+		return $time_spent;
+	}
+
+	/**
+	 * Given a feed schedule configuration calculate when the next feed fetch will happen.
+	 *
+	 * @since x.x.x
+	 * @param array $schedule Facebook feed schedule.
+	 * @return int Next feed fetch timestamp.
+	 */
+	private function convert_schedule_to_next_execution_timestamp( $schedule ) {
+		switch ( $schedule['interval'] ) {
+			case 'HOURLY':
+				$start    = new \DateTime( "today  +{$schedule['hour']} hours +{$schedule['minute']} minutes", new \DateTimeZone( $schedule['timezone'] ) );
+				$interval = HOUR_IN_SECONDS;
+				break;
+			case 'DAILY':
+				$start    = new \DateTime( "today  +{$schedule['hour']} hours +{$schedule['minute']} minutes", new \DateTimeZone( $schedule['timezone'] ) );
+				$interval = DAY_IN_SECONDS;
+				break;
+			case 'WEEKLY':
+				$start    = new \DateTime( "next {$schedule['day_of_week']} +{$schedule['hour']} hours +{$schedule['minute']} minutes", new \DateTimeZone( $schedule['timezone'] ) );
+				$interval = WEEK_IN_SECONDS;
+				break;
+			default:
+				// We should never get here but in case we did let's just guess.
+				$start    = new \DateTime( 'today' );
+				$interval = HOUR_IN_SECONDS;
+				facebook_for_woocommerce()->log( __( 'Unrecognized schedule interval', 'facebook-for-woocommerce' ) );
+				break;
+		}
+
+		// Check if we are not past the start.
+		$now        = time();
+		$next_fetch = (int) $start->format( 'U' );
+		if ( $next_fetch > $now ) {
+			// The next fetch is in the future we can return.
+			return $next_fetch;
+		}
+
+		// Move to the next scheduled fetch that is past now.
+		$next_fetch += ceil( (float) ( $now - $next_fetch ) / ( $interval * $schedule['interval_count'] ) ) * ( $interval * $schedule['interval_count'] );
+
+		return $next_fetch;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We want to make sure that the feed file generation finishes before Facebook requests the file. This PR modifies feed scheduling in such a way that when Facebook requests the feed file, the feed file should be fresh and ready :)

### How to test the changes in this Pull Request:

<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Set this PR up on a site that has a valid connection and feed schedule in FB settings.
2. Run one full generation of the feed file. Roughly check how much time it took. From start till finish.
3. Cancel the next occurrence of `facebook_for_woocommerce_start_feed_generation` Action Scheduler action.
4. Refresh admin interface. A new `facebook_for_woocommerce_start_feed_generation` will be created. Inspect Schedule date.
5. Confirm that the next feed generation time is scheduled roughly 1.5 * feed generation ( wall ) time before the next feed schedule according to the FB settings.

This PR already takes into consideration that there are other valid feed schedules than `DAILY` even if other parts of the code do not support this.

My example scenario:

![image](https://user-images.githubusercontent.com/17271089/121707025-76ceab80-cad6-11eb-86f1-ee6ca3499625.png)
The next scheduled feed fetch will happen on Wednesday at 13:16 ( UTC + 2 ).

![image](https://user-images.githubusercontent.com/17271089/121707090-85b55e00-cad6-11eb-89d2-3728b9b4c4b5.png)
The next feed generation is planned for Wednesday at 10:59 ( UTC + 0 ).

This means that the feed file generation will be started roughly 15 minutes before the next feed fetch. My feed generates in roughly 10 minutes.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
> New - Smart feed generation scheduling.
<!-- See [previous releases](../../releases) for more examples. -->
