### PR TITLE
Product should sync filter.

### DIFF
--- a/includes/Jobs/GenerateProductFeed.php
+++ b/includes/Jobs/GenerateProductFeed.php
@@ -94,9 +94,19 @@ class GenerateProductFeed extends AbstractChainedJob {
 
 		foreach ( $products as $product ) {
 			// Check if product is enabled for synchronization.
-			if ( ! facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_all_checks() ) {
+			$product_is_valid_for_feed_sync = facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_all_checks();
+
+			/**
+			 * Should product bee included in sync filter.
+			 *
+			 * @since x.x.x
+			 * @param bool $product_is_valid_for_feed_sync Is product valid for sync based on the default set of rules.
+			 * @param WC_Product @product Product being filtered.
+			 */
+			if ( ! apply_filters( 'wc_facebook_product_is_valid_for_feed_sync', $product_is_valid_for_feed_sync, $product ) ) {
 				continue;
 			}
+
 			$processed_items[] = $this->process_item( $product, $args );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add a filter that allows filtering if the product should be included in the feed file or not.

Closes #2003  .

### How to test the changes in this Pull Request:

<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create and add filter function for `wc_facebook_product_is_valid_for_feed_sync` filter name.
2. Check if in the generated feed this filters the products according to the filter function.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
* New - Feed file product sync filter hook.
<!-- See [previous releases](../../releases) for more examples. -->
