### PR TITLE
Try/feed status UI prototype

### DIFF
--- a/assets/css/facebook.css
+++ b/assets/css/facebook.css
@@ -306,3 +306,8 @@
 	vertical-align: middle !important;
 	line-height: 28px !important;
 }
+
+.facebook-for-woocommerce-status-item .dashicons {
+	position: relative;
+	top:  -1px;
+}

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -45,6 +45,8 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 
 		add_action( 'woocommerce_admin_field_product_sync_title', array( $this, 'render_title' ) );
+		add_action( 'woocommerce_admin_field_facebook_for_woocommerce_status_item', array( $this, 'render_status_item' ) );
+
 
 		add_action( 'woocommerce_admin_field_product_sync_google_product_categories', array( $this, 'render_google_product_category_field' ) );
 	}
@@ -197,6 +199,41 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 		<?php
 	}
 
+	/**
+	 * Renders a custom status / info text item.
+	 *
+	 * @internal
+	 *
+	 * @since x.x.x
+	 *
+	 * @param array $field field data
+	 */
+	public function render_status_item( $field ) {
+		$label     = array_key_exists('label', $field ) ? $field['label'] : '';
+		$text      = array_key_exists('text', $field ) ? $field['text'] : '';
+		$help_tip  = array_key_exists('help_tip', $field ) ? $field['help_tip'] : '';
+		// $icon      = array_key_exists('icon', $field ) ? $field['icon'] : '';
+		$info_text = array_key_exists('info_text', $field ) ? $field['info_text'] : '';
+
+		?>
+			<tr>
+				<th scope="row" class="titledesc">
+					<label for=""><?php esc_html_e( $label ) ?>
+						<?php if ( ! empty( $help_tip ) ) : ?>
+					 		<span class="woocommerce-help-tip" data-tip="<?php esc_attr_e( $help_tip ) ?>"></span>
+						<?php endif; ?>
+					 </label>
+				</th>
+				<td class="">
+					<?php echo esc_html( $text ) ?>
+					<?php if ( ! empty( $info_text ) ) : ?>
+				 		<span class="facebook-for-woocommerce-feed-info-text" style="font-size: smaller;"> • <?php esc_html_e( $info_text ) ?></span>
+					<?php endif; ?>
+				</td>
+			</tr>
+		<?php
+	}
+
 
 	/**
 	 * Saves the Product Sync settings.
@@ -247,6 +284,43 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 		);
 	}
 
+	/**
+	 * Define settings UI for product feed (data source) sync.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return array
+	 */
+	public function get_product_feed_settings() {
+		return array(
+			array(
+				'type'  => 'title',
+				'title' => __( 'Product feed', 'facebook-for-woocommerce' ),
+			),
+			array(
+				'type'      => 'facebook_for_woocommerce_status_item',
+				'label'     => __( 'Data source', 'facebook-for-woocommerce' ),
+				'help_tip'  => __( 'docs / help', 'facebook-for-woocommerce' ),
+				'text'      => __( 'Data source configured', 'facebook-for-woocommerce' ),
+				'info_text' => __( 'Is totally set up and legit AF', 'facebook-for-woocommerce' ),
+			),
+			array(
+				'type'      => 'facebook_for_woocommerce_status_item',
+				'label'     => __( 'Feed file', 'facebook-for-woocommerce' ),
+				'help_tip'  => __( 'docs / help', 'facebook-for-woocommerce' ),
+				'text'      => __( 'CSV file generated', 'facebook-for-woocommerce' ),
+				'info_text' => __( 'Last updated 8 June 2021 1:12 am, containing 125 products', 'facebook-for-woocommerce' ),
+			),
+			array(
+				'type'      => 'facebook_for_woocommerce_status_item',
+				'label'     => __( 'Sync with Facebook', 'facebook-for-woocommerce' ),
+				'help_tip'  => __( 'docs / help', 'facebook-for-woocommerce' ),
+				'text'      => __( 'Sync successful', 'facebook-for-woocommerce' ),
+				'info_text' => __( 'Last sync 9 June 2021 4:41 am, containing 125 products', 'facebook-for-woocommerce' ),
+			),
+			array( 'type' => 'sectionend' ),
+		);
+	}
 
 	/**
 	 * Gets the screen settings.
@@ -278,7 +352,7 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 
 		$product_tags = $term_query->get_terms();
 
-		return array(
+		$sync_settings = array(
 
 			array(
 				'type'  => 'product_sync_title',
@@ -341,6 +415,12 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 			),
 			array( 'type' => 'sectionend' ),
 
+
+		);
+
+		return array_merge(
+			$sync_settings,
+			$this->get_product_feed_settings(),
 		);
 	}
 

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -206,17 +206,37 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 	 *
 	 * @since x.x.x
 	 *
-	 * @param array $field field data
+	 * @param array $field field data TBD list all required and available fields
 	 */
 	public function render_status_item( $field ) {
 		$label     = array_key_exists('label', $field ) ? $field['label'] : '';
 		$text      = array_key_exists('text', $field ) ? $field['text'] : '';
 		$help_tip  = array_key_exists('help_tip', $field ) ? $field['help_tip'] : '';
-		// $icon      = array_key_exists('icon', $field ) ? $field['icon'] : '';
+		$status    = array_key_exists('status', $field ) ? $field['status'] : '';
 		$info_text = array_key_exists('info_text', $field ) ? $field['info_text'] : '';
 
+		$link_label       = array_key_exists('link_label', $field ) ? $field['link_label'] : '';
+		$link_url         = array_key_exists('link_url', $field ) ? $field['link_url'] : '';
+		$link_is_external = array_key_exists('link_is_external', $field ) ? $field['link_is_external'] : false;
+
+		$clipboard_label = array_key_exists('clipboard_label', $field ) ? $field['clipboard_label'] : '';
+		$clipboard_text  = array_key_exists('clipboard_text', $field ) ? $field['clipboard_text'] : '';
+
+		$status_color = '';
+		$status_icon = '';
+		if ( $status === 'success' ) {
+			$status_icon = '<span class="dashicons dashicons-yes-alt"></span>';
+			$status_color = 'green';
+		} else if ( $status === 'warning' ) {
+			$status_icon = '<span class="dashicons dashicons-warning"></span>';
+			$status_color = 'orange';
+		} else if ( $status === 'error' ) {
+			$status_icon = '<span class="dashicons dashicons-dismiss"></span>';
+			$status_color = 'red';
+		}
+
 		?>
-			<tr>
+			<tr class='facebook-for-woocommerce-status-item'>
 				<th scope="row" class="titledesc">
 					<label for=""><?php esc_html_e( $label ) ?>
 						<?php if ( ! empty( $help_tip ) ) : ?>
@@ -225,9 +245,24 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 					 </label>
 				</th>
 				<td class="">
-					<?php echo esc_html( $text ) ?>
+					<span class="facebook-for-woocommerce-feed-text" style="font-weight: 600; color: <?php esc_attr_e( $status_color ) ?>">
+						<?php echo $status_icon ?>
+						<?php echo esc_html( $text ) ?>
+					</span>
+					<?php if ( ! empty( $link_label ) && ! empty( $link_url ) ) : ?>
+				 		 • <a class=""
+				 			href="<?php esc_attr_e( $link_url ) ?>" style="font-size: smaller;">
+				 			    <?php esc_html_e( $link_label ) ?></a>
+			 				<?php if ( $link_is_external ) {
+			 					echo '<span style="color: #2271b1" class="dashicons dashicons-external"></span>';
+			 				} ?>
+					<?php endif; ?>
 					<?php if ( ! empty( $info_text ) ) : ?>
 				 		<span class="facebook-for-woocommerce-feed-info-text" style="font-size: smaller;"> • <?php esc_html_e( $info_text ) ?></span>
+					<?php endif; ?>
+					<?php if ( ! empty( $clipboard_label ) && ! empty( $clipboard_text ) ) : ?>
+				 		 • <a class="facebook-for-woocommerce-copy-to-clipboard"
+				 			data-clipboard-text="<?php esc_attr_e( $clipboard_text ) ?>" style="font-size: smaller;"><?php esc_html_e( $clipboard_label ) ?></a>
 					<?php endif; ?>
 				</td>
 			</tr>
@@ -298,25 +333,32 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 				'title' => __( 'Product feed', 'facebook-for-woocommerce' ),
 			),
 			array(
-				'type'      => 'facebook_for_woocommerce_status_item',
-				'label'     => __( 'Data source', 'facebook-for-woocommerce' ),
-				'help_tip'  => __( 'docs / help', 'facebook-for-woocommerce' ),
-				'text'      => __( 'Data source configured', 'facebook-for-woocommerce' ),
-				'info_text' => __( 'Is totally set up and legit AF', 'facebook-for-woocommerce' ),
+				'type'             => 'facebook_for_woocommerce_status_item',
+				'label'            => __( 'Facebook data source', 'facebook-for-woocommerce' ),
+				'status'           => 'success',
+				'help_tip'         => __( 'docs / help', 'facebook-for-woocommerce' ),
+				'text'             => __( 'Data source configured', 'facebook-for-woocommerce' ),
+				'link_label'       => __( 'ID 987458740587', 'facebook-for-woocommerce' ),
+				'link_url'         => __( 'http://business.facebook.com/myshop?feed=987458740587', 'facebook-for-woocommerce' ),
+				'link_is_external' => true,
 			),
 			array(
-				'type'      => 'facebook_for_woocommerce_status_item',
-				'label'     => __( 'Feed file', 'facebook-for-woocommerce' ),
-				'help_tip'  => __( 'docs / help', 'facebook-for-woocommerce' ),
-				'text'      => __( 'CSV file generated', 'facebook-for-woocommerce' ),
-				'info_text' => __( 'Last updated 8 June 2021 1:12 am, containing 125 products', 'facebook-for-woocommerce' ),
+				'type'              => 'facebook_for_woocommerce_status_item',
+				'label'             => __( 'Feed file', 'facebook-for-woocommerce' ),
+				'help_tip'          => __( 'docs / help', 'facebook-for-woocommerce' ),
+				'status'            => 'success',
+				'clipboard_label'   => __( 'Copy feed URL', 'facebook-for-woocommerce' ),
+				'clipboard_content' => __( 'http://arealfeedurl.com/feed?secret=1235', 'facebook-for-woocommerce' ),
+				'text'              => __( 'CSV file generated', 'facebook-for-woocommerce' ),
+				'info_text'         => __( 'Completed 9 June 2021 3:12 am, containing 125 items', 'facebook-for-woocommerce' ),
 			),
 			array(
 				'type'      => 'facebook_for_woocommerce_status_item',
 				'label'     => __( 'Sync with Facebook', 'facebook-for-woocommerce' ),
+				'status'    => 'success',
 				'help_tip'  => __( 'docs / help', 'facebook-for-woocommerce' ),
 				'text'      => __( 'Sync successful', 'facebook-for-woocommerce' ),
-				'info_text' => __( 'Last sync 9 June 2021 4:41 am, containing 125 products', 'facebook-for-woocommerce' ),
+				'info_text' => __( 'Last sync 9 June 2021 4:41 am, 125 products persisted', 'facebook-for-woocommerce' ),
 			),
 			array( 'type' => 'sectionend' ),
 		);


### PR DESCRIPTION
Related to #2007

### Changes proposed in this Pull Request:

This PR is a prototype UI for showing the status of the product feed (data source) and potentially guiding merchant to set it up. It's not intended to ship as is – is a starting point for deciding what minimal UI we need in 2.7. 

- A new section is added to the `Marketing > Facebook > Product sync` tab. Feed UI / info should be on this tab as it's part of syncing products (should not be a separate tab).
- In this section, there are three items, for 3 aspects of the feed:
  - If it is configured and set up (correctly).
  - The status of generating the feed file.
  - The status of the sync, i.e. if it's been pulled ("uploaded") to Facebook, and any errors.

I've prototyped a mini "component" (in PHP - see `render_status_item()`) to generically prototype all these and give us some flexibility. Note this is not completely implemented (no copy to clipboard etc), just a sketch to help prototype.

<img width="762" alt="component" src="https://user-images.githubusercontent.com/4167300/121833500-9822d800-cd20-11eb-9fb2-4ebccbe548d8.png">

The component has the following params, most are optional:

- `label` The main heading label on the left.
- `text` The primary text status / info label (on the right).
- `status` An optional status (`success error warning`) to add colour and an icon.
- `help_tip` Tooltip for the help icon button.
- Inline link - e.g. for linking to help or to Facebook business settings (or elsewhere in Woo admin).
  - `link_label` Link label text.
  - `link_url` Link destination URL. 
  - `link_is_external` Specify `true` to show the "external" icon.
- Clipboard link - e.g. for copying the feed URL so you can configure a data source in Facebook (minimal setup UI).
  - `clipboard_label` Label / prompt.
  - `clipboard_content` Text to copy to clipboard.

### Feed status prototypes
<img width="880" alt="set up + mostly working" src="https://user-images.githubusercontent.com/4167300/121833531-abce3e80-cd20-11eb-8a75-6ba6e82065b5.png">
<img width="880" alt="not set up + partially generated" src="https://user-images.githubusercontent.com/4167300/121833534-ad980200-cd20-11eb-9579-193063db0502.png">
<img width="869" alt="totally set up and working" src="https://user-images.githubusercontent.com/4167300/121833535-ae309880-cd20-11eb-94a4-7aff0443e567.png">


### How to test the changes in this Pull Request:
_tbc_

### Changelog entry
_tbc_

<!-- Add suggested changelog entry here. For example: -->
> Fix / Dev / New - Remove duplicate visibility meta entries from postmeta table
<!-- See [previous releases](../../releases) for more examples. -->
