### PR TITLE
Fix #2018 - Correct Content IDs in Purchase event

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -889,8 +889,13 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			foreach ( $order->get_items() as $item ) {
 
-				if ( $product = isset( $item['product_id'] ) ? wc_get_product( $item['product_id'] ) : null ) {
-
+				$product = null;
+				if ( isset( $item['variation_id'] ) ) {
+					$product = wc_get_product( $item['variation_id'] );
+				} else if ( isset( $item['product_id'] ) ) {
+					$product = wc_get_product( $item['product_id'] );
+				}
+				if ( $product ) {
 					$product_ids[]   = \WC_Facebookcommerce_Utils::get_fb_content_ids( $product );
 					$product_names[] = $product->get_name();
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -889,12 +889,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			foreach ( $order->get_items() as $item ) {
 
-				$product = null;
-				if ( isset( $item['variation_id'] ) ) {
-					$product = wc_get_product( $item['variation_id'] );
-				} else if ( isset( $item['product_id'] ) ) {
-					$product = wc_get_product( $item['product_id'] );
-				}
+				$product = $item->get_product();
+				
 				if ( $product ) {
 					$product_ids[]   = \WC_Facebookcommerce_Utils::get_fb_content_ids( $product );
 					$product_names[] = $product->get_name();


### PR DESCRIPTION
### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Fixes mismatch of Content IDs between events. Use `get_product()` on order item which applies the logic - if `variation_id` is set then prefer that over `product_id` in order to get the relevant product. That ends up producing the same Content IDs as earlier events in the purchase. It works the same as before for simple products as `variation_id` is not set on the order item.

Closes #2018.

### How to test the changes in this Pull Request:

As per Steps to Reproduce in #2018.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
> Fix - Correct Content IDs in Purchase event for variable products
<!-- See [previous releases](../../releases) for more examples. -->
