### PR TITLE
Ignore `phpcs` in files where there are existing errors

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,13 @@
-### Changes proposed in this Pull Request:
+Fixes # 
 
+- [ ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.
+
+### Changes proposed in this Pull Request:
 <!-- Describe the changes made to this Pull Request and the reason for such changes. -->
 
-Closes # .
 
 ### How to test the changes in this Pull Request:
-
 <!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
-
 1.
 2.
 3.

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -61,7 +61,7 @@ jobs:
         run: phpcs -i
 
       - name: Run PHPCS on all files
-        run: npm run lint:php:pr | cs2pr
+        run: npm run lint:php:pr --silent | cs2pr
 
       - name: Run PHPCS with PHP 5.2 on plugin loader file
         run: phpcs facebook-for-woocommerce.php --runtime-set testVersion 5.2 -q -n --report=checkstyle

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -61,7 +61,7 @@ jobs:
         run: phpcs -i
 
       - name: Run PHPCS on all files
-        run: phpcs . -q -n --report=checkstyle | cs2pr
+        run: npm run lint:php:pr | cs2pr
 
       - name: Run PHPCS with PHP 5.2 on plugin loader file
         run: phpcs facebook-for-woocommerce.php --runtime-set testVersion 5.2 -q -n --report=checkstyle

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/facebook-commerce-messenger-chat.php
+++ b/facebook-commerce-messenger-chat.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/facebook-config-warmer.php
+++ b/facebook-config-warmer.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API.php
+++ b/includes/API.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Catalog/Product_Group/Products/Read/Request.php
+++ b/includes/API/Catalog/Product_Group/Products/Read/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Catalog/Product_Group/Products/Read/Response.php
+++ b/includes/API/Catalog/Product_Group/Products/Read/Response.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Catalog/Product_Item/Find/Request.php
+++ b/includes/API/Catalog/Product_Item/Find/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Catalog/Product_Item/Response.php
+++ b/includes/API/Catalog/Product_Item/Response.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Catalog/Request.php
+++ b/includes/API/Catalog/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Catalog/Response.php
+++ b/includes/API/Catalog/Response.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Catalog/Send_Item_Updates/Response.php
+++ b/includes/API/Catalog/Send_Item_Updates/Response.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Exceptions/Request_Limit_Reached.php
+++ b/includes/API/Exceptions/Request_Limit_Reached.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/FBE/Configuration/Messenger.php
+++ b/includes/API/FBE/Configuration/Messenger.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/FBE/Configuration/Read/Response.php
+++ b/includes/API/FBE/Configuration/Read/Response.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/FBE/Configuration/Request.php
+++ b/includes/API/FBE/Configuration/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/FBE/Configuration/Update/Request.php
+++ b/includes/API/FBE/Configuration/Update/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/FBE/Installation/Read/Request.php
+++ b/includes/API/FBE/Installation/Read/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/FBE/Installation/Read/Response.php
+++ b/includes/API/FBE/Installation/Read/Response.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/FBE/Installation/Request.php
+++ b/includes/API/FBE/Installation/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Orders/Abstract_Request.php
+++ b/includes/API/Orders/Abstract_Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Orders/Acknowledge/Request.php
+++ b/includes/API/Orders/Acknowledge/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Orders/Cancel/Request.php
+++ b/includes/API/Orders/Cancel/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Orders/Fulfillment/Request.php
+++ b/includes/API/Orders/Fulfillment/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Orders/Order.php
+++ b/includes/API/Orders/Order.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Orders/Read/Request.php
+++ b/includes/API/Orders/Read/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Orders/Read/Response.php
+++ b/includes/API/Orders/Read/Response.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Orders/Refund/Request.php
+++ b/includes/API/Orders/Refund/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Orders/Request.php
+++ b/includes/API/Orders/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Orders/Response.php
+++ b/includes/API/Orders/Response.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Pages/Read/Request.php
+++ b/includes/API/Pages/Read/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Pages/Read/Response.php
+++ b/includes/API/Pages/Read/Response.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Pixel/Events/Request.php
+++ b/includes/API/Pixel/Events/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Response.php
+++ b/includes/API/Response.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Traits/Idempotent_Request.php
+++ b/includes/API/Traits/Idempotent_Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Traits/Paginated_Response.php
+++ b/includes/API/Traits/Paginated_Response.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Traits/Rate_Limited_API.php
+++ b/includes/API/Traits/Rate_Limited_API.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Traits/Rate_Limited_Request.php
+++ b/includes/API/Traits/Rate_Limited_Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/Traits/Rate_Limited_Response.php
+++ b/includes/API/Traits/Rate_Limited_Response.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/User/Permissions/Delete/Request.php
+++ b/includes/API/User/Permissions/Delete/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/User/Request.php
+++ b/includes/API/User/Request.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/API/User/Response.php
+++ b/includes/API/User/Response.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Admin/Google_Product_Category_Field.php
+++ b/includes/Admin/Google_Product_Category_Field.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Admin/Product_Sets.php
+++ b/includes/Admin/Product_Sets.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Admin/Settings_Screens/Advertise.php
+++ b/includes/Admin/Settings_Screens/Advertise.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Admin/Settings_Screens/Messenger.php
+++ b/includes/Admin/Settings_Screens/Messenger.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Admin/Settings_Screens/Product_Sets.php
+++ b/includes/Admin/Settings_Screens/Product_Sets.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Commerce.php
+++ b/includes/Commerce.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Debug/ProfilingLogger.php
+++ b/includes/Debug/ProfilingLogger.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 
 namespace SkyVerge\WooCommerce\Facebook\Debug;
 

--- a/includes/Debug/ProfilingLoggerProcess.php
+++ b/includes/Debug/ProfilingLoggerProcess.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 
 namespace SkyVerge\WooCommerce\Facebook\Debug;
 

--- a/includes/Events/AAMSettings.php
+++ b/includes/Events/AAMSettings.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Events/Normalizer.php
+++ b/includes/Events/Normalizer.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Exceptions/ConnectWCAPIException.php
+++ b/includes/Exceptions/ConnectWCAPIException.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 
 namespace SkyVerge\WooCommerce\Facebook\API\Exceptions;
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Handlers/WebHook.php
+++ b/includes/Handlers/WebHook.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Integrations/Bookings.php
+++ b/includes/Integrations/Bookings.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Integrations/Integrations.php
+++ b/includes/Integrations/Integrations.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Jobs/AbstractChainedJob.php
+++ b/includes/Jobs/AbstractChainedJob.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 
 namespace SkyVerge\WooCommerce\Facebook\Jobs;
 

--- a/includes/Jobs/GenerateProductFeed.php
+++ b/includes/Jobs/GenerateProductFeed.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 
 namespace SkyVerge\WooCommerce\Facebook\Jobs;
 

--- a/includes/Jobs/JobRegistry.php
+++ b/includes/Jobs/JobRegistry.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 
 namespace SkyVerge\WooCommerce\Facebook\Jobs;
 

--- a/includes/Jobs/LoggingTrait.php
+++ b/includes/Jobs/LoggingTrait.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 
 namespace SkyVerge\WooCommerce\Facebook\Jobs;
 

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Locale.php
+++ b/includes/Locale.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Product_Categories.php
+++ b/includes/Product_Categories.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Products/FBCategories.php
+++ b/includes/Products/FBCategories.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Products/Stock.php
+++ b/includes/Products/Stock.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Utilities/Background_Handle_Virtual_Products_Variations.php
+++ b/includes/Utilities/Background_Handle_Virtual_Products_Variations.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
+++ b/includes/Utilities/Background_Remove_Duplicate_Visibility_Meta.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Utilities/Heartbeat.php
+++ b/includes/Utilities/Heartbeat.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 
 namespace SkyVerge\WooCommerce\Facebook\Utilities;
 

--- a/includes/Utilities/Shipment.php
+++ b/includes/Utilities/Shipment.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -127,8 +126,8 @@ class Tracker {
 		 * @since 2.6.0
 		 */
 		$config = get_transient( self::TRANSIENT_WCTRACKER_FBE_BUSINESS_CONFIG );
-		$data['extensions']['facebook-for-woocommerce']['instagram-shopping-enabled'] = wc_bool_to_string( $config ?: $config->ig_shopping_enabled );
-		$data['extensions']['facebook-for-woocommerce']['instagram-cta-enabled']      = wc_bool_to_string( $config ?: $config->ig_cta_enabled );
+		$data['extensions']['facebook-for-woocommerce']['instagram-shopping-enabled'] = wc_bool_to_string( $config ? $config->ig_shopping_enabled : false );
+		$data['extensions']['facebook-for-woocommerce']['instagram-cta-enabled']      = wc_bool_to_string( $config ? $config->ig_cta_enabled : false );
 
 		/**
 		 * Feed pull / upload settings configured in Facebook UI.
@@ -141,10 +140,11 @@ class Tracker {
 	}
 
 	/**
-	 * Update transient with feed file generation time (in seconds).
+	 * Update transient with feed file generation time.
 	 *
 	 * Note this is used to clear the transient (set to -1) to track feed generation failure.
 	 *
+	 * @param float $time_in_seconds Time taken to generate feed file (in seconds).
 	 * @since 2.6.0
 	 */
 	public function track_feed_file_generation_time( $time_in_seconds ) {
@@ -173,8 +173,8 @@ class Tracker {
 		bool $ig_cta_enabled
 	) {
 		$transient = array(
-			'ig_shopping_enabled'   => $ig_shopping_enabled,
-			'ig_cta_enabled'        => $ig_cta_enabled,
+			'ig_shopping_enabled' => $ig_shopping_enabled,
+			'ig_cta_enabled'      => $ig_cta_enabled,
 		);
 		set_transient( self::TRANSIENT_WCTRACKER_FBE_BUSINESS_CONFIG, $transient, self::TRANSIENT_WCTRACKER_LIFE_TIME );
 	}

--- a/includes/fbasync.php
+++ b/includes/fbasync.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/fbbackground.php
+++ b/includes/fbbackground.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/fbgraph.php
+++ b/includes/fbgraph.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/fbinfobanner.php
+++ b/includes/fbinfobanner.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/test/facebook-integration-test.php
+++ b/includes/test/facebook-integration-test.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/includes/test/fbproductfeed-test.php
+++ b/includes/test/fbproductfeed-test.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "generate:category_attribute_json": "php bin/GenerateCategoryAttributeMapping.php",
     "lint:php": "vendor/bin/phpcs . --extensions=php -p -s --colors ",
+    "lint:php:pr": "vendor/bin/phpcs . --extensions=php --warning-severity=0 --report=checkstyle ",
     "lint:php:summary": "vendor/bin/phpcs . --extensions=php --colors --report=summary",
     "build:assets": "NODE_ENV=production wp-scripts build",
     "start": "wp-scripts start",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "scripts": {
     "generate:category_attribute_json": "php bin/GenerateCategoryAttributeMapping.php",
-    "lint:php": "vendor/bin/phpcs . -p -s --colors ",
+    "lint:php": "vendor/bin/phpcs . --extensions=php -p -s --colors ",
+    "lint:php:summary": "vendor/bin/phpcs . --extensions=php --colors --report=summary",
     "build:assets": "NODE_ENV=production wp-scripts build",
     "start": "wp-scripts start",
     "deploy:sake": "npm run build:assets && npx sake deploy --deployAssets=0",


### PR DESCRIPTION
Closes #1931

### Changes proposed in this Pull Request:

This PR adds `// phpcs:ignoreFile` to all files that have existing phpcs issues. This gives us a clean phpcs result on open PRs, and allows us iteratively improve phpcs coverage by removing the comments on files we touch in new PRs.

Currently this is the majority of files (😬).

To encourage improving phpcs coverage over time, I've added a prompt to the PR template to uncomment and fix issues in any files touched by the PR. This PR includes fixes for one tribute file as an example - `Tracker.php`.

### How to test the changes in this Pull Request:
- Notice that this PR is passing automated checks! 🎉 
- Try opening a new PR off this branch, add some bad PHP in an un-ignored file. Confirm that the PR check highlights your issues.
- Open another PR. Uncomment `phpcs:ignoreFile` in a file of your choosing, and fix the phpcs issues.

Looking for more of these!

<img width="963" alt="Screen Shot 2021-06-21 at 4 02 21 PM" src="https://user-images.githubusercontent.com/4167300/122705548-172c8900-d2aa-11eb-9719-dee59e61985a.png">


### Changelog entry

No changelog needed - this doesn't impact users or change behaviour.