### PR TITLE
Use Feed Sync for initial products sync

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -414,7 +414,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		}
 
 		// Must be outside of admin for cron to schedule correctly.
-		add_action( 'sync_all_fb_products_using_feed', array( $this, 'handle_scheduled_resync_action' ), self::FB_PRIORITY_MID );
+		add_action( self::ACTION_HOOK_SCHEDULED_RESYNC, array( $this, 'handle_scheduled_resync_action' ), self::FB_PRIORITY_MID );
 
 		// Handle the special background feed generation action.
 		add_action( 'wc_facebook_generate_product_catalog_feed', array( $this, 'handle_generate_product_catalog_feed' ) );

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -167,7 +167,7 @@ class Connection {
 				}
 			}
 		} catch ( SV_WC_API_Exception $exception ) {
-			
+
 			$this->get_plugin()->log( 'Could not refresh business configuration. ' . $exception->getMessage() );
 		}
 
@@ -301,7 +301,9 @@ class Connection {
 			$this->update_system_user_id( $system_user_id );
 			$this->update_installation_data();
 
-			facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
+			// We want to schedule the feed generation and feed sync.
+			facebook_for_woocommerce()->get_product_feed_handler()->schedule_feed_generation();
+			facebook_for_woocommerce()->get_product_feed_handler()->shedule_feed_sync();
 
 			update_option( 'wc_facebook_has_connected_fbe_2', 'yes' );
 			update_option( 'wc_facebook_has_authorized_pages_read_engagement', 'yes' );
@@ -1187,15 +1189,15 @@ class Connection {
 
 			$this->get_plugin()->log( 'Wrong (or empty) WebHook Event received' );
 			$this->get_plugin()->log( print_r( $data, true ) ); //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
-			
+
 			return;
 		}
 
 		$log_data = array();
-		
+
 		$this->get_plugin()->log( 'WebHook User Event received' );
 		$this->get_plugin()->log( print_r( $data, true ) ); //phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
-		
+
 
 		$entry = (array) $data->entry[0];
 		if ( empty( $entry ) ) {

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -188,6 +188,33 @@ class Feed {
 		}
 	}
 
+	/**
+	 * Schedules the feed sync, once the feed us synced. this task will be unschedule.
+	 *
+	 * @internal
+	 * @since 2.6.1
+	 */
+	public function shedule_feed_sync() {
+		if ( ! $this->can_schedule_feed_jobs() ) {
+			$this->unschedule_feed_sync();
+
+			return;
+		}
+
+		$interval = $this->get_feed_generation_interval();
+		if ( ! as_next_scheduled_action( self::SYNC_FEED_ACTION ) ) {
+			// We'll give an hour for the feed to generate
+			as_schedule_single_action( strtotime( '+1 hour' ), self::SYNC_FEED_ACTION, array(), facebook_for_woocommerce()->get_id_dasherized() );
+		}
+	}
+
+	/**
+	 * Unschedule the feed sync.
+	 * @since 2.6.1
+	 */
+	private function unschedule_feed_sync() {
+		as_unschedule_all_actions( self::SYNC_FEED_ACTION );
+	}
 
 	/**
 	 * Checks whether fpassthru has been disabled in PHP.

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -34,6 +34,8 @@ class Feed {
 	/** @var string the WordPress option name where the secret included in the feed URL is stored */
 	const OPTION_FEED_URL_SECRET = 'wc_facebook_feed_url_secret';
 
+	/** @var string The action name for that triggers the feed sync */
+	const SYNC_FEED_ACTION = 'facebook_for_woocommerce_sync_feed';
 
 	/**
 	 * Feed constructor.

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -255,4 +255,41 @@ class Feed {
 	}
 
 
+
+	/**
+	 * If connection is configured, product sync enabled and legacy file generated,
+	 * we can allow the jobs in this class to be scheduled.
+	 *
+	 * @return bool
+	 * @since 2.6.1
+	 */
+	private function can_schedule_feed_jobs() {
+		$integration   = facebook_for_woocommerce()->get_integration();
+		$configured_ok = $integration && $integration->is_configured();
+
+		// Only schedule feed job if store has not opted out of product sync.
+		$store_allows_sync = $configured_ok && $integration->is_product_sync_enabled();
+		// Only schedule if has not opted out of feed generation (e.g. large stores).
+		$store_allows_feed = $configured_ok && $integration->is_legacy_feed_file_generation_enabled();
+
+		return ( $store_allows_sync && $store_allows_feed );
+	}
+
+	/**
+	 * Gets the feed generation interval.
+	 *
+	 * @return integer
+	 */
+	public function get_feed_generation_interval() {
+		/**
+		 * Filters the frequency with which the product feed data is generated.
+		 *
+		 * @param int $interval the frequency with which the product feed data is generated, in seconds. Defaults to every 15 minutes.
+		 *
+		 * @since 2.5.0 Feed generation interval increased to 24h.
+		 *
+		 * @since 1.11.0
+		 */
+		return apply_filters( 'wc_facebook_feed_generation_interval', DAY_IN_SECONDS );
+	}
 }

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -756,7 +756,7 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 		}
 
 
-		private function create_feed() {
+		public function create_feed() {
 			$result = $this->fbgraph->create_feed(
 				$this->facebook_catalog_id,
 				array( 'name' => self::FEED_NAME )
@@ -776,7 +776,7 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 			return $feed_id;
 		}
 
-		private function create_upload( $facebook_feed_id ) {
+		public function create_upload( $facebook_feed_id ) {
 			$result = $this->fbgraph->create_upload(
 				$facebook_feed_id,
 				$this->get_file_path()


### PR DESCRIPTION
Fixes #2025 .

### Changes proposed in this Pull Request:
This PR switches from batch sync to feed sync after the site is connected to FB. The approach is to schedule a recurring task that will validate if the feed file is generated, once is generated the feed will be pushed to FB and after this the recurring task will be removed.

<img width="1020" alt="Screen Shot 2021-06-22 at 14 33 29" src="https://user-images.githubusercontent.com/532402/122995456-dfcfe200-d366-11eb-86f7-1bb97be6a40a.png">


### How to test the changes in this Pull Request:

<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. If you're site is already connected, disconnect and connect again with FB.
2. From WP admin visit *Action Scheduler Actions*
3. Two actions should be scheduled `wc_facebook_regenerate_feed ` and `facebook_for_woocommerce_sync_feed`
4. Feel free to manually run `wc_facebook_regenerate_feed` for the feed to be generated (if you already have a feed, you can skip this step)
5. Once the feed file is completed, you can wait for `facebook_for_woocommerce_sync_feed` to be executed or run it manually
6. Wait for the action to finish
7. Validate via DB that there's a `wc_facebook_feed_id` (`SELECT * FROM `wp_options` WHERE option_name = 'wc_facebook_feed_id'`)
8. Now go to FB and confirm that the _Data Source_ exists (see screenshot)
9. Also confirm that `facebook_for_woocommerce_sync_feed` action is not scheduled
10. Bonus points. Manually set `wc_facebook_feed_id` option to test that the feed is not synced multiple times

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
> Dev - Use Feed sync for initial products sync
<!-- See [previous releases](../../releases) for more examples. -->
