### PR TITLE
Add hook to allow disable of full batch api sync (e.g. for large stores) to avoid potential performance issues

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,8 +1,7 @@
 *** Facebook for WooCommerce Changelog ***
 
 2021-xx-xx - version 2.6.1
- * Fix: Prevent full catalog sync (using Batch API) for larger stores to avoid performance issues
- * Dev: Add facebook_for_woocommerce_allow_full_batch_api_sync filter to allow external developers to disable or enable full batch API sync
+ * Dev: Add `facebook_for_woocommerce_allow_full_batch_api_sync` filter to allow opt-out full batch API sync, to avoid possible performance issues on large sites
 
 2021-06-10 - version 2.6.0
  * Fix – Add cron heartbeat and use to offload feed generation from init / admin_init (performance) #1953

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,8 @@
 *** Facebook for WooCommerce Changelog ***
 
 2021-xx-xx - version 2.6.1
+ * Fix: Prevent full catalog sync (using Batch API) for larger stores to avoid performance issues
+ * Dev: Add facebook_for_woocommerce_allow_full_batch_api_sync filter to allow external developers to disable or enable full batch API sync
 
 2021-06-10 - version 2.6.0
  * Fix – Add cron heartbeat and use to offload feed generation from init / admin_init (performance) #1953

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -809,7 +809,19 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * @since 2.6.1
 	 */
 	public function allow_full_batch_api_sync() {
-		return ( $this->get_product_count() < self::MAX_PRODUCTS_FOR_FULL_SYNC );
+		/**
+		 * Allow full batch api sync to be enabled or disabled.
+		 *
+		 * @param bool $allow Is full batch allowed based on threshold (@see WC_Facebookcommerce_Integration::MAX_PRODUCTS_FOR_FULL_SYNC)
+		 * @param int $product_count Number of products in store
+		 *
+		 * @since 2.6.1
+		 */
+		return apply_filters(
+			'facebook_for_woocommerce_allow_full_batch_api_sync',
+			( $this->get_product_count() < self::MAX_PRODUCTS_FOR_FULL_SYNC ),
+			$this->get_product_count()
+		);
 	}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -800,13 +800,13 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		return $product_counts->publish;
 	}
 
-
 	/**
 	 * Should full batch-API sync be allowed?
 	 *
 	 * Used to disable various full sync UI/APIs to avoid performance impact.
 	 *
 	 * @return boolean True if full sync is safe.
+	 * @since 2.6.1
 	 */
 	public function allow_full_batch_api_sync() {
 		return ( $this->get_product_count() < self::MAX_PRODUCTS_FOR_FULL_SYNC );

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -113,12 +113,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var string custom taxonomy FB product set ID */
 	const FB_PRODUCT_SET_ID = 'fb_product_set_id';
 
-	/**
-	 * @var int Maximum number of products for full sync.
-	 * Used to disable full batch-API sync flows which may cause performance issues.
-	 **/
-	const MAX_PRODUCTS_FOR_FULL_SYNC = 5000;
-
 	/** @var string|null the configured product catalog ID */
 	public $product_catalog_id;
 
@@ -804,14 +798,13 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/**
 	 * Should full batch-API sync be allowed?
 	 *
-	 * Used to disable various full sync UI/APIs to avoid performance impact.
+	 * May be used to disable various full sync UI/APIs to avoid performance impact.
 	 *
 	 * @return boolean True if full batch sync is safe.
 	 * @since 2.6.1
 	 */
 	public function allow_full_batch_api_sync() {
-		// By default, disable batch API sync if store has a large number of products.
-		$default_allow_sync = ( $this->get_product_count() < self::MAX_PRODUCTS_FOR_FULL_SYNC );
+		$default_allow_sync = true;
 
 		/**
 		 * Allow full batch api sync to be enabled or disabled.

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -809,17 +809,19 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * @since 2.6.1
 	 */
 	public function allow_full_batch_api_sync() {
+		$default = $this->get_product_count() < self::MAX_PRODUCTS_FOR_FULL_SYNC;
+
 		/**
 		 * Allow full batch api sync to be enabled or disabled.
 		 *
-		 * @param bool $allow Is full batch allowed based on threshold (@see WC_Facebookcommerce_Integration::MAX_PRODUCTS_FOR_FULL_SYNC)
+		 * @param bool $allow Is full batch allowed?
 		 * @param int $product_count Number of products in store
 		 *
 		 * @since 2.6.1
 		 */
 		return apply_filters(
 			'facebook_for_woocommerce_allow_full_batch_api_sync',
-			( $this->get_product_count() < self::MAX_PRODUCTS_FOR_FULL_SYNC ),
+			$default,
 			$this->get_product_count()
 		);
 	}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -116,7 +116,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * @var int Maximum number of products for full sync.
 	 * Used to disable full batch-API sync flows which may cause performance issues.
 	 **/
-	const MAX_PRODUCTS_FOR_FULL_SYNC = 500;
+	const MAX_PRODUCTS_FOR_FULL_SYNC = 5000;
 
 	/** @var string|null the configured product catalog ID */
 	public $product_catalog_id;

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -785,26 +785,14 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		return $product_item_ids;
 	}
 
-
 	/**
-	 * Gets the total of published products.
+	 * Gets the total number of published products.
 	 *
 	 * @return int
 	 */
 	public function get_product_count() {
-
-		$args = array(
-			'post_type'      => 'product',
-			'post_status'    => 'publish',
-			'posts_per_page' => -1,
-			'fields'         => 'ids',
-		);
-
-		$products = new WP_Query( $args );
-
-		wp_reset_postdata();
-
-		return $products->found_posts;
+		$product_counts = wp_count_posts( 'product' );
+		return $product_counts->publish;
 	}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -112,6 +112,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var string custom taxonomy FB product set ID */
 	const FB_PRODUCT_SET_ID = 'fb_product_set_id';
 
+	/**
+	 * @var int Maximum number of products for full sync.
+	 * Used to disable full batch-API sync flows which may cause performance issues.
+	 **/
+	const MAX_PRODUCTS_FOR_FULL_SYNC = 500;
 
 	/** @var string|null the configured product catalog ID */
 	public $product_catalog_id;
@@ -793,6 +798,18 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	public function get_product_count() {
 		$product_counts = wp_count_posts( 'product' );
 		return $product_counts->publish;
+	}
+
+
+	/**
+	 * Should full batch-API sync be allowed?
+	 *
+	 * Used to disable various full sync UI/APIs to avoid performance impact.
+	 *
+	 * @return boolean True if full sync is safe.
+	 */
+	public function allow_full_batch_api_sync() {
+		return ( $this->get_product_count() < self::MAX_PRODUCTS_FOR_FULL_SYNC );
 	}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -806,23 +806,25 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 *
 	 * Used to disable various full sync UI/APIs to avoid performance impact.
 	 *
-	 * @return boolean True if full sync is safe.
+	 * @return boolean True if full batch sync is safe.
 	 * @since 2.6.1
 	 */
 	public function allow_full_batch_api_sync() {
-		$default = $this->get_product_count() < self::MAX_PRODUCTS_FOR_FULL_SYNC;
+		// By default, disable batch API sync if store has a large number of products.
+		$default_allow_sync = ( $this->get_product_count() < self::MAX_PRODUCTS_FOR_FULL_SYNC );
 
 		/**
 		 * Allow full batch api sync to be enabled or disabled.
 		 *
-		 * @param bool $allow Is full batch allowed?
-		 * @param int $product_count Number of products in store
+		 * @param bool $allow Default value - is full batch sync allowed?
+		 * @param int $product_count Number of products in store.
 		 *
+		 * @return boolean True if full batch sync is safe.
 		 * @since 2.6.1
 		 */
 		return apply_filters(
 			'facebook_for_woocommerce_allow_full_batch_api_sync',
-			$default,
+			$default_allow_sync,
 			$this->get_product_count()
 		);
 	}

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -215,6 +215,11 @@ class AJAX {
 	 */
 	public function sync_products() {
 
+		if ( facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
+			wp_send_json_error( __( 'Full product sync disabled because store has a large number of products.', 'facebook-for-woocommerce' ) );
+			return;
+		}
+
 		check_admin_referer( Product_Sync::ACTION_SYNC_PRODUCTS, 'nonce' );
 
 		facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -214,7 +214,7 @@ class AJAX {
 	 * @since 2.0.0
 	 */
 	public function sync_products() {
-
+		// Inhibit on-demand full batch-api sync if the store has large product count.
 		if ( facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
 			wp_send_json_error( __( 'Full product sync disabled because store has a large number of products.', 'facebook-for-woocommerce' ) );
 			return;

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -215,7 +215,7 @@ class AJAX {
 	 */
 	public function sync_products() {
 		// Inhibit on-demand full batch-api sync if the store has large product count.
-		if ( facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
+		if ( ! facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
 			wp_send_json_error( __( 'Full product sync disabled because store has a large number of products.', 'facebook-for-woocommerce' ) );
 			return;
 		}

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -215,7 +215,7 @@ class AJAX {
 	 * @since 2.0.0
 	 */
 	public function sync_products() {
-		// Inhibit on-demand full batch-api sync if the store has large product count.
+		// Allow opt-out of full batch-API sync, for example if store has a large number of products.
 		if ( ! facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
 			wp_send_json_error( __( 'Full product sync disabled because store has a large number of products.', 'facebook-for-woocommerce' ) );
 			return;

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -217,7 +217,7 @@ class AJAX {
 	public function sync_products() {
 		// Allow opt-out of full batch-API sync, for example if store has a large number of products.
 		if ( ! facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
-			wp_send_json_error( __( 'Full product sync disabled because store has a large number of products.', 'facebook-for-woocommerce' ) );
+			wp_send_json_error( __( 'Full product sync disabled by filter hook `facebook_for_woocommerce_allow_full_batch_api_sync`.', 'facebook-for-woocommerce' ) );
 			return;
 		}
 

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -174,9 +174,7 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 	 * @param array $field field data
 	 */
 	public function render_title( $field ) {
-		$integration = facebook_for_woocommerce()->get_integration();
 		?>
-
 		<h2>
 
 			<?php esc_html_e( 'Product sync', 'facebook-for-woocommerce' ); ?>

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -80,8 +80,6 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 		/* translators: Placeholders: {count} number of remaining items */
 		$sync_remaining_items_string = _n_noop( '{count} item remaining.', '{count} items remaining.', 'facebook-for-woocommerce' );
 
-		$fb_integration = facebook_for_woocommerce()->get_integration();
-
 		wp_localize_script(
 			'facebook-for-woocommerce-settings-sync',
 			'facebook_for_woocommerce_settings_sync',
@@ -90,10 +88,9 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 				'set_excluded_terms_prompt_nonce' => wp_create_nonce( 'set-excluded-terms-prompt' ),
 				'sync_products_nonce'             => wp_create_nonce( self::ACTION_SYNC_PRODUCTS ),
 				'sync_status_nonce'               => wp_create_nonce( self::ACTION_GET_SYNC_STATUS ),
-				'total_product_count'             => $fb_integration->get_product_count(),
 				'sync_in_progress'                => Sync::is_sync_in_progress(),
-				'excluded_category_ids'           => $fb_integration->get_excluded_product_category_ids(),
-				'excluded_tag_ids'                => $fb_integration->get_excluded_product_tag_ids(),
+				'excluded_category_ids'           => facebook_for_woocommerce()->get_integration()->get_excluded_product_category_ids(),
+				'excluded_tag_ids'                => facebook_for_woocommerce()->get_integration()->get_excluded_product_tag_ids(),
 				'i18n'                            => array(
 					/* translators: Placeholders %s - html code for a spinner icon */
 					'confirm_resync'                => esc_html__( 'Your products will now be resynced to Facebook, this may take some time.', 'facebook-for-woocommerce' ),

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -80,6 +80,8 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 		/* translators: Placeholders: {count} number of remaining items */
 		$sync_remaining_items_string = _n_noop( '{count} item remaining.', '{count} items remaining.', 'facebook-for-woocommerce' );
 
+		$fb_integration = facebook_for_woocommerce()->get_integration();
+
 		wp_localize_script(
 			'facebook-for-woocommerce-settings-sync',
 			'facebook_for_woocommerce_settings_sync',
@@ -88,9 +90,10 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 				'set_excluded_terms_prompt_nonce' => wp_create_nonce( 'set-excluded-terms-prompt' ),
 				'sync_products_nonce'             => wp_create_nonce( self::ACTION_SYNC_PRODUCTS ),
 				'sync_status_nonce'               => wp_create_nonce( self::ACTION_GET_SYNC_STATUS ),
+				'total_product_count'             => $fb_integration->get_product_count(),
 				'sync_in_progress'                => Sync::is_sync_in_progress(),
-				'excluded_category_ids'           => facebook_for_woocommerce()->get_integration()->get_excluded_product_category_ids(),
-				'excluded_tag_ids'                => facebook_for_woocommerce()->get_integration()->get_excluded_product_tag_ids(),
+				'excluded_category_ids'           => $fb_integration->get_excluded_product_category_ids(),
+				'excluded_tag_ids'                => $fb_integration->get_excluded_product_tag_ids(),
 				'i18n'                            => array(
 					/* translators: Placeholders %s - html code for a spinner icon */
 					'confirm_resync'                => esc_html__( 'Your products will now be resynced to Facebook, this may take some time.', 'facebook-for-woocommerce' ),

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -175,16 +175,13 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 	 */
 	public function render_title( $field ) {
 		$integration = facebook_for_woocommerce()->get_integration();
-
-		$show_sync_button = $integration->allow_full_batch_api_sync() &&
-			facebook_for_woocommerce()->get_connection_handler()->is_connected();
 		?>
 
 		<h2>
 
 			<?php esc_html_e( 'Product sync', 'facebook-for-woocommerce' ); ?>
 
-			<?php if ( $show_sync_button ) : ?>
+			<?php if ( facebook_for_woocommerce()->get_connection_handler()->is_connected() ) : ?>
 				<a
 					id="woocommerce-facebook-settings-sync-products"
 					class="button product-sync-field"

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -174,14 +174,17 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 	 * @param array $field field data
 	 */
 	public function render_title( $field ) {
+		$integration = facebook_for_woocommerce()->get_integration();
 
+		$show_sync_button = $integration->allow_full_batch_api_sync() &&
+			facebook_for_woocommerce()->get_connection_handler()->is_connected();
 		?>
 
 		<h2>
 
 			<?php esc_html_e( 'Product sync', 'facebook-for-woocommerce' ); ?>
 
-			<?php if ( facebook_for_woocommerce()->get_connection_handler()->is_connected() ) : ?>
+			<?php if ( $show_sync_button ) : ?>
 				<a
 					id="woocommerce-facebook-settings-sync-products"
 					class="button product-sync-field"

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -301,7 +301,10 @@ class Connection {
 			$this->update_system_user_id( $system_user_id );
 			$this->update_installation_data();
 
-			facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
+			// Only trigger initial full batch-api sync if the store doesn't have large product count.
+			if ( $facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
+				facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
+			}
 
 			update_option( 'wc_facebook_has_connected_fbe_2', 'yes' );
 			update_option( 'wc_facebook_has_authorized_pages_read_engagement', 'yes' );

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -302,7 +302,7 @@ class Connection {
 			$this->update_installation_data();
 
 			// Only trigger initial full batch-api sync if the store doesn't have large product count.
-			if ( $facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
+			if ( facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
 				facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
 			}
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -302,7 +302,7 @@ class Connection {
 			$this->update_system_user_id( $system_user_id );
 			$this->update_installation_data();
 
-			// Only trigger initial full batch-api sync if the store doesn't have large product count.
+			// Allow opt-out of full batch-API sync, for example if store has a large number of products.
 			if ( facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
 				facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
 			}

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -306,6 +306,10 @@ class Connection {
 			if ( facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
 				facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
 			}
+			else {
+				facebook_for_woocommerce()->log( 'Initial full product sync disabled by filter hook `facebook_for_woocommerce_allow_full_batch_api_sync`', 'facebook_for_woocommerce_connect' );
+			}
+
 
 			update_option( 'wc_facebook_has_connected_fbe_2', 'yes' );
 			update_option( 'wc_facebook_has_authorized_pages_read_engagement', 'yes' );

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,8 @@ When opening a bug on GitHub, please give us as many details as possible.
 == Changelog ==
 
 = 2.6.1 - 2021-xx-xx =
+ * Fix: Prevent full catalog sync (using Batch API) for larger stores to avoid performance issues
+ * Dev: Add facebook_for_woocommerce_allow_full_batch_api_sync filter to allow external developers to disable or enable full batch API sync
 
 = 2.6.0 - 2021-06-10 =
  * Fix – Add cron heartbeat and use to offload feed generation from init / admin_init (performance) #1953

--- a/readme.txt
+++ b/readme.txt
@@ -40,8 +40,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 == Changelog ==
 
 = 2.6.1 - 2021-xx-xx =
- * Fix: Prevent full catalog sync (using Batch API) for larger stores to avoid performance issues
- * Dev: Add facebook_for_woocommerce_allow_full_batch_api_sync filter to allow external developers to disable or enable full batch API sync
+ * Dev: Add `facebook_for_woocommerce_allow_full_batch_api_sync` filter to allow opt-out full batch API sync, to avoid possible performance issues on large sites
 
 = 2.6.0 - 2021-06-10 =
  * Fix – Add cron heartbeat and use to offload feed generation from init / admin_init (performance) #1953


### PR DESCRIPTION
Fixes #2022, #2035

See also related #2023 #2025 #2029 

- [ ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changes proposed in this Pull Request:
This PR provides a hook to allow developers (or hosting platforms) to disable specific full-catalog sync operations (via Batch API). See below `Why?` for more background and context.

Specifically these two flows are affected:

- Onboarding & initial connection. The initial full catalog sync is only triggered if the filter allows it.
- On-demand sync using button in `Marketing > Facebook > Product sync`. If full batch API sync is disabled via filter, an error will be shown.
- AJAX full sync endpoint (used for button above) returns an error if site has large number of products.

The default behaviour is that the full batch-api background sync is allowed (consistent with previous releases).

Some example use-cases for the hook.

- On shared hosting or other resource-limited environments, to disable full batch API sync for large-scale sites (5000+ products, or completely disable).
- On hosts that have detailed database logging, to disable batch API sync more aggressively (e.g. 1000+ products).

Example use of hook:

```php
function wpcomsh_disallow_fb_for_woo_full_batch_api_sync( $allow_full_sync, $product_count ) {
	// Disable only for sites with a large number of products.
	$max_products_for_safe_full_sync = 10;
	if ( $product_count > $max_products_for_safe_full_sync ) {
		return false;
	}

	return $allow_full_sync;
}
add_filter( 'facebook_for_woocommerce_allow_full_batch_api_sync', 'wpcomsh_disallow_fb_for_woo_full_batch_api_sync', 10, 2 );
```

Also in this PR the `get_product_count()` function has been optimised to use `wp_count_posts`. We're passing the total number of products to the hook. The previous query was loading all the IDs into memory, which is unnecessary and could impact performance for larger stores.

##### Why?
A full catalog sync using the batch API and the [`Products\Sync\Background`](https://github.com/woocommerce/facebook-for-woocommerce/blob/master/includes/Products/Sync/Background.php) task can cause issues.

The `Background` class uses the [`SkyVerge` background job framework](https://github.com/skyverge/wc-plugin-framework/blob/master/woocommerce/utilities/class-sv-wp-background-job-handler.php). This adds an option to the database representing the job status and progress, which includes all product IDs that are included in the sync job. 

There are two risks with this:

- The option is large, and grows with the number of products that need to be synched => large database size.
- The option is re-written constantly => large database traffic/throughput. This can generate significant database logs (depending on config of course).

Long term, we may need to tweak or replace the `Products\Sync\Background` so we have a scalable, robust way to sync full catalog. This is a medium-term patch to prevent this sync mechanism causing issues for merchants and web hosts, and to give more control over whether full batch sync happens.

##### How does this impact stores, and the product sync feature?
- Disabling the initial sync means that new stores (over the num products threshold) will not see their products in Facebook catalog by default. Products will incrementally sync as they are added or edited; or potentially sites can use feed-based sync.
- The manual full sync button will show an error (see below). Should be low impact, as it's not intended to be used regularly; is intended as a workaround for sync issues.
- Note: this will not affect any stores by default - a filter function needs to be added to prevent any syncs from occurring.

<img width="760" alt="Screen Shot 2021-06-28 at 1 06 02 PM" src="https://user-images.githubusercontent.com/4167300/123565765-0a5fe600-d812-11eb-89c6-5b6251e81a82.png">


##### Does this solve the issue?
It may be still possible to trigger a similar problem via code or API (or UI!), by marking a large number of products as needing sync (e.g. make a trivial edit). This PR doesn't fix the root of the problem (`Products\Sync\Background` scalability). One potential workaround: #2034

### How to test the changes in this Pull Request:
Add a filter for `facebook_for_woocommerce_allow_full_batch_api_sync` to disable full sync, e.g. for sites with > 5000 products.

Two main flows to test:

1. Full sync on-demand via admin button.
2. Full sync triggered automatically after onboarding.
3. Any other way of triggering a full batch API sync.

Test to ensure the filter disables full sync appropriately.

### Changelog entry

> Dev: Add `facebook_for_woocommerce_allow_full_batch_api_sync` filter to allow external developers to disable or enable full catalog sync (batch API)
