### PR TITLE
Disable full batch API sync on Atomic env

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -809,7 +809,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * @return boolean True if full sync is safe.
 	 */
 	public function allow_full_batch_api_sync() {
-		return ( $this->get_product_count() < self::MAX_PRODUCTS_FOR_FULL_SYNC );
+		return ( ( $this->get_product_count() < self::MAX_PRODUCTS_FOR_FULL_SYNC ) && ! \WC_Facebookcommerce_Utils::is_Atomic_env() );
 	}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -785,26 +785,14 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		return $product_item_ids;
 	}
 
-
 	/**
-	 * Gets the total of published products.
+	 * Gets the total number of published products.
 	 *
 	 * @return int
 	 */
 	public function get_product_count() {
-
-		$args = array(
-			'post_type'      => 'product',
-			'post_status'    => 'publish',
-			'posts_per_page' => -1,
-			'fields'         => 'ids',
-		);
-
-		$products = new WP_Query( $args );
-
-		wp_reset_postdata();
-
-		return $products->found_posts;
+		$product_counts = wp_count_posts( 'product' );
+		return $product_counts->publish;
 	}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -112,6 +112,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var string custom taxonomy FB product set ID */
 	const FB_PRODUCT_SET_ID = 'fb_product_set_id';
 
+	/**
+	 * @var int Maximum number of products for full sync.
+	 * Used to disable full batch-API sync flows which may cause performance issues.
+	 **/
+	const MAX_PRODUCTS_FOR_FULL_SYNC = 500;
 
 	/** @var string|null the configured product catalog ID */
 	public $product_catalog_id;
@@ -793,6 +798,18 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	public function get_product_count() {
 		$product_counts = wp_count_posts( 'product' );
 		return $product_counts->publish;
+	}
+
+
+	/**
+	 * Should full batch-API sync be allowed?
+	 *
+	 * Used to disable various full sync UI/APIs to avoid performance impact.
+	 *
+	 * @return boolean True if full sync is safe.
+	 */
+	public function allow_full_batch_api_sync() {
+		return ( $this->get_product_count() < self::MAX_PRODUCTS_FOR_FULL_SYNC );
 	}
 
 

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -215,6 +215,11 @@ class AJAX {
 	 */
 	public function sync_products() {
 
+		if ( facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
+			wp_send_json_error( __( 'Full product sync disabled because store has a large number of products.', 'facebook-for-woocommerce' ) );
+			return;
+		}
+
 		check_admin_referer( Product_Sync::ACTION_SYNC_PRODUCTS, 'nonce' );
 
 		facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -214,7 +214,7 @@ class AJAX {
 	 * @since 2.0.0
 	 */
 	public function sync_products() {
-
+		// Inhibit on-demand full batch-api sync if the store has large product count.
 		if ( facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
 			wp_send_json_error( __( 'Full product sync disabled because store has a large number of products.', 'facebook-for-woocommerce' ) );
 			return;

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -80,8 +80,6 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 		/* translators: Placeholders: {count} number of remaining items */
 		$sync_remaining_items_string = _n_noop( '{count} item remaining.', '{count} items remaining.', 'facebook-for-woocommerce' );
 
-		$fb_integration = facebook_for_woocommerce()->get_integration();
-
 		wp_localize_script(
 			'facebook-for-woocommerce-settings-sync',
 			'facebook_for_woocommerce_settings_sync',
@@ -90,10 +88,9 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 				'set_excluded_terms_prompt_nonce' => wp_create_nonce( 'set-excluded-terms-prompt' ),
 				'sync_products_nonce'             => wp_create_nonce( self::ACTION_SYNC_PRODUCTS ),
 				'sync_status_nonce'               => wp_create_nonce( self::ACTION_GET_SYNC_STATUS ),
-				'total_product_count'             => $fb_integration->get_product_count(),
 				'sync_in_progress'                => Sync::is_sync_in_progress(),
-				'excluded_category_ids'           => $fb_integration->get_excluded_product_category_ids(),
-				'excluded_tag_ids'                => $fb_integration->get_excluded_product_tag_ids(),
+				'excluded_category_ids'           => facebook_for_woocommerce()->get_integration()->get_excluded_product_category_ids(),
+				'excluded_tag_ids'                => facebook_for_woocommerce()->get_integration()->get_excluded_product_tag_ids(),
 				'i18n'                            => array(
 					/* translators: Placeholders %s - html code for a spinner icon */
 					'confirm_resync'                => esc_html__( 'Your products will now be resynced to Facebook, this may take some time.', 'facebook-for-woocommerce' ),

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -80,6 +80,8 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 		/* translators: Placeholders: {count} number of remaining items */
 		$sync_remaining_items_string = _n_noop( '{count} item remaining.', '{count} items remaining.', 'facebook-for-woocommerce' );
 
+		$fb_integration = facebook_for_woocommerce()->get_integration();
+
 		wp_localize_script(
 			'facebook-for-woocommerce-settings-sync',
 			'facebook_for_woocommerce_settings_sync',
@@ -88,9 +90,10 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 				'set_excluded_terms_prompt_nonce' => wp_create_nonce( 'set-excluded-terms-prompt' ),
 				'sync_products_nonce'             => wp_create_nonce( self::ACTION_SYNC_PRODUCTS ),
 				'sync_status_nonce'               => wp_create_nonce( self::ACTION_GET_SYNC_STATUS ),
+				'total_product_count'             => $fb_integration->get_product_count(),
 				'sync_in_progress'                => Sync::is_sync_in_progress(),
-				'excluded_category_ids'           => facebook_for_woocommerce()->get_integration()->get_excluded_product_category_ids(),
-				'excluded_tag_ids'                => facebook_for_woocommerce()->get_integration()->get_excluded_product_tag_ids(),
+				'excluded_category_ids'           => $fb_integration->get_excluded_product_category_ids(),
+				'excluded_tag_ids'                => $fb_integration->get_excluded_product_tag_ids(),
 				'i18n'                            => array(
 					/* translators: Placeholders %s - html code for a spinner icon */
 					'confirm_resync'                => esc_html__( 'Your products will now be resynced to Facebook, this may take some time.', 'facebook-for-woocommerce' ),

--- a/includes/Admin/Settings_Screens/Product_Sync.php
+++ b/includes/Admin/Settings_Screens/Product_Sync.php
@@ -174,14 +174,17 @@ class Product_Sync extends Admin\Abstract_Settings_Screen {
 	 * @param array $field field data
 	 */
 	public function render_title( $field ) {
+		$integration = facebook_for_woocommerce()->get_integration();
 
+		$show_sync_button = $integration->allow_full_batch_api_sync() &&
+			facebook_for_woocommerce()->get_connection_handler()->is_connected();
 		?>
 
 		<h2>
 
 			<?php esc_html_e( 'Product sync', 'facebook-for-woocommerce' ); ?>
 
-			<?php if ( facebook_for_woocommerce()->get_connection_handler()->is_connected() ) : ?>
+			<?php if ( $show_sync_button ) : ?>
 				<a
 					id="woocommerce-facebook-settings-sync-products"
 					class="button product-sync-field"

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -301,7 +301,10 @@ class Connection {
 			$this->update_system_user_id( $system_user_id );
 			$this->update_installation_data();
 
-			facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
+			// Only trigger initial full batch-api sync if the store doesn't have large product count.
+			if ( $facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
+				facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_all_products();
+			}
 
 			update_option( 'wc_facebook_has_connected_fbe_2', 'yes' );
 			update_option( 'wc_facebook_has_authorized_pages_read_engagement', 'yes' );

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -595,6 +595,16 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			);
 			return $cached_best_tip;
 		}
+
+		/**
+		 * Detects if current env is WP Atomic
+		 *
+		 * @return bool
+		 * @since 2.6.1
+		 */
+		public static function is_Atomic_env() {
+			return ( defined( 'IS_ATOMIC' ) && IS_ATOMIC );
+		}
 	}
 
 endif;


### PR DESCRIPTION
Fixes # 

- [ ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changes proposed in this Pull Request:
Disables full batch API sync when the site is hosted on Atomic environment. We validate Atomic environment with the constant `IS_ATOMIC`

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
1. Edit your `wp-config.php` or create an `mu-plugin` file, and add:
```php
define( 'IS_ATOMIC', true );
``` 
2. Go to _Marketing > Facebook > Product sync_
3. Validate *Sync products* button is not rendered'
<img width="351" alt="Screen Shot 2021-06-23 at 19 09 48" src="https://user-images.githubusercontent.com/532402/123187150-cefe9980-d456-11eb-8a58-7d21efbf8ef3.png">


### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
> Fix - Disable full batch API sync from Atomic sites
<!-- See [previous releases](../../releases) for more examples. -->
