### PR TITLE
Use relative paths rather than absolute root paths

### DIFF
--- a/includes/Integrations/Integrations.php
+++ b/includes/Integrations/Integrations.php
@@ -53,13 +53,13 @@ class Integrations {
 	private function load_integrations() {
 
 		$registered_integrations = array(
-			'WC_Facebook_WPML_Injector' => '/includes/fbwpml.php',
-			Bookings::class             => '/includes/Integrations/Bookings.php',
+			'WC_Facebook_WPML_Injector' => __DIR__ . '/../fbwpml.php',
+			Bookings::class             => __DIR__ . '/Bookings.php',
 		);
 
 		foreach ( $registered_integrations as $class_name => $path ) {
 
-			if ( ! class_exists( $class_name ) && ! is_readable( $path ) ) {
+			if ( ! class_exists( $class_name ) && is_readable( $path ) ) {
 
 				$this->integrations[ $class_name ] = $this->plugin->load_class( $path, $class_name );
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This is to solve the following warning:
PHP Warning: is_readable(): open_basedir restriction in effect. File(/includes/fbwpml.php) is not within the allowed path(s) [...]

The is_readable call is using a system-root url, i.e. it's looking for `/includes/fbwpml.php` rather than `/path-to-wp/wp-content/plugins/facebook-for-woocommerce/includes/fbwpml.php` which causes a warning similar to the above for any system with open_basedir restrictions that don't allow this.

Also, the call to is_readable will always return false with these paths.

Removes the negation on is_readable also, to take the conditional from `IF class does not exist AND file _is not_ readable` to `IF class does not exist AND file _is_ readable`

### Changelog entry

> Fix - Use relative paths when checking if an integration file exists
