### PR TITLE
Fix the file path when doing the is_readable check.

### DIFF
--- a/includes/Integrations/Integrations.php
+++ b/includes/Integrations/Integrations.php
@@ -59,7 +59,7 @@ class Integrations {
 
 		foreach ( $registered_integrations as $class_name => $path ) {
 
-			if ( ! class_exists( $class_name ) && ! is_readable( $path ) ) {
+			if ( ! class_exists( $class_name ) && is_readable( $this->plugin->get_plugin_path() . $path ) ) {
 
 				$this->integrations[ $class_name ] = $this->plugin->load_class( $path, $class_name );
 			}


### PR DESCRIPTION
Fixes #1642

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This concatenates the path to be the same as used in the `load_class` method. This prevents the `is_readable` check from attempting to check in the root path of the operating system for the files and instead looks in the correct location of the plugin. Looking for `/includes/fbwpml.php` and `/includes/Integrations/Bookings.php`

In our production environment these failed checks were adding 3 seconds to the PHP execution time with PHP 7.4.21.

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
1. It is a simple fix.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
> Fix - Fix the file path when doing the is_readable check for integrations.
<!-- See [previous releases](../../releases) for more examples. -->
