### PR TITLE
Update marketing API to version 11

### DIFF
--- a/includes/fbgraph.php
+++ b/includes/fbgraph.php
@@ -394,7 +394,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 		}
 
 		public function delete_product_group( $product_group_id ) {
-			$product_group_url = $this->build_url( $product_group_id );
+			$product_group_url = $this->build_url( $product_group_id, '?deletion_method=delete_items' );
 			return self::_delete( $product_group_url );
 		}
 

--- a/includes/fbgraph.php
+++ b/includes/fbgraph.php
@@ -26,7 +26,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 	 */
 	class WC_Facebookcommerce_Graph_API {
 		const GRAPH_API_URL = 'https://graph.facebook.com/';
-		const API_VERSION   = 'v9.0';
+		const API_VERSION   = 'v11.0';
 		const CURL_TIMEOUT  = 500;
 
 		/**

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -604,9 +604,9 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 				$product_data                            = $this->apply_enhanced_catalog_fields_from_attributes( $product_data, $google_product_category );
 			}
 
-			// add the Commerce values (only inventory for the moment)
+			// add the Commerce values (only stock quantity for the moment)
 			if ( Products::is_product_ready_for_commerce( $this->woo_product ) ) {
-				$product_data['inventory'] = (int) max( 0, $this->woo_product->get_stock_quantity() );
+				$product_data['quantity_to_sell_on_facebook'] = (int) max( 0, $this->woo_product->get_stock_quantity() );
 			}
 
 			// Only use checkout URLs if they exist.

--- a/tests/integration/WC_Facebook_Product_Test.php
+++ b/tests/integration/WC_Facebook_Product_Test.php
@@ -33,7 +33,7 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 
 
 	/** @see \WC_Facebook_Product::prepare_product() */
-	public function test_prepare_product_not_ready_for_commerce_inventory() {
+	public function test_prepare_product_not_ready_for_commerce_stock_quantity() {
 
 		$product = $this->tester->get_product();
 
@@ -41,7 +41,7 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 
 		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product( null, \WC_Facebook_Product::PRODUCT_PREP_TYPE_ITEMS_BATCH );
 
-		$this->assertArrayNotHasKey( 'inventory', $data );
+		$this->assertArrayNotHasKey( 'quantity_to_sell_on_facebook', $data );
 	}
 
 
@@ -89,12 +89,12 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @see \WC_Facebook_Product::prepare_product()
 	 *
-	 * @dataProvider provider_prepare_product_ready_for_commerce_inventory
+	 * @dataProvider provider_prepare_product_ready_for_commerce_stock_quantity
 	 *
 	 * @param int|string $woo_quantity WooCommerce stock quantity
-	 * @param int $facebook_expected expected Facebook inventory value
+	 * @param int $facebook_expected expected Facebook quantity_to_sell_on_facebook value
 	 */
-	public function test_prepare_product_ready_for_commerce_inventory( $woo_quantity, $facebook_expected ) {
+	public function test_prepare_product_ready_for_commerce_stock_quantity( $woo_quantity, $facebook_expected ) {
 
 		$product = $this->tester->get_product( [
 			'status'         => 'publish',
@@ -108,12 +108,12 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 
 		$data = ( new \WC_Facebook_Product( $product ) )->prepare_product();
 
-		$this->assertSame( $facebook_expected, $data['inventory'] );
+		$this->assertSame( $facebook_expected, $data['quantity_to_sell_on_facebook'] );
 	}
 
 
-	/** @see test_prepare_product_ready_for_commerce_inventory */
-	public function provider_prepare_product_ready_for_commerce_inventory() {
+	/** @see test_prepare_product_ready_for_commerce_stock_quantity */
+	public function provider_prepare_product_ready_for_commerce_stock_quantity() {
 
 		return [
 			'valid stock quantity'    => [ 4, 4 ],


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR updates the marketing API from [version 9](https://github.com/woocommerce/facebook-for-woocommerce/pull/1787) to version 11.

In addition to bumping the version several relevant changes have been addressed from the changes listed in the following docs:
https://developers.facebook.com/docs/graph-api/changelog/version10.0#marketing-api
https://developers.facebook.com/docs/graph-api/changelog/version11.0#marketing-api

#### [Deprecation of Product Inventory Field](https://developers.facebook.com/docs/graph-api/changelog/version11.0#catalog-api)
Rename `inventory` to `quantity_to_sell_on_facebook`

##### Test these changes
1. Create a product that is in stock and set manage stock to set a stock quantity.
2. Mark the product as commerce enabled or set `_wc_facebook_commerce_enabled` to `yes` in the post meta.
3. On the page Marketing > Facebook > Product Sync click the button to sync products
4. Go to WooCommerce > Status > Logs and check the latest facebook log file. Check that the value `quantity_to_sell_on_facebook` is set to the stock quantity.
5. Confirm in the log file that requests are going to the endpoint with v11 included in the URL.

#### [Deletion of Non-Empty Product Groups](https://developers.facebook.com/docs/graph-api/changelog/version11.0#catalog-api)

For variable products we use a combined group ID for all the variations. For simple products each product has a unique group ID, so deleting the group with all the included items will only delete the single item.

When deleting the variable product with v11, we run into the following error message:

```
This product group can't be deleted because it has variants. You'll need to delete both the product group and its variants by requesting deletion_method=delete_items. This action can't be undone.
```

##### Test these changes
1. Create a variable product and sync it to facebook
2. In the Facebook box click "Delete product(s) on Facebook"
3. Go to WooCommerce > Status > Logs and check the latest facebook log file. Confirm that the product variations and product group (shared between variations) has been deleted without errors

#### [Deletion of Live Product Sets](https://developers.facebook.com/docs/graph-api/changelog/version11.0#catalog-api)

It mentions that we need to set `allow_delete_catalog_with_live_product_set` although the [documentation for v11](https://developers.facebook.com/docs/marketing-api/reference/product-set/#Deleting) seems to mention it should be `allow_live_product_set_deletion`.

We already set this value through a [filter in the code](https://github.com/woocommerce/facebook-for-woocommerce/blob/2.6.1/includes/fbgraph.php#L414) (which defaults to true). So in testing I didn't encounter any errors when deleting a product set containing live products.


### Changelog entry
* Update - Marketing API v11