### PR TITLE
Adding Support for alternate product feeds into facebook, but still have order sync though this plugin

### DIFF
--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -180,10 +180,13 @@ class Orders {
 			}
 
 			if ( ! $product instanceof \WC_Product ) {
+				// One extra catch to support sites using custom feed sync to Facebook, but using retailer_id as the main key
+				if (! is_a($product,'WC_Product')){
+					// add a note and skip this item
+					$local_order->add_order_note( "Product with retailer ID {$item['retailer_id']} not found" );
+					continue;
+				}
 
-				// add a note and skip this item
-				$local_order->add_order_note( "Product with retailer ID {$item['retailer_id']} not found" );
-				continue;
 			}
 
 			$matching_wc_order_item = false;
@@ -376,9 +379,12 @@ class Orders {
 	 */
 	public function update_local_orders() {
 		// sanity check for connection status
+		/*
+		// Had to disable this to get orders to sync, which worked, so this santiy check must be off for some reason???
 		if ( ! facebook_for_woocommerce()->get_commerce_handler()->is_connected() ) {
 			return;
 		}
+		*/
 
 		$page_id = facebook_for_woocommerce()->get_integration()->get_facebook_page_id();
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -1236,7 +1236,23 @@ class Products {
 				$product = current( $products );
 			}
 		}
+		
+		// Adding some code to work with a site that uses it's own custom feed sync to facebook, but uses the product ID (post_id) as the main id, 
+		//  allowing the facebook order sync solution to still work - shouldn't affect any other site, as the above would occur in most scenarios
+		if ( empty( $product ) ) {
+			$products = wc_get_products(
+				array(
+					'limit'      => 1,
+					'include' => array($fb_product_id),
+				)
+			);
 
+			if ( ! empty( $products ) ) {
+				$product = current( $products );
+			}
+		}
+		// End ability to sync products outside of this plugin, and still use the plugin
+		
 		return ! empty( $product ) ? $product : null;
 	}
 


### PR DESCRIPTION
Fixes # 

- [ X ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changes proposed in this Pull Request:
adding support for a site doing it's own product sync to facebook (outside of this plugin) to still get orders to sync in.  I believe all my edits shouldn't affect a site which is already using the sync native to this plugin.


### How to test the changes in this Pull Request:
Create a feed outside of this plugin, post to facebook, create an order, and it should sync.  All that needs to happen is to have the retailer_id == post_id (or == wc_post_id_<postid>)

### Changelog entry
Added some extra catches and functionality to allow a site using an external product sync, to still use this plugin for order synchronization.
