### PR TITLE
Update logs formatting for connect server logs.

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -280,7 +280,7 @@ class Connection {
 
 			$is_error                 = ! empty( $_GET['err'] ) ? true : false;
 			$error_code               = ! empty( $_GET['err_code'] ) ? stripslashes( sanitize_text_field( $_GET['err_code'] ) ) : '';
-			$merchant_access_token    = ! empty( $_GET['merchant_access_token'] ) ?  sanitize_text_field( $_GET['merchant_access_token'] ) : '';
+			$merchant_access_token    = ! empty( $_GET['merchant_access_token'] ) ? sanitize_text_field( $_GET['merchant_access_token'] ) : '';
 			$system_user_access_token = ! empty( $_GET['system_user_access_token'] ) ? sanitize_text_field( $_GET['system_user_access_token'] ) : '';
 			$system_user_id           = ! empty( $_GET['system_user_id'] ) ? sanitize_text_field( $_GET['system_user_id'] ) : '';
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -334,7 +334,7 @@ class Connection {
 		} catch ( Connect_WC_API_Exception $exception ) {
 			$message = $this->prepare_connect_server_message_for_user_display( $exception->getMessage() );
 
-			facebook_for_woocommerce()->log( sprintf( 'Failed to connect to Facebook. Reason: %s', $message), 'facebook_for_woocommerce_connect' );
+			facebook_for_woocommerce()->log( sprintf( 'Failed to connect to Facebook. Reason: %s', $message ), 'facebook_for_woocommerce_connect' );
 
 			set_transient( 'wc_facebook_connection_failed', time(), 30 );
 		}

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -37,6 +37,9 @@ class Connection {
 	/** @var string WooCommerce connection for APP Store login URL */
 	const APP_STORE_LOGIN_URL = 'https://connect.woocommerce.com/app-store-login/facebook/';
 
+	/** @var string WooCommerce connection authentication URL */
+	const CONNECTION_AUTHENTICATION_URL = 'https://connect.woocommerce.com/auth/facebookcommerce/';
+
 	/** @var string the Standard Auth type */
 	const AUTH_TYPE_STANDARD = 'standard';
 
@@ -545,7 +548,7 @@ class Connection {
 	 * include the final site URL, which is where the merchant will redirect to with the data that needs to be stored.
 	 * So the final URL looks like this without encoding:
 	 *
-	 * https://www.facebook.com/commerce_manager/onboarding/?app_id={id}&redirect_url=https://connect.woocommerce.com/auth/facebook/?site_url=https://example.com/?wc-api=wc_facebook_connect_commerce&nonce=1234
+	 * https://www.facebook.com/commerce_manager/onboarding/?app_id={id}&redirect_url=https://connect.woocommerce.local/auth/facebook/?site_url=https://example.com/?wc-api=wc_facebook_connect_commerce&nonce=1234
 	 *
 	 * If testing only, &is_test_mode=true can be appended to the URL using the wc_facebook_commerce_connect_url filter
 	 * to trigger the test account flow, where fake US-based business details can be used.
@@ -566,7 +569,7 @@ class Connection {
 		);
 
 		// build the proxy app URL where the user will land after onboarding, to be redirected to the site URL
-		$redirect_url = add_query_arg( 'site_url', urlencode( $site_url ), 'https://connect.woocommerce.com/auth/facebookcommerce/' );
+		$redirect_url = add_query_arg( 'site_url', urlencode( $site_url ), $this->get_connection_authentication_url() );
 
 		// build the final connect URL, direct to Facebook
 		$connect_url = add_query_arg(
@@ -848,6 +851,24 @@ class Connection {
 		return (string) apply_filters( 'wc_facebook_connection_app_store_login_url', self::APP_STORE_LOGIN_URL );
 	}
 
+	/**
+	 * Gets connect server authentication url.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string URL
+	 */
+	public function get_connection_authentication_url() {
+
+		/**
+		 * Filters App Store login URL.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string $connection_authentication_url the connection App Store login URL
+		 */
+		return (string) apply_filters( 'wc_facebook_connection_authentication_url', self::CONNECTION_AUTHENTICATION_URL );
+	}
 
 	/**
 	 * Gets the full redirect URL where the user will return to after OAuth.


### PR DESCRIPTION
The intent of this PR  is ( part of the effort ) to have more comprehensive logs from connect server. The plugin only displays the logs that are passed from the connect server so this PR focuses only on the formatting of said logs. All the important changes are happening inside the connect server PR https://github.com/Automattic/connect.woocommerce.com/pull/137 which is needed to properly test this one.

One additional change ( I should be a separate PR I know ) is the addition of `CONNECTION_AUTHENTICATION_URL` const and the fetcher for this const. It is merely for making debugging easier. The added filter allows redirecting the authentication to the local connect server instance.

### How to test the changes in this Pull Request:
 - Enable the plugin using this PR
 - follow the instruction inside the https://github.com/Automattic/connect.woocommerce.com/pull/137 

Example output in the facebook_for_woocommerce_connect logs in Status->Logs:

```
09-23-2021 @ 07:20:24 - Failed to connect to Facebook. Reason: {
    "message": "Application does not have permission for this action",
    "type": "OAuthException",
    "code": 10,
    "error_subcode": 2859015,
    "is_transient": false,
    "error_user_title": "Your account is restricted right now",
    "error_user_msg": "You have been temporarily blocked from performing this action.",
    "fbtrace_id": "AgIrd2kMFugwcCqVAyH-HDX"
}
```

The actual message depends on the testing scenario.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
> New - Better logging format for connections issues.
<!-- See [previous releases](../../releases) for more examples. -->
