### PR TITLE
Clean up headers from logs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ The best place to get support is the [WordPress.org Facebook for WooCommerce for
 
 If you have a WooCommerce.com account, you can [start a chat or open a ticket on WooCommerce.com](https://woocommerce.com/my-account/create-a-ticket/).
 
+### Logging
+The plugin offers logging that can help debug various problems. You can enable debug mode in the main plugin settings panel under the `Enable debug mode` section.
+By default plugin omits headers in the requests to make the logs more readable. If debugging with headers is necessary you can enable the headers in the logs by setting `wc_facebook_request_headers_in_debug_log` option to true.
 ## Development 
 ### Developing
 - Clone this repository into the `wp-content/plugins/` folder your WooCommerce development environment.

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -435,7 +435,17 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				return;
 			}
 
-			parent::log_api_request( $request, $response, $log_id );
+			// Maybe remove headers from the debug log.
+			if( ! $this->get_integration()->are_headers_requested_for_debug() ) {
+				unset( $request['headers'] );
+				unset( $response['headers'] );
+			}
+
+			$this->log( $this->get_api_log_message( $request ), $log_id );
+
+			if ( ! empty( $response ) ) {
+				$this->log( $this->get_api_log_message( $response ), $log_id );
+			}
 		}
 
 		/**

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -101,6 +101,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var string the "debug mode" setting ID */
 	const SETTING_ENABLE_DEBUG_MODE = 'wc_facebook_enable_debug_mode';
 
+	/** @var string request headers in the debug log */
+	const SETTING_REQUEST_HEADERS_IN_DEBUG_MODE = 'wc_facebook_request_headers_in_debug_log';
+
 	/** @var string the standard product description mode name */
 	const PRODUCT_DESCRIPTION_MODE_STANDARD = 'standard';
 
@@ -3265,6 +3268,18 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 * @param \WC_Facebookcommerce_Integration $integration the integration instance
 		 */
 		return (bool) apply_filters( 'wc_facebook_is_debug_mode_enabled', 'yes' === get_option( self::SETTING_ENABLE_DEBUG_MODE ), $this );
+	}
+
+	/**
+	 * Check if logging headers is requested.
+	 * For a typical troubleshooting session the request headers bring zero value except making the log unreadable.
+	 * They will be disabled by default. Enabling them will require setting an option in the options table.
+	 *
+	 * @since x.x.x
+	 *
+	 */
+	public function are_headers_requested_for_debug() {
+		return (bool) get_option( self::SETTING_REQUEST_HEADERS_IN_DEBUG_MODE, false );
 	}
 
 


### PR DESCRIPTION
Fixes cluttered logs.

This PR makes the debug logs much cleaner and saner to review. Previously we have logged the whole response header which was making the log bloated and it made it much harder to spot the problems.

To enable old style logs one needs to set to true the following option `wc_facebook_request_headers_in_debug_log`

New style log:
```log
10-04-2021 @ 08:15:27 - Request
uri: https://graph.facebook.com/v11.0/catalog:997957297700812:dmFyaWDDOTHVfYWdhaW5fMjE1/?debug=all&fields=id,product_group{id}
timeout: 500

10-04-2021 @ 08:15:28 - Response
code: 400
message: Bad Request
body: {"error":{"message":"Unsupported get request. Object with ID 'catalog:997957297700812:dmFyaWFibGVfYWdhaW5fMjE1' does not exist, cannot be loaded due to missing permissions, or does not support this operation. Please read the Graph API documentation at https:\/\/developers.facebook.com\/docs\/graph-api","type":"GraphMethodException","code":100,"error_subcode":33,"fbtrace_id":"ABZC11WDNjRjzNlXAWug4H6"}}
```

Old style log:
```log
10-04-2021 @ 08:21:52 - Request
uri: https://graph.facebook.com/v11.0/catalog:997957297700812:dmFyaWDDOTHVfYWdhaW5fMjE1/?fields=id,product_group{id}
headers: Array
(
    [Authorization] => **********************************************************************************************************************************************************************************************************************
)
timeout: 500

10-04-2021 @ 08:21:52 - Response
code: 400
message: Bad Request
headers: Array
(
    [content-encoding] => gzip
    [vary] => Array
        (
            [0] => Origin
            [1] => Accept-Encoding
        )

    [cross-origin-resource-policy] => cross-origin
    [x-app-usage] => {"call_count":26,"total_cputime":0,"total_time":3}
    [x-fb-rlafr] => 0
    [content-type] => application/json; charset=UTF-8
    [www-authenticate] => OAuth "Facebook Platform" "invalid_request" "Unsupported get request. Object with ID 'catalog:997957297700812:dmFyaWFibGVfYWdhaW5fMjE1' does not exist, cannot be loaded due to missing permissions, or does not support this operation. Please read the Graph API documentation at https://developers.facebook.com/docs/graph-api"
    [access-control-allow-origin] => *
    [facebook-api-version] => v11.0
    [strict-transport-security] => max-age=15552000; preload
    [pragma] => no-cache
    [cache-control] => no-store
    [expires] => Sat, 01 Jan 2000 00:00:00 GMT
    [x-fb-request-id] => AfBRGQvvXdP1szYiH302_Ic
    [x-fb-trace-id] => CgwCNj8AO1D
    [x-fb-rev] => 1004497277
    [x-fb-debug] => IYFFNxXAh7G0ixd8HMkUHrRBfjPcgkan7gjO5uVtKET05rBoSILAew1nmwpjZ1n4oLXygqKaR1X4uvq+2+CG8g==
    [date] => Mon, 04 Oct 2021 08:21:52 GMT
    [alt-svc] => h3=":443"; ma=3600, h3-29=":443"; ma=3600,h3-27=":443"; ma=3600
    [content-length] => 322
)
body: {"error":{"message":"Unsupported get request. Object with ID 'catalog:997957297700812:dmFyaWFibGVfYWdhaW5fMjE1' does not exist, cannot be loaded due to missing permissions, or does not support this operation. Please read the Graph API documentation at https:\/\/developers.facebook.com\/docs\/graph-api","type":"GraphMethodException","code":100,"error_subcode":33,"fbtrace_id":"AfBRGQvvXdP1szYiH302_Ic"}}
```

- [ ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
1. Enable logs.
2. Create and sync product ( variable for more logs ) on master and observe logs.
3. Create and sync product ( variable for more logs ) on this branch and observe logs.

Any operation that calls API is logged so by just spending some time in the plugin we can see the effect of the new logger format.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
New - Hide headers in logs for better visibiltiy.
<!-- See [previous releases](../../releases) for more examples. -->
