### PR TITLE
Track batched feed generation time.

### DIFF
--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -29,11 +29,32 @@ class Tracker {
 	const TRANSIENT_WCTRACKER_LIFE_TIME = 2 * WEEK_IN_SECONDS;
 
 	/**
-	 * Transient key name; how long it took to generate the most recent feed file, or zero if it failed.
+	 * Transient key name; how long it took to generate the most recent feed file, or minus one if it failed.
 	 *
 	 * @var string
 	 */
 	const TRANSIENT_WCTRACKER_FEED_GENERATION_TIME = 'facebook_for_woocommerce_wctracker_feed_generation_time';
+
+	/**
+	 * Transient key name; how long it took to generate already generated batches.
+	 *
+	 * @var string
+	 */
+	const TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_TIME = 'facebook_for_woocommerce_wctracker_feed_generation_batch_time';
+
+	/**
+	 * Transient key name; how much wall ( clock ) time it took to generate the feed file.
+	 *
+	 * @var string
+	 */
+	const TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_WALL_TIME = 'facebook_for_woocommerce_wctracker_feed_generation_batch_wall_time';
+
+	/**
+	 * Transient key name; the time when was the batched feed generation started.
+	 *
+	 * @var string
+	 */
+	const TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_WALL_START_TIME = 'facebook_for_woocommerce_wctracker_feed_generation_batch_wall_time';
 
 	/**
 	 * Transient key name; true if feed has been requested by Facebook.
@@ -103,12 +124,26 @@ class Tracker {
 		$data['extensions']['facebook-for-woocommerce']['messenger-enabled'] = wc_bool_to_string( $messenger_enabled );
 
 		/**
-		 * How long did the last feed generation take (or did it fail - 0)?
+		 * How long did the last feed generation take (or did it fail - 0)? This counts just the time when the batches have been generated.
+		 * It does not take into account the time between the batches.
 		 *
 		 * @since 2.6.0
 		 */
 		$feed_generation_time = get_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_TIME );
 		$data['extensions']['facebook-for-woocommerce']['feed-generation-time'] = floatval( $feed_generation_time );
+
+		/**
+		 * How long did the last feed generation take in wall time. This is the whole duration. Batches plus time in between.
+		 *
+		 * @since x.x.x
+		 */
+		if ( facebook_for_woocommerce()->get_integration()->is_new_style_feed_generation_enabled() ) {
+			$feed_generation_batch_wall_time = intval( get_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_WALL_TIME ) );
+		} else {
+			// For old feed generator this is the same thing $feed_generation_time because the process is done in one step.
+			$feed_generation_batch_wall_time = intval( $feed_generation_time );
+		}
+		$data['extensions']['facebook-for-woocommerce']['feed-generation-wall-time'] = $feed_generation_batch_wall_time;
 
 		/**
 		 * Has the feed file been requested since the last snapshot?
@@ -156,6 +191,58 @@ class Tracker {
 	 */
 	public function track_feed_file_generation_time( $time_in_seconds ) {
 		set_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_TIME, $time_in_seconds, self::TRANSIENT_WCTRACKER_LIFE_TIME );
+	}
+
+	/**
+	 * Reset  the feed generation in batch time counter.
+	 *
+	 * @since x.x.x
+	 */
+	public function reset_batch_generation_time() {
+		// Reset the main counter.
+		$this->track_feed_file_generation_time( -1 );
+		set_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_TIME, 0, self::TRANSIENT_WCTRACKER_LIFE_TIME );
+		set_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_WALL_TIME, 0, self::TRANSIENT_WCTRACKER_LIFE_TIME );
+		set_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_WALL_START_TIME, time(), self::TRANSIENT_WCTRACKER_LIFE_TIME );
+	}
+
+	/**
+	 * Add time to batch feed_generation_time.
+	 * This accumulates time over all of the calculated feed batches.
+	 *
+	 * @param float $time_in_seconds Time to add to the generation time(in seconds).
+	 * @since x.x.x
+	 */
+	public function increment_batch_generation_time( $time_in_seconds ) {
+		$tracked_generation_time = floatval( get_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_TIME ) );
+		set_transient(
+			self::TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_TIME,
+			floatval( $time_in_seconds ) + $tracked_generation_time,
+			self::TRANSIENT_WCTRACKER_LIFE_TIME
+		);
+	}
+
+	/**
+	 * Save batch generation time.
+	 *
+	 * This is the last step in batch feed generation time tracking.
+	 * The accumulated time value is copied to the main transient
+	 * that is later used by the tracking code to track feed generation time.
+	 *
+	 * @since x.x.x
+	 */
+	public function save_batch_generation_time() {
+		$this->track_feed_file_generation_time(
+			get_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_TIME )
+		);
+
+		$start = intval( get_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_WALL_START_TIME ) );
+		$end   = time();
+		set_transient(
+			self::TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_WALL_TIME,
+			$end - $start,
+			self::TRANSIENT_WCTRACKER_LIFE_TIME
+		);
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add tracking of batched feed generation time.

Because the new feed generator generates the feed-in batches we need to modify how we are collecting elapsed time. This PR adds an accumulator value that sums all of the batches generation time for one feed generation:
`TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_TIME`
This is later used to populate ( when the generation process ends ) the
`TRANSIENT_WCTRACKER_FEED_GENERATION_TIME` This is the transient that is used ( also for the old feed generator ) by the tracking code to colled the feed generation time.
Collecting just this value is not enough for the new tracking.  In addition to calculating how much time it took to generate the feed batches we also need to collect how long the whole process took, start to finish, including the time between the batches. 
To achieve this we are using `TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_WALL_TIME` and `TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_WALL_START_TIME`. They are later used by the tracker code to populate the:
```PHP
['extensions']['facebook-for-woocommerce']['feed-generation-wall-time']
```
property.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
1. Trigger the feed generation with: `wc_facebook_regenerate_feed` action - should be in pending.
2. Using wp wc tracker snapshot --format=json check if the new field `feed-generation-wall-time` is picked up in the snapshot - it should be the same ( minus fractional part ) as `feed-generation-time`.
3. Change the setting and enable 'Experimental! Enable new style...`
![image](https://user-images.githubusercontent.com/17271089/138667858-9b2a38a7-cebb-468c-8761-44377495d0c9.png)
4. Trigger the feed generation again.
5. Check again the snapshot data to see if the value has changed. Depending on the number of products ( the more the better ) the `feed-generation-wall-time` will be bigger and bigger compared to `feed-generation-time`.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
Dev - Collect feed generation wall time in tracking.
<!-- See [previous releases](../../releases) for more examples. -->
