### PR TITLE
Check for keys before trying to access them.

### DIFF
--- a/includes/Feed/FeedConfigurationDetection.php
+++ b/includes/Feed/FeedConfigurationDetection.php
@@ -19,7 +19,7 @@ class FeedConfigurationDetection {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( Heartbeat::DAILY, array( $this, 'track_data_source_feed_tracker_info' ) );
+		add_action( 'admin_init', array( $this, 'track_data_source_feed_tracker_info' ) );
 	}
 
 	/**
@@ -78,7 +78,7 @@ class FeedConfigurationDetection {
 		 * If one has the same ID as $integration_feed_id, we use that.
 		 * Otherwise we pick the one that was most recently updated.
 		 */
-		$active_feed_metadata = null;
+		$active_feed_metadata = array();
 		foreach ( $feed_nodes as $feed ) {
 			$metadata = $this->get_feed_metadata( $feed['id'], $graph_api );
 
@@ -97,8 +97,20 @@ class FeedConfigurationDetection {
 			}
 		}
 
-		$active_feed['created-time']  = gmdate( 'Y-m-d H:i:s', strtotime( $active_feed_metadata['created_time'] ) );
-		$active_feed['product-count'] = $active_feed_metadata['product_count'];
+		if ( empty( $active_feed_metadata ) ) {
+			// No active feed available, we don't have data to collect.
+			$info['active-feed'] = null;
+			return $info;
+		}
+
+		$active_feed = array();
+		if ( array_key_exists( 'created_time', $active_feed_metadata ) ) {
+			$active_feed['created-time'] = gmdate( 'Y-m-d H:i:s', strtotime( $active_feed_metadata['created_time'] ) );
+		}
+
+		if ( array_key_exists( 'product_count', $active_feed_metadata ) ) {
+			$active_feed['product-count'] = $active_feed_metadata['product_count'];
+		}
 
 		/*
 		 * Upload schedule settings can be in two keys:
@@ -118,9 +130,9 @@ class FeedConfigurationDetection {
 
 		$info['active-feed'] = $active_feed;
 
-		$latest_upload = $active_feed_metadata['latest_upload'];
 		if ( array_key_exists( 'latest_upload', $active_feed_metadata ) ) {
-			$upload = array();
+			$latest_upload = $active_feed_metadata['latest_upload'];
+			$upload        = array();
 
 			if ( array_key_exists( 'end_time', $latest_upload ) ) {
 				$upload['end-time'] = gmdate( 'Y-m-d H:i:s', strtotime( $latest_upload['end_time'] ) );

--- a/includes/Feed/FeedConfigurationDetection.php
+++ b/includes/Feed/FeedConfigurationDetection.php
@@ -19,7 +19,7 @@ class FeedConfigurationDetection {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'admin_init', array( $this, 'track_data_source_feed_tracker_info' ) );
+		add_action( Heartbeat::DAILY, array( $this, 'track_data_source_feed_tracker_info' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes PHP warnings and declutters the debug.log file.

Fixes #2045

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The code was trying to access array keys that weren't there. This was happening when the user had no feed configuration in the Facebook Business Manager.

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
1. Connect the plugin.
2. Trigger the `get_data_source_feed_tracker_info` method manually. 
4. Check the debug.log file.
3. Go to the business manager and remove the feed configuration.
2. Trigger again the `get_data_source_feed_tracker_info` method manually
3. Check the debug.log file again and confirm that we don't see Warnings from #2045 ( line numbers are now different in case there are Issues )

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
> Fix - Adjust tracker fetching logic to prevent PHP Warnings.
<!-- See [previous releases](../../releases) for more examples. -->
