### PR TITLE
Add compatibility with the WooCommerce checkout block.

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -130,6 +130,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'inject_purchase_event' ) );
 			add_action( 'woocommerce_thankyou', array( $this, 'inject_purchase_event' ), 40 );
 
+			// Checkout update order meta from the Checkout Block.
+			add_action( '__experimental_woocommerce_blocks_checkout_update_order_meta', array( $this, 'inject_order_meta_event_for_checkout_block_flow' ) );
+
 			// TODO move this in some 3rd party plugin integrations handler at some point {FN 2020-03-20}
 			add_action( 'wpcf7_contact_form', array( $this, 'inject_lead_event_hook' ), 11 );
 		}
@@ -935,6 +938,26 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			// mark the order as tracked
 			$order->update_meta_data( $purchase_tracked_meta, 'yes' );
+			$order->save_meta_data();
+		}
+
+		/**
+		 * Inject order meta gor WooCommerce Blocks flow.
+		 *
+		 * @internal
+		 *
+		 *  @param WC_Order $order Order object.
+		 */
+		public function inject_order_meta_event_for_checkout_block_flow( $order ) {
+
+			$event_name = 'Purchase';
+
+			if ( ! $this->is_pixel_enabled() || $this->pixel->is_last_event( $event_name ) ) {
+				return;
+			}
+
+			$order_placed_meta = '_wc_' . facebook_for_woocommerce()->get_id() . '_order_placed';
+			$order->update_meta_data( $order_placed_meta, 'yes' );
 			$order->save_meta_data();
 		}
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -981,26 +981,6 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		}
 
 
-		/**
-		 * Triggers a Purchase event.
-		 *
-		 * Duplicate of {@see \WC_Facebookcommerce_EventsTracker::inject_purchase_event()}
-		 *
-		 * TODO remove this deprecated method by version 2.0.0 or by March 2020 {FN 2020-03-20}
-		 *
-		 * @internal
-		 * @deprecated since 1.11.0
-		 *
-		 * @param int $order_id order identifier
-		 */
-		public function inject_gateway_purchase_event( $order_id ) {
-
-			wc_deprecated_function( __METHOD__, '1.11.0', __CLASS__ . '::inject_purchase_event()' );
-
-			$this->inject_purchase_event( $order_id );
-		}
-
-
 		/** Contact Form 7 Support **/
 		public function inject_lead_event_hook() {
 			add_action( 'wp_footer', array( $this, 'inject_lead_event' ), 11 );

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -942,9 +942,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		}
 
 		/**
-		 * Inject order meta gor WooCommerce Blocks flow.
+		 * Inject order meta gor WooCommerce Checkout Blocks flow.
+		 * The blocks flow does not trigger the woocommerce_checkout_update_order_meta so we can't rely on it.
+		 * The Checkout Block has its own ( so far ) experimental hook that allows us to inject the meta at
+		 * the appropriate moment: __experimental_woocommerce_blocks_checkout_update_order_meta.
 		 *
-		 * @internal
+		 *  @since x.x.x
 		 *
 		 *  @param WC_Order $order Order object.
 		 */


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5008 

- [X] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Add order meta required by the Purchase event flow. When the Checkout Block is used we need to use `__experimental_woocommerce_blocks_checkout_update_order_meta` to inject FB purchase order meta as the `woocommerce_checkout_update_order_meta` is not available.

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
1. Using Checkout block purchase a product
2. Verify that the purchase was tracked.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
Add - Purchase event tracking for the WooCommerce Checkout block.
<!-- See [previous releases](../../releases) for more examples. -->
