### PR TITLE
Release/2.6.6

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-2021-xx-xx - version 2.6.6
+2021-11-03 - version 2.6.6
 * New - Memory improved feed generation process. #2099
 * New - Add compatibility with the WooCommerce checkout block. #2095
 * New - Track batched feed generation time in the tracker snapshots. #2104

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,15 @@
 *** Facebook for WooCommerce Changelog ***
 
+2021-xx-xx - version 2.6.6
+* New - Memory improved feed generation process. #2099
+* New - Add compatibility with the WooCommerce checkout block. #2095
+* New - Track batched feed generation time in the tracker snapshots. #2104
+* New - Track usage of the new style feed generator in the tracker snapshots. #2103
+* New - Hide headers in logs for better visibility. #2093
+* Dev - Update composer dependencies. #2090
+* New - Add no synchronization reason to the product edit screen in the Facebook meta box. #1937
+* Fix - Use published variations only for the default variation. #2091
+
 2021-09-16 - version 2.6.5
 * Fix - Incorrect `is_readable()` usage when loading Integration classes.
 * Tweak - WC 5.7 compatibility.

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -947,7 +947,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * The Checkout Block has its own ( so far ) experimental hook that allows us to inject the meta at
 		 * the appropriate moment: __experimental_woocommerce_blocks_checkout_update_order_meta.
 		 *
-		 *  @since x.x.x
+		 *  @since 2.6.6
 		 *
 		 *  @param WC_Order $order Order object.
 		 */

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1457,7 +1457,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * Determines if there is a matching variation for the default attributes.
 	 * Select closest matching if best can't be found.
 	 *
-	 * @since x.x.x
+	 * @since 2.6.6
 	 * The algorithm only considers the variations that already have been synchronized to the catalog successfully.
 	 *
 	 * @since 2.1.2
@@ -3196,7 +3196,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/**
 	 * Determines whether debug mode is enabled.
 	 *
-	 * @since x.x.x
+	 * @since 2.6.6
 	 *
 	 * @return bool
 	 */
@@ -3209,7 +3209,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * For a typical troubleshooting session the request headers bring zero value except making the log unreadable.
 	 * They will be disabled by default. Enabling them will require setting an option in the options table.
 	 *
-	 * @since x.x.x
+	 * @since 2.6.6
 	 *
 	 */
 	public function are_headers_requested_for_debug() {

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,7 +11,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 2.6.5
+ * Version: 2.6.6
  * Text Domain: facebook-for-woocommerce
  * Tested up to: 5.8
  * WC requires at least: 3.5.0
@@ -33,7 +33,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '2.6.5'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '2.6.6'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.0.0';

--- a/includes/Admin/Product_Sync_Meta_Box.php
+++ b/includes/Admin/Product_Sync_Meta_Box.php
@@ -7,7 +7,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class responsible for display and operations of product sync status metabox.
  *
- * @since x.x.x
+ * @since 2.6.6
  */
 class Product_Sync_Meta_Box {
 
@@ -44,7 +44,7 @@ class Product_Sync_Meta_Box {
 	/**
 	 * Renders the content of the product meta box.
 	 *
-	 * @since x.x.x
+	 * @since 2.6.6
 	 */
 	public static function output() {
 		global $post;

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -143,7 +143,7 @@ class Feed {
 	 * @internal
 	 *
 	 * @since 1.11.0
-	 * @since x.x.x Enable new feed generation code if requested.
+	 * @since 2.6.6 Enable new feed generation code if requested.
 	 */
 	public function regenerate_feed() {
 		// Maybe use new ( experimental ), feed generation framework.

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -135,7 +135,7 @@ class Tracker {
 		/**
 		 * How long did the last feed generation take in wall time. This is the whole duration. Batches plus time in between.
 		 *
-		 * @since x.x.x
+		 * @since 2.6.6
 		 */
 		if ( facebook_for_woocommerce()->get_integration()->is_new_style_feed_generation_enabled() ) {
 			$feed_generation_batch_wall_time = intval( get_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_WALL_TIME ) );
@@ -174,7 +174,7 @@ class Tracker {
 		/**
 		 * Detect if the user has enabled the new experimental feed generator feature.
 		 *
-		 * @since x.x.x
+		 * @since 2.6.6
 		 */
 		$data['extensions']['facebook-for-woocommerce']['new-feed-generator-enabled'] = wc_bool_to_string( facebook_for_woocommerce()->get_integration()->is_new_style_feed_generation_enabled() );
 
@@ -196,7 +196,7 @@ class Tracker {
 	/**
 	 * Reset  the feed generation in batch time counter.
 	 *
-	 * @since x.x.x
+	 * @since 2.6.6
 	 */
 	public function reset_batch_generation_time() {
 		// Reset the main counter.
@@ -211,7 +211,7 @@ class Tracker {
 	 * This accumulates time over all of the calculated feed batches.
 	 *
 	 * @param float $time_in_seconds Time to add to the generation time(in seconds).
-	 * @since x.x.x
+	 * @since 2.6.6
 	 */
 	public function increment_batch_generation_time( $time_in_seconds ) {
 		$tracked_generation_time = floatval( get_transient( self::TRANSIENT_WCTRACKER_FEED_GENERATION_BATCH_TIME ) );
@@ -229,7 +229,7 @@ class Tracker {
 	 * The accumulated time value is copied to the main transient
 	 * that is later used by the tracking code to track feed generation time.
 	 *
-	 * @since x.x.x
+	 * @since 2.6.6
 	 */
 	public function save_batch_generation_time() {
 		$this->track_feed_file_generation_time(

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -368,7 +368,7 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 		/**
 		 * Prepare a fresh empty temporary feed file with the header row.
 		 *
-		 * @since x.x.x
+		 * @since 2.6.6
 		 *
 		 * @throws Framework\SV_WC_Plugin_Exception We can't open the file or the file is not writable.
 		 * @return resource A file pointer resource.
@@ -396,7 +396,7 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 		/**
 		 * Write products feed into a file.
 		 *
-		 * @since x.x.x
+		 * @since 2.6.6
 		 *
 		 * @return void
 		 */
@@ -438,7 +438,7 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 		 * Rename temporary feed file into the final feed file.
 		 * This is the last step fo the feed generation procedure.
 		 *
-		 * @since x.x.x
+		 * @since 2.6.6
 		 *
 		 * @return void
 		 */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,16 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
+= 2.6.6 - 2021-xx-xx =
+* New - Memory improved feed generation process. #2099
+* New - Add compatibility with the WooCommerce checkout block. #2095
+* New - Track batched feed generation time in the tracker snapshots. #2104
+* New - Track usage of the new style feed generator in the tracker snapshots. #2103
+* New - Hide headers in logs for better visibility. #2093
+* Dev - Update composer dependencies. #2090
+* New - Add no synchronization reason to the product edit screen in the Facebook meta box. #1937
+* Fix - Use published variations only for the default variation. #2091
+
 = 2.6.5 - 2021-09-16 =
 * Fix - Incorrect `is_readable()` usage when loading Integration classes.
 * Tweak - WC 5.7 compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 5.8
-Stable tag: 2.6.5
+Stable tag: 2.6.6
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later
@@ -39,7 +39,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= 2.6.6 - 2021-xx-xx =
+= 2.6.6 - 2021-11-03 =
 * New - Memory improved feed generation process. #2099
 * New - Add compatibility with the WooCommerce checkout block. #2095
 * New - Track batched feed generation time in the tracker snapshots. #2104


### PR DESCRIPTION
* New - Memory improved feed generation process. #2099
* New - Add compatibility with the WooCommerce checkout block. #2107
* New - Track batched feed generation time in the tracker snapshots. #2104
* New - Track usage of the new style feed generator in the tracker snapshots. #2103
* New - Hide headers in logs for better visibility. #2093
* Dev - Update composer dependencies. #2090
* New - Add no synchronization reason to the product edit screen in the Facebook meta box. #1937
* Fix - Use published variations only for the default variation. #2091
