### PR TITLE
Fix parameters overloading for PHP 7.0

### DIFF
--- a/includes/Jobs/GenerateProductFeed.php
+++ b/includes/Jobs/GenerateProductFeed.php
@@ -111,7 +111,7 @@ class GenerateProductFeed extends AbstractChainedJob {
 	 * Empty function to satisfy parent class requirements.
 	 * We don't use it because we are processing the whole batch at once in process_items.
 	 */
-	protected function process_item( $product, $args ) {}
+	protected function process_item( $item, array $args ) {}
 
 	/**
 	 * Get the name/slug of the job.


### PR DESCRIPTION
Fixes #2112

- [ ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
1. Start the site with the plugin on PHP 7.0 it should not break.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
Fix - parameters overloading for PHP 7.0
<!-- See [previous releases](../../releases) for more examples. -->
