### PR TITLE
Fix typo in message retrival.

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1804,7 +1804,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	function display_error_message_from_result( $result ) {
 		$error = json_decode( $result['body'] )->error;
-		$msg   = ( 'Fatal' === $error->message && ! empty( $error->error_user_title ) ) ? $error->error_user_title : $error_message;
+		$msg   = ( 'Fatal' === $error->message && ! empty( $error->error_user_title ) ) ? $error->error_user_title : $error->message;
 		$this->display_error_message( $msg );
 	}
 


### PR DESCRIPTION
The code was fetching non-existing value for the message.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
> Fix - Fetch correct message for api errors.
<!-- See [previous releases](../../releases) for more examples. -->
