### PR TITLE
Prevent attempts to delete non existing sets.

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -128,7 +128,6 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			add_action( 'init', array( $this, 'register_custom_taxonomy' ) );
 			add_action( 'add_meta_boxes_product', array( $this, 'remove_product_fb_product_set_metabox' ), 50 );
 			add_filter( 'fb_product_set_row_actions', array( $this, 'product_set_links' ) );
-			add_filter( 'manage_edit-fb_product_set_columns', array( $this, 'manage_fb_product_set_columns' ) );
 
 			// Product Set breadcrumb filters
 			add_filter( 'woocommerce_navigation_is_connected_page', array( $this, 'is_current_page_conected_filter' ), 99, 2 );
@@ -155,6 +154,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				$this->sync_background_handler   = new \SkyVerge\WooCommerce\Facebook\Products\Sync\Background();
 				$this->configuration_detection   = new \SkyVerge\WooCommerce\Facebook\Feed\FeedConfigurationDetection();
 				$this->product_sets_sync_handler = new \SkyVerge\WooCommerce\Facebook\ProductSets\Sync();
+				$this->product_sets_admin_edit   = new SkyVerge\WooCommerce\Facebook\ProductSets\SetsEdit();
 				$this->commerce_handler          = new \SkyVerge\WooCommerce\Facebook\Commerce();
 				$this->fb_categories             = new \SkyVerge\WooCommerce\Facebook\Products\FBCategories();
 
@@ -510,22 +510,6 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			unset( $actions['view'] );
 			return $actions;
 		}
-
-
-		/**
-		 * Remove posts count column from FB Product Set custom taxonomy
-		 *
-		 * @since 2.3.0
-		 *
-		 * @param array $columns Taxonomy columns.
-		 *
-		 * @return array
-		 */
-		public function manage_fb_product_set_columns( $columns ) {
-			unset( $columns['posts'] );
-			return $columns;
-		}
-
 
 		/**
 		 * Filter WC Breadcrumbs when the page is FB Product Sets

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -437,7 +437,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		);
 
 		// Product Set hooks.
-		add_action( 'fb_wc_product_set_sync', array( $this, 'create_or_update_product_set_item' ), 99, 2 );
+		
 		add_action( 'fb_wc_product_set_delete', array( $this, 'delete_product_set_item' ), 99 );
 	}
 
@@ -1562,52 +1562,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		}
 		*/
 	}
-
-
-	/**
-	 * Create or update product set
-	 *
-	 * @since 2.3.0
-	 *
-	 * @param array $product_set_data Product Set data.
-	 * @param int   $product_set_id   Product Set Term Id.
-	 **/
-	public function create_or_update_product_set_item( $product_set_data, $product_set_id ) {
-
-		// check if exists in FB
-		$fb_product_set_id = get_term_meta( $product_set_id, self::FB_PRODUCT_SET_ID, true );
-
-		// set data and execute API call
-		$method = empty( $fb_product_set_id ) ? 'create' : 'update';
-		$id     = empty( $fb_product_set_id ) ? $this->get_product_catalog_id() : $fb_product_set_id;
-		$result = $this->check_api_result(
-			call_user_func_array(
-				array(
-					$this->fbgraph,
-					$method . '_product_set_item',
-				),
-				array(
-					$id,
-					$product_set_data,
-				)
-			)
-		);
-
-		// update product set to set FB Product Set ID
-		if ( $result && empty( $fb_product_set_id ) ) {
-
-			// decode and get ID from result body
-			$decode_result     = WC_Facebookcommerce_Utils::decode_json( $result['body'] );
-			$fb_product_set_id = $decode_result->id;
-
-			update_term_meta(
-				$product_set_id,
-				self::FB_PRODUCT_SET_ID,
-				$fb_product_set_id
-			);
-		}
-	}
-
 
 	/**
 	 * Delete product set

--- a/includes/ProductSets/SetsEdit.php
+++ b/includes/ProductSets/SetsEdit.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * The edit functionality is provided by edit-tags.php?taxonomy=fb_product_set
+ * this file extends the settings.
+ */
+
+namespace SkyVerge\WooCommerce\Facebook\ProductSets;
+
+class SetsEdit {
+	public function __construct() {
+		$this->add_hooks();
+	}
+
+	private function add_hooks() {
+		add_filter( 'manage_edit-fb_product_set_columns', array( $this, 'add_column_header' ), 20, 1 );
+		add_action( 'manage_fb_product_set_custom_column', array( $this, 'add_column_values' ), 10, 3 );
+		add_filter( 'pre_insert_term', array( $this, 'validate_term_before_insert' ), 10, 2 );
+	}
+
+	public function add_column_header( $headers ) {
+		// Remove count column.
+		unset( $headers['posts'] );
+		// Add FB id column.
+		$headers['fb_set_id'] = __( 'FB set id', 'facebook-for-woocommerce' );
+		return $headers;
+	}
+
+	/**
+	 * Set values for custom columns in user taxonomies
+	 */
+	public function add_column_values( $display, $column, $term_id ) {
+		$fb_product_set_id = get_term_meta( $term_id, \WC_Facebookcommerce_Integration::FB_PRODUCT_SET_ID, true );
+		echo $fb_product_set_id;
+
+		// if ( 'users' === $column && isset( $_GET['taxonomy'] ) ) {
+		// 	$term = get_term( $term_id, $_GET['taxonomy'] );
+		// 	echo '<a href="'.admin_url( 'users.php?user_tag='.$term->slug ).'">'.$term->count.'</a>';
+		// } elseif ( 'export' === $column ) {
+		// 	$url = wp_nonce_url( add_query_arg( [
+		// 		'eut_export_csv' => '1',
+		// 		'user_tag' => $term_id
+		// 	] ), 'eut_export_csv' );
+
+		// 	echo '<a href="'.$url.'" class="button">'.__( 'Export to CSV', 'automatewoo' ).'</a>';
+		// } else {
+		// 	echo '-';
+		// }
+	}
+
+	public function validate_term_before_insert( $term, $taxonomy ) {
+		if ( 'fb_product_set' !== $taxonomy ) {
+			return $term;
+		}
+		$wc_product_cats = empty( $_POST[ \WC_Facebookcommerce::PRODUCT_SET_META ] ) ? '' : $_POST[ \WC_Facebookcommerce::PRODUCT_SET_META ]; //phpcs:ignore
+		if ( empty( $wc_product_cats ) ) {
+			return new \WP_Error( 'missing_set_categories', __( 'Creating a product set without categories is not allowed. Please add categories to create a FB product set.', 'facebook-for-woocommerce' ) );
+		}
+
+		$product_cat_ids = array_map( 'intval', $wc_product_cats );
+
+		/*
+		 * Check if we have products for a given set of categories.
+		 */
+		$products_args = array(
+			'fields'         => 'ids',
+			'post_type'      => 'product',
+			'post_status'    => 'publish',
+			'posts_per_page' => 1, // We just need to know if we have anything, just one post is great.
+			'tax_query'      => array(
+				array(
+					'taxonomy' => 'product_cat',
+					'field'    => 'term_taxonomy_id',
+					'terms'    => $product_cat_ids,
+					'operator' => 'IN',
+				),
+			),
+		);
+
+		$product_ids = get_posts( $products_args );
+
+		if ( empty( $product_ids ) ) {
+			return new \WP_Error( 'empty_products_set', __( 'Creating a product set with categories that do not have any products is not allowed. Please select different categories combination', 'facebook-for-woocommerce' ) );
+		}
+
+		return $term;
+	}
+}

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -350,6 +350,10 @@ class Sync {
 		// Removes the Product Set if it doesn't have products.
 		if ( empty( $product_ids ) ) {
 			$fb_product_set_id = get_term_meta( $product_set_id, \WC_Facebookcommerce_Integration::FB_PRODUCT_SET_ID, true );
+			if ( empty( $fb_product_set_id ) ) {
+				// Without FB Product Set Id there is nothing to delete.
+				return;
+			}
 			update_term_meta( $product_set_id, \WC_Facebookcommerce_Integration::FB_PRODUCT_SET_ID, '' );
 			do_action( 'fb_wc_product_set_delete', $fb_product_set_id );
 			return;


### PR DESCRIPTION
When a new set gets created using categories that do not represent any products the code was detecting this empty set and interpreted it as an existing set that no longer has products. Because a set that has no products is pointless the code was trying to delete it. But in this case, the set was never created so the code was doing a delete request with an empty set id that was triggering the following error response:

```
11-09-2021 @ 13:35:11 - Response
code: 400
message: Bad Request
body: {"error":{"message":"Unsupported delete request. Please read the Graph API documentation at https://developers.facebook.com/docs/graph-api","type":"GraphMethodException","code":100,"error_subcode":33,"fbtrace_id":"APuNGdfgsdfgsfifbM0RyliCu"}}
```

- [ ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->
1. Go to Products > FB sets
2. Create a FB set using a category that is not used by any products
3. Check logs ( remember to enable logging in the plugin settings ) the error message should not be there.

### Changelog entry

<!-- Add suggested changelog entry here. For example: -->
> Fix - No empty set delete graph API calls for new empty sets.
<!-- See [previous releases](../../releases) for more examples. -->
