### PR TITLE
Replace is_ajax (deprecated in WooCommerce 6.1) with wp_doing_ajax

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -158,7 +158,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				$this->commerce_handler          = new \SkyVerge\WooCommerce\Facebook\Commerce();
 				$this->fb_categories             = new \SkyVerge\WooCommerce\Facebook\Products\FBCategories();
 
-				if ( is_ajax() ) {
+				if ( wp_doing_ajax() ) {
 					$this->ajax = new \SkyVerge\WooCommerce\Facebook\AJAX();
 				}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -976,7 +976,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 *
 		 * @see ajax_delete_fb_product()
 		 */
-		if ( ( ! is_ajax() || ! isset( $_POST['action'] ) || 'ajax_delete_fb_product' !== $_POST['action'] )
+		if ( ( ! wp_doing_ajax() || ! isset( $_POST['action'] ) || 'ajax_delete_fb_product' !== $_POST['action'] )
 			 && ! Products::published_product_should_be_synced( $product ) ) {
 
 			return;

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -130,7 +130,7 @@ class Sync {
 		}
 
 		// bail if admin and not AJAX
-		if ( is_admin() && ! is_ajax() ) {
+		if ( is_admin() && ! wp_doing_ajax() ) {
 			return;
 		}
 


### PR DESCRIPTION
- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changes proposed in this Pull Request:

This PR replaces the deprecated WC function `is_ajax()` with the suggested WP's function `wp_doing_ajax()`.

WooCommerce's `is_ajax()` function will be deprecated in version `6.1`:

https://github.com/woocommerce/woocommerce/blob/71cdcf322c972d51fa6c767a445652e74f1a6e90/plugins/woocommerce/includes/wc-deprecated-functions.php#L1129-L1139

This causes a deprecated warning in Facebook for WooCommerce:

<img width="2554" alt="Screenshot 2022-01-04 at 16 33 44" src="https://user-images.githubusercontent.com/914406/148031423-899001d4-ae08-4689-91d3-46bc1eed7ad7.png">

✏️ Note that `Facebook for WooCommerce` uses a vendor module called [skyverge/wc-plugin-framework](https://github.com/skyverge/wc-plugin-framework), and it has the deprecated `is_ajax()` function as well, so in order to test if this PR fixes the warnings we need to update the vendor's code locally, please see the steps below for more information. Also created an issue in skyverge/wc-plugin-framework#554.

### How to test the changes in this Pull Request:

1. Install [WooCommerce 6.1.0 RC 1](https://github.com/woocommerce/woocommerce/releases/tag/6.1.0-rc.1).
2. Enable debugging (`define( 'WP_DEBUG', true );`).
3. Update [skyverge/wc-plugin-framework](https://github.com/skyverge/wc-plugin-framework)'s code locally:

    ```bash
    grep --exclude-dir={.bzr,CVS,.git,.hg,.svn,.idea,.tox,node_modules} -rl 'is_ajax' ./vendor | xargs sed -I '' -e 's/is_ajax/wp_doing_ajax/g'
    ```
4. Visit any WooCommerce page and confirm that the deprecation warning is not visible.
    - Confirms using wp_doing_ajax instead of is_ajax.