### PR TITLE
Add/filter to block full batch api sync

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -713,6 +713,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		}
 
 		$default_allow_sync = true;
+		// If 'facebook_for_woocommerce_allow_full_batch_api_sync' is not used, prevent get_product_count from firing.
+		if ( ! has_filter( 'facebook_for_woocommerce_allow_full_batch_api_sync' ) ) {
+			return $default_allow_sync;
+		}
+
 		/**
 		 * Allow full batch api sync to be enabled or disabled.
 		 *

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -699,9 +699,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		/**
 		 * Block the full batch API sync.
 		 *
-		 * @param bool $allow Default value - is full batch sync allowed?
+		 * @param bool $block_sync Should the full batch API sync be blocked?
 		 *
-		 * @return boolean True if full batch sync is safe.
+		 * @return boolean True if full batch sync should be blocked.
 		 * @since x.x.x
 		 */
 		$block_sync = apply_filters(

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -694,7 +694,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 * @since 2.6.1
 	 */
 	public function allow_full_batch_api_sync() {
-		$default_allow_sync = true;
 
 		/**
 		 * Block the full batch API sync.
@@ -713,6 +712,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			return false;
 		}
 
+		$default_allow_sync = true;
 		/**
 		 * Allow full batch api sync to be enabled or disabled.
 		 *
@@ -728,7 +728,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				$default_allow_sync,
 				$this->get_product_count(),
 			),
-			'x.x.x'
+			'2.6.10'
 		);
 	}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -725,7 +725,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 * @param int $product_count Number of products in store.
 		 *
 		 * @return boolean True if full batch sync is safe.
+		 *
 		 * @since 2.6.1
+		 * @deprecated deprecated since version 2.6.10
 		 */
 		return apply_filters_deprecated(
 			'facebook_for_woocommerce_allow_full_batch_api_sync',

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -697,6 +697,23 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		$default_allow_sync = true;
 
 		/**
+		 * Block the full batch API sync.
+		 *
+		 * @param bool $allow Default value - is full batch sync allowed?
+		 *
+		 * @return boolean True if full batch sync is safe.
+		 * @since x.x.x
+		 */
+		$block_sync = apply_filters(
+			'facebook_for_woocommerce_block_full_batch_api_sync',
+			false,
+		);
+
+		if ( $block_sync ) {
+			return false;
+		}
+
+		/**
 		 * Allow full batch api sync to be enabled or disabled.
 		 *
 		 * @param bool $allow Default value - is full batch sync allowed?
@@ -705,10 +722,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 * @return boolean True if full batch sync is safe.
 		 * @since 2.6.1
 		 */
-		return apply_filters(
+		return apply_filters_deprecated(
 			'facebook_for_woocommerce_allow_full_batch_api_sync',
 			$default_allow_sync,
-			$this->get_product_count()
+			$this->get_product_count(),
+			'x.x.x'
 		);
 	}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -735,7 +735,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				$default_allow_sync,
 				$this->get_product_count(),
 			),
-			'2.6.10'
+			'2.6.10',
+			'facebook_for_woocommerce_block_full_batch_api_sync'
 		);
 	}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -724,8 +724,10 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 */
 		return apply_filters_deprecated(
 			'facebook_for_woocommerce_allow_full_batch_api_sync',
-			$default_allow_sync,
-			$this->get_product_count(),
+			array(
+				$default_allow_sync,
+				$this->get_product_count(),
+			),
 			'x.x.x'
 		);
 	}

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -217,7 +217,7 @@ class AJAX {
 	public function sync_products() {
 		// Allow opt-out of full batch-API sync, for example if store has a large number of products.
 		if ( ! facebook_for_woocommerce()->get_integration()->allow_full_batch_api_sync() ) {
-			wp_send_json_error( __( 'Full product sync disabled by filter hook `facebook_for_woocommerce_allow_full_batch_api_sync`.', 'facebook-for-woocommerce' ) );
+			wp_send_json_error( __( 'Full product sync disabled by filter.', 'facebook-for-woocommerce' ) );
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add a new filter that can be used to disable full catalog batch API sync.
The new filter is named `facebook_for_woocommerce_block_full_batch_api_sync` and it is created to replace the old filter ( I am deprecating it here ) `facebook_for_woocommerce_allow_full_batch_api_sync`.

### Rationale:

There are two issues with the old filter.

**First problem:** The parameter that it is passing is the products count. Unfortunately, this does not include variations. This is problematic for sites that have a catalog with products that have multiple variations. This means that the number we are passing to the filter does not allow the filtering code to properly gauge if the batch should be blocked or not.

**Second problem:** Is in a way related to the first one. The original filter should not pass any values ( like products count ) in the first place. It is up to the filtering code to decide what are the criteria for blocking or allowing the batch sync. It may have nothing to do with products count, therefore precalculating that value is not efficient.

### Implementation details.

If the filter is not used or returns false. The code behaves as it used to. If the filter returns `true` ( block the batch API sync ) the logic returns before applying the `facebook_for_woocommerce_allow_full_batch_api_sync`.  This way we are not wasting resources by calling unnecessarily the code that fetches the number of products. 

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

<!--- Optional --->

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

No additona filter scenario:
1. Without any additional code everything should work like it used to. The `facebook_for_woocommerce_allow_full_batch_api_sync` should be respected.

`Filter facebook_for_woocommerce_block_full_batch_api_sync` defined scenario:
1. If the filter returns `true` the full batch API sync should be blocked and the `facebook_for_woocommerce_allow_full_batch_api_sync` should not be called.

To test out the new filter following snippets can be used:

- Filter by calculating products + variations:
```php
function should_block_facebook_batch_api( $allow_full_sync ) {
	global $wpdb;
	// Disable if site has more than 5000 products with variations.
	$max_products_for_sync = 5000;

	$count = $wpdb->get_var(
		$wpdb->prepare(
			"SELECT COUNT(*) FROM $wpdb->posts WHERE ( post_type = 'product' OR post_type = 'product_variation' ) AND post_status = 'publish'"
		)
	);

	if ( $count > $max_products_for_sync ) {
		return true;
	}

	return $allow_full_sync;
}

add_filter( 'facebook_for_woocommerce_block_full_batch_api_sync', 'should_block_facebook_batch_api', 10 );
```

- Preserving the old logic ( counting just the products ):

```php
function should_block_facebook_batch_api( $allow_full_sync ) {
	// Disable if site has more than 10 products.
	$max_products_for_sync = 10;

	$products = wp_count_posts( 'product' );

	if ( $products->publish > $max_products_for_sync ) {
		return true;
	}

	return $allow_full_sync;
}

add_filter( 'facebook_for_woocommerce_block_full_batch_api_sync', 'should_block_facebook_batch_api', 10 );
```


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

* Add - Filter to block full catalog batch API sync 'facebook_for_woocommerce_block_full_batch_api_sync'.
* Update - Deprecate 'facebook_for_woocommerce_allow_full_batch_api_sync' filter.
