### PR TITLE
Bump Marketing API version from v11.0 to v12.0.

### DIFF
--- a/includes/fbgraph.php
+++ b/includes/fbgraph.php
@@ -26,7 +26,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Graph_API' ) ) :
 	 */
 	class WC_Facebookcommerce_Graph_API {
 		const GRAPH_API_URL = 'https://graph.facebook.com/';
-		const API_VERSION   = 'v11.0';
+		const API_VERSION   = 'v12.0';
 		const CURL_TIMEOUT  = 500;
 
 		/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update Facebook Marketing API to v12.0

There should be no changes in the endpoints that we use so the application should behave as it used to without any additional changes.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Use https://github.com/woocommerce/facebook-for-woocommerce/wiki/Smoke-tests for testing instructions

Make sure that the logging is enabled in the plugin. After the tests inspect the logs for errors.
The use of v12 API will be clearly visible in the endpoint url:

<img width="568" alt="image" src="https://user-images.githubusercontent.com/17271089/154799052-3bd9d617-dd59-4801-9ddf-bfa33c570cfe.png">


Everything should work as normal. There should be no errors in logs related to the changed API ( some errors can still be visible due to how the plugin work. Some of the flows need fixing. But the errors should not be releaded to the API. If in doubt log it in the PR.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with `(Fix|Add|Tweak|Update) - `, for example:
> Fix - I took care of something that wasn't working.
> Add - I added something new that's pretty cool.
> Tweak - I made a small change.
> Update - I made big changes to something that wasn't broken.

Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Update - Facebook Marketing API from v11.0 to v12.0.
