### PR TITLE
#2164-fix product title length check to account for encoding.

### DIFF
--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -349,7 +349,7 @@ class ProductValidator {
 		if ( \WC_Facebookcommerce_Utils::is_all_caps( $title ) ) {
 			throw new ProductInvalidException( __( 'Product title is all capital letters. Please change the title to sentence case in order to allow synchronization of your product.', 'facebook-for-woocommerce' ) );
 		}
-		if ( strlen( $title ) > self::MAX_TITLE_LENGTH ) {
+		if ( mb_strlen( $title, 'UTF-8' ) > self::MAX_TITLE_LENGTH ) {
 			throw new ProductInvalidException( __( 'Product title is too long. Maximum allowed length is 150 characters.', 'facebook-for-woocommerce' ) );
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2164.

* Fixed the length check logic in the validate_product_title() method. It now accounts for the title character encoding which will resolve issues with non-Latin characters.

- [x] Do the changed files pass `phpcs` checks? 


### Screenshots:

![Screenshot of product synced](https://user-images.githubusercontent.com/4209011/156571440-b5b58a7a-91c0-4fce-b534-bb32234a7340.jpg)


### Detailed test instructions:

1. Check out the PR branch.
2. Ensure you have a working FB connection.
3. Create a product (enable FB syncing), and set the title to คู่มือเครื่องสกัดน้ำผลไม้สแตนเลสเชิงพาณิชย์ (สำหรับบาร์,คาเฟ่). You should be able to sync with no issue.



### Changelog entry

> Fix - fix product title length check to account for encoding.
