### PR TITLE
Fix Scheduled job logs written to options table are never removed if job does not complete

### DIFF
--- a/includes/Jobs/CleanupSkyvergeFrameworkJobOptions.php
+++ b/includes/Jobs/CleanupSkyvergeFrameworkJobOptions.php
@@ -9,7 +9,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class CleanupSkyvergeFrameworkJobOptions
  *
- * Responsible for cleaning up old completed background sync jobs from SkyVerge background job system.
+ * Responsible for cleaning up old completed and failed background sync jobs from SkyVerge background job system.
  * Each job is represented by a row in wp_options table, and these can accumulate over time.
  *
  * Note - this is closely coupled to the SkyVerge background job system, and is essentially a patch to improve it.
@@ -29,7 +29,7 @@ class CleanupSkyvergeFrameworkJobOptions {
 	}
 
 	/**
-	 * Delete old completed product sync job rows from options table.
+	 * Delete old completed/failed product sync job rows from options table.
 	 *
 	 * Logic and database query are adapted from SV_WP_Background_Job_Handler::get_jobs().
 	 *
@@ -42,7 +42,7 @@ class CleanupSkyvergeFrameworkJobOptions {
 		/**
 		 * Query notes:
 		 * - Matching product sync job only (Products\Sync\Background class).
-		 * - Matching "completed" status by sniffing json option value.
+		 * - Matching "completed" or "failed" status by sniffing json option value.
 		 * - Order by lowest id, to delete older rows first.
 		 * - Limit number of rows (periodic task will eventually remove all).
 		 * Using `get_results` so we can limit number of items; `delete` doesn't allow this.

--- a/includes/Jobs/CleanupSkyvergeFrameworkJobOptions.php
+++ b/includes/Jobs/CleanupSkyvergeFrameworkJobOptions.php
@@ -9,7 +9,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class CleanupSkyvergeFrameworkJobOptions
  *
- * Responsible for cleaning up old completed background sync jobs from SkyVerge background job system.
+ * Responsible for cleaning up old background sync jobs from SkyVerge background job system.
  * Each job is represented by a row in wp_options table, and these can accumulate over time.
  *
  * Note - this is closely coupled to the SkyVerge background job system, and is essentially a patch to improve it.
@@ -25,7 +25,7 @@ class CleanupSkyvergeFrameworkJobOptions {
 	 */
 	public function init() {
 		// Register our cleanup routine to run regularly.
-		add_action( Heartbeat::DAILY, array( $this, 'clean_up_old_completed_options' ) );
+		add_action( Heartbeat::DAILY, array( $this, 'clean_up_old_options' ) );
 	}
 
 	/**
@@ -36,13 +36,12 @@ class CleanupSkyvergeFrameworkJobOptions {
 	 * @see SV_WP_Background_Job_Handler
 	 * @see Products\Sync\Background
 	 */
-	public function clean_up_old_completed_options() {
+	public function clean_up_old_options() {
 		global $wpdb;
 
 		/**
 		 * Query notes:
 		 * - Matching product sync job only (Products\Sync\Background class).
-		 * - Matching "completed" status by sniffing json option value.
 		 * - Order by lowest id, to delete older rows first.
 		 * - Limit number of rows (periodic task will eventually remove all).
 		 * Using `get_results` so we can limit number of items; `delete` doesn't allow this.
@@ -51,7 +50,6 @@ class CleanupSkyvergeFrameworkJobOptions {
 			"DELETE
 			FROM {$wpdb->options}
 			WHERE option_name LIKE 'wc_facebook_background_product_sync_job_%'
-			AND option_value LIKE '%\"status\":\"completed\"%'
 			ORDER BY option_id ASC
 			LIMIT 250"
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Scheduled job logs written to the options table are never removed if a job is not marked as complete. This means that jobs with other statuses are never removed, resulting in excessive options table entries. 

This PR proposes to remove all entries with the option_name wc_facebook_background_product_sync_job_% regardless of the status value.

Closes #2179.

_Replace this with a good description of your changes & reasoning._

- [ x] Do the changed files pass `phpcs` checks? 

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1.  Trigger a product sync and verify that the job has been logged in the `wp_options` table by executing the SQL command:

```
SELECT * FROM `wp_options` WHERE `option_name` LIKE 'wc_facebook_background_product_sync_job%' AND ( option_value LIKE '%\"status\":\"queued\"%' OR option_value LIKE '%\"status\":\"failed\"%' )
```

2. Run the `facebook_for_woocommerce_daily_heartbeat_cron` cron task
3.  Confirm all entries with `option_name` `wc_facebook_background_product_sync_job%` have been removed from the `wp_options` table

### Changelog entry

> Fix - Scheduled job logs written to options table are never removed if job does not complete
