### PR TITLE
Fix 2166: Use Automattic\WooCommerce\Admin\Features\Features::is_enabled.

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -17,6 +17,7 @@ use SkyVerge\WooCommerce\Facebook\Utilities\Background_Remove_Duplicate_Visibili
 use SkyVerge\WooCommerce\PluginFramework\v5_10_0 as Framework;
 use SkyVerge\WooCommerce\Facebook\ProductSync\ProductValidator as ProductSyncValidator;
 use SkyVerge\WooCommerce\Facebook\Utilities\Heartbeat;
+use Automattic\WooCommerce\Admin\Features\Features as WooAdminFeatures;
 
 if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
@@ -374,8 +375,12 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 			if ( Framework\SV_WC_Plugin_Compatibility::is_enhanced_admin_available() ) {
 
-				$is_marketing_enabled = is_callable( 'Automattic\WooCommerce\Admin\Loader::is_feature_enabled' )
-										&& Automattic\WooCommerce\Admin\Loader::is_feature_enabled( 'marketing' );
+				if (  class_exists( WooAdminFeatures::class ) ) {
+					$is_marketing_enabled =  WooAdminFeatures::is_enabled( 'marketing' );
+				} else {
+					$is_marketing_enabled = is_callable( '\Automattic\WooCommerce\Admin\Loader::is_feature_enabled' )
+						&& \Automattic\WooCommerce\Admin\Loader::is_feature_enabled( 'marketing' );
+				}
 
 				if ( $is_marketing_enabled ) {
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -76,8 +76,12 @@ class Settings {
 
 		if ( Framework\SV_WC_Plugin_Compatibility::is_enhanced_admin_available() ) {
 
-			$is_marketing_enabled = is_callable( '\Automattic\WooCommerce\Admin\Loader::is_feature_enabled' )
-									&& \Automattic\WooCommerce\Admin\Loader::is_feature_enabled( 'marketing' );
+			if (  class_exists( WooAdminFeatures::class ) ) {
+				$is_marketing_enabled =  WooAdminFeatures::is_enabled( 'marketing' );
+			} else {
+				$is_marketing_enabled = is_callable( '\Automattic\WooCommerce\Admin\Loader::is_feature_enabled' )
+					&& \Automattic\WooCommerce\Admin\Loader::is_feature_enabled( 'marketing' );
+			}
 
 			if ( $is_marketing_enabled ) {
 


### PR DESCRIPTION

### Changes proposed in this Pull Request:

Facebook for WooCommerce still makes use of the Loader::is_feature_enabled within WooCommerce Admin, this function has been [deprecated](https://github.com/woocommerce/woocommerce-admin/blob/main/src/Loader.php#L217).

Closes #2166.

This PR introduces the usage of `Automattic\WooCommerce\Admin\Features\Features::is_enabled` instead of the deprecated `WooCommerce\Admin\Loader::is_feature_enabled`.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:

1. This method is used to correctly put the Facebook admin menu in the Marketing tab and warn the user that the Fb menu has moved. The Facebook menu should still be in the marketing tab after this change with no issues or warnings.


Leave the "Changelog entry" header in place completely empty, without any summary if no changelog entry is needed.
If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.
-->
### Changelog entry

> Tweak - Use `Automattic\WooCommerce\Admin\Features\Features::is_enabled` instead of the deprecated `WooCommerce\Admin\Loader::is_feature_enabled`
