### PR TITLE
Fix Facebook doesn't show up in the new navigation

### DIFF
--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -60,7 +60,7 @@ class Settings {
 
 		add_action( 'wp_loaded', array( $this, 'save' ) );
 
-		$this->use_woo_nav = class_exists( WooAdminFeatures::class ) && class_exists( WooAdminMenu::class ) && WooAdminFeatures::is_enabled( 'navigation' );
+		$this->use_woo_nav = false;
 	}
 
 
@@ -73,6 +73,7 @@ class Settings {
 
 		$root_menu_item       = 'woocommerce';
 		$is_marketing_enabled = false;
+		$this->use_woo_nav = class_exists( WooAdminFeatures::class ) && class_exists( WooAdminMenu::class ) && WooAdminFeatures::is_enabled( 'navigation' );
 
 		if ( Framework\SV_WC_Plugin_Compatibility::is_enhanced_admin_available() ) {
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -60,7 +60,6 @@ class Settings {
 
 		add_action( 'wp_loaded', array( $this, 'save' ) );
 
-		$this->use_woo_nav = false;
 	}
 
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -72,7 +72,7 @@ class Settings {
 
 		$root_menu_item       = 'woocommerce';
 		$is_marketing_enabled = false;
-		$this->use_woo_nav = class_exists( WooAdminFeatures::class ) && class_exists( WooAdminMenu::class ) && WooAdminFeatures::is_enabled( 'navigation' );
+		$this->use_woo_nav	  = class_exists( WooAdminFeatures::class ) && class_exists( WooAdminMenu::class ) && WooAdminFeatures::is_enabled( 'navigation' );
 
 		if ( Framework\SV_WC_Plugin_Compatibility::is_enhanced_admin_available() ) {
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

If we go to WooCommerce > Settings > Advanced > Features and enable the Navigation option, Facebook doesn't show under Extensions. Instead, it shows FB Product Sets which is part of the old menu. This is because `$this->use_woo_nav ` is set too early. 

I am moving this initialization in the `add_menu_item` function, which runs on the `admin_menu` action hook.

Closes #2184.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

![Screenshot 2022-04-08 at 12 34 44](https://user-images.githubusercontent.com/4209011/162419133-9c87cab3-b84d-4403-8966-2785ee8e56e0.jpg)


### Detailed test instructions:

1. Activate the Facebook plugin
2. Go to WooCommerce > Settings > Advanced > Features and enable the Navigation option
3. View the new navigation menu and confirm Facebook is displayed under Extensions

### Changelog entry

> Fix - Issue with Facebook not displayed in the new WC navigation
