### PR TITLE
Fix - Variable products are not synced into product sets.

### DIFF
--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -357,7 +357,13 @@ class Sync {
 
 		// gets products variations
 		global $wpdb;
-		$variation_ids = $wpdb->get_results( $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = 'product_variation' AND post_parent IN (%s) ", implode( ',', $product_ids ) ) );
+
+		$sql = sprintf(
+			"SELECT ID FROM $wpdb->posts WHERE post_type = 'product_variation' AND post_parent IN (%s) ",
+			implode( ', ', array_map( 'intval', $product_ids ) )
+		);
+
+		$variation_ids = $wpdb->get_results( $sql );
 		if ( ! empty( $variation_ids ) ) {
 
 			// product_variations: add retailer id to the products filter


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Variable products do not sync correctly / fully to their category-mapped Facebook Product Sets. This happens because the variations IDs were not returned because of  SQL query string was not properly built.

Closes #1916.

The `IN` clause contained a concatenated string of product ID instead of an array of ID values. E.g.:

`SELECT ID FROM wp_posts WHERE post_type = 'product_variation' AND post_parent IN ('32,22,23,15,12');
`
Instead of:

`SELECT ID FROM wp_posts WHERE post_type = 'product_variation' AND post_parent IN (32, 22, 23, 15, 12) 
`

This PR corrects this.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

![Screenshot 2022-04-13 at 13 16 01](https://user-images.githubusercontent.com/4209011/163168854-de8f446d-885e-4a58-8bdf-2bb59c979a0e.jpg)
A set with a variable product


### Detailed test instructions:

1. Create Category 1 in WooCommerce that contains only simple products
2. Create Category 2 in WooCommerce that contains variable products or a mix of simple and variable products
3. Go to Products > FB Product Sets and create corresponding, mapped Product Sets for each of your WooCommerce test categories
4. Log in to Facebook and access the catalog
5. See that all products in Category 1 are synced correctly
6. Before this fix, Category 2 would be missing some products. With this fix, all variable products and simple products are synced correctly.

### Changelog entry

> Fix - Issue with variable products syncing to FB product sets.
