### PR TITLE
Forcing latin characters into user-agent http request header.

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -41,6 +41,8 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/** @var string the product set categories meta name */
 		const PRODUCT_SET_META = '_wc_facebook_product_cats';
 
+		/** @var string the plugin user agent name to use for HTTP calls within User-Agent header */
+		const PLUGIN_USER_AGENT_NAME = 'Facebook-for-WooCommerce';
 
 		/** @var \WC_Facebookcommerce singleton instance */
 		protected static $instance;
@@ -134,6 +136,11 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			// Product Set breadcrumb filters
 			add_filter( 'woocommerce_navigation_is_connected_page', array( $this, 'is_current_page_conected_filter' ), 99, 2 );
 			add_filter( 'woocommerce_navigation_get_breadcrumbs', array( $this, 'wc_page_breadcrumbs_filter' ), 99 );
+
+			add_filter(
+				'wc_' . WC_Facebookcommerce::PLUGIN_ID . '_http_request_args',
+				array( $this, 'force_user_agent_in_latin' )
+			);
 
 			if ( \WC_Facebookcommerce_Utils::isWoocommerceIntegration() ) {
 				require_once __DIR__ . '/vendor/autoload.php';
@@ -580,6 +587,30 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			}
 
 			return $is_conected;
+		}
+
+		/**
+		 * Filter is responsible to always set latin user agent header value, because translated plugin names
+		 * may contain characters which Facebook does not accept and return 400 response for requests with such
+		 * header values.
+		 * Applying either sanitize_title() nor remove_accents() on header value will not work for all the languages
+		 * we support translations to e.g. Hebrew is going to convert into something %d7%90%d7%a8%d7%99%d7%92 which is
+		 * not acceptable neither.
+		 *
+		 * @param array $http_request_headers - http request headers
+		 * @return array
+		 */
+		public function force_user_agent_in_latin( array $http_request_headers ) {
+			if ( isset( $http_request_headers['user-agent'] ) ) {
+				$http_request_headers['user-agent'] = sprintf(
+					'%s/%s (WooCommerce/%s; WordPress/%s)',
+					WC_Facebookcommerce::PLUGIN_USER_AGENT_NAME,
+					WC_Facebookcommerce::PLUGIN_VERSION,
+					defined( 'WC_VERSION' ) ? WC_VERSION : WC_Facebook_Loader::MINIMUM_WC_VERSION,
+					$GLOBALS['wp_version']
+				);
+			}
+			return $http_request_headers;
 		}
 
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When requesting Facebook, HTTP User-Agent header is set using plugin name, which is a subject for translation in WooCommerce. When using languages other than English, the header may receive non latin characters into it which Facebook rejects. Making User-Agent to always contain English version of extension name in it.

e.g. for Turkish language User-Agent becomes `WooCommerce-için-Facebook` which makes Facebook return 400 Bad Request in response. Doing `sanitize_title` or `remove_accent` will produce strings like `%d7%90%d7%a8%d7%99%d7%92` for languages which have no latin characters in their alphabets (Arabic, Hebrew, Cyrillic, etc.), so using these functions on the User-Agent is not a 100% fix.

Closes #2139.

### Detailed test instructions:

1. Set the site language to Turkish.
2. Connect to Facebook.
3. Return to the site after the connection is complete.
4. Note that no details are visible on Marketing > Facebook > Connection.

![147952173-8ea31560-34a9-4b80-9b65-0dd818fc0683](https://user-images.githubusercontent.com/9010963/165087566-1b5ffbf5-f3dc-4306-8730-ff0d974495c3.png)

### Changelog entry

> Fix - User-Agent to contain English extension name
