### PR TITLE
Fix - clear out wc_facebook_external_business_id option on disconnect.

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -421,7 +421,6 @@ class Connection {
 
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, '' );
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, '' );
-		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, '' );
 
 		facebook_for_woocommerce()->get_integration()->update_product_catalog_id( '' );
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -417,12 +417,16 @@ class Connection {
 		$this->update_ad_account_id( '' );
 		$this->update_instagram_business_id( '' );
 		$this->update_commerce_merchant_settings_id( '' );
+		$this->update_external_business_id('');
 
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID, '' );
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, '' );
+		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, '' );
+
 		facebook_for_woocommerce()->get_integration()->update_product_catalog_id( '' );
 
 		delete_transient( 'wc_facebook_business_configuration_refresh' );
+
 	}
 
 
@@ -688,7 +692,7 @@ class Connection {
 
 			$external_id = get_option( self::OPTION_EXTERNAL_BUSINESS_ID );
 
-			if ( ! is_string( $external_id ) ) {
+			if ( ! is_string( $external_id ) || empty( $external_id ) ) {
 
 				/**
 				 * Filters the shop's business external ID.
@@ -708,7 +712,8 @@ class Connection {
 
 				$external_id = uniqid( sprintf( '%s-', $external_id ), false );
 
-				update_option( self::OPTION_EXTERNAL_BUSINESS_ID, $external_id );
+				$this->update_external_business_id( $external_id );
+
 			}
 
 			$this->external_business_id = $external_id;
@@ -1146,6 +1151,18 @@ class Connection {
 		update_option( self::OPTION_PAGE_ACCESS_TOKEN, is_string( $value ) ? $value : '' );
 	}
 
+	/**
+	 * Stores the given external business id.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $value external business id
+	 */
+	public function update_external_business_id( $value ) {
+
+		update_option( self::OPTION_EXTERNAL_BUSINESS_ID, is_string( $value ) ? $value : '' );
+	}
+
 
 	/**
 	 * Determines whether the site is connected.
@@ -1304,7 +1321,7 @@ class Connection {
 		}
 
 		if ( ! empty( $values->business_id ) ) {
-			update_option( self::OPTION_EXTERNAL_BUSINESS_ID, sanitize_text_field( $values->business_id ) );
+			$this->update_external_business_id( sanitize_text_field( $values->business_id ) );
 			$log_data[ self::OPTION_EXTERNAL_BUSINESS_ID ] = sanitize_text_field( $values->business_id );
 		}
 


### PR DESCRIPTION

### Changes proposed in this Pull Request:

When FB is disconnected the wc_facebook_external_business_id option value isn't cleared. This creates issues with the reconnection flow. 

I have added a method to modify the wc_facebook_external_business_id option to keep consistent with the other options. I also noticed that we were not regenerating the external_business_id if the option was empty. This is a problem if the value of the option is set to an empty string, the user would not be able to complete the connection flow.

Closes #1990.



- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1. Check out the branch, and complete the FB connection setup.
2. Take note of the FB external ID options (/wp-admin/options.php).
3. Now disconnect from FB. Check the  wc_facebook_external_business_id, the value should be updated.
4. Complete FB connection setup again -- preferably with a different FB account. Connection should be successful.

### Changelog entry

Fix - clear out wc_facebook_external_business_id option on disconnect.
