### PR TITLE
Fix product custom attribute value with semicolon breaks sync.

### DIFF
--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -312,9 +312,30 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 				 * @param string $value Attribute value.
 				 * @return string Return the desired replacement string.
 				 */
-				$attribute_value = str_replace(
+				$val = str_replace(
 					',',
 					apply_filters( 'facebook_for_woocommerce_variant_attribute_comma_replacement', ' ', $val ),
+					$val
+				);
+				/**
+				 * Filter: facebook_for_woocommerce_variant_attribute_semicolon_replacement
+				 *
+				 * The Facebook API expects a comma-separated list of attributes in `additional_variant_attribute` field.
+				 * When encoded into JSON, attribute value with semicolons will break the format.
+				 * URL encoded semicolon version will remain so (%3A) at Facebook side after the sync.
+				 * This means that WooCommerce product attributes values should avoid the comma (`:`) character.
+				 * Facebook for WooCommerce replaces any `:` with a space by default.
+				 * This filter allows a site to provide a different replacement string.
+				 *
+				 * @since x.x.x
+				 *
+				 * @param string $replacement The default replacement string (`:`).
+				 * @param string $value Attribute value.
+				 * @return string Return the desired replacement string.
+				 */
+				$attribute_value = str_replace(
+					':',
+					apply_filters( 'facebook_for_woocommerce_variant_attribute_semicolon_replacement', ' ', $val ),
 					$val
 				);
 				$attributes[]    = $key . ':' . $attribute_value;

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -312,33 +312,13 @@ class Background extends Framework\SV_WP_Background_Job_Handler {
 				 * @param string $value Attribute value.
 				 * @return string Return the desired replacement string.
 				 */
-				$val = str_replace(
+				$attribute_value = str_replace(
 					',',
 					apply_filters( 'facebook_for_woocommerce_variant_attribute_comma_replacement', ' ', $val ),
 					$val
 				);
-				/**
-				 * Filter: facebook_for_woocommerce_variant_attribute_semicolon_replacement
-				 *
-				 * The Facebook API expects a comma-separated list of attributes in `additional_variant_attribute` field.
-				 * When encoded into JSON, attribute value with semicolons will break the format.
-				 * URL encoded semicolon version will remain so (%3A) at Facebook side after the sync.
-				 * This means that WooCommerce product attributes values should avoid the comma (`:`) character.
-				 * Facebook for WooCommerce replaces any `:` with a space by default.
-				 * This filter allows a site to provide a different replacement string.
-				 *
-				 * @since x.x.x
-				 *
-				 * @param string $replacement The default replacement string (`:`).
-				 * @param string $value Attribute value.
-				 * @return string Return the desired replacement string.
-				 */
-				$attribute_value = str_replace(
-					':',
-					apply_filters( 'facebook_for_woocommerce_variant_attribute_semicolon_replacement', ' ', $val ),
-					$val
-				);
-				$attributes[]    = $key . ':' . $attribute_value;
+				/** Force replacing , and : characters if those were not cleaned up by filters */
+				$attributes[]    = $key . ':' . str_replace( array( ',', ':' ), ' ', $attribute_value );
 			}
 
 			$data['additional_variant_attribute'] = implode( ',', $attributes );


### PR DESCRIPTION
When variable product has custom attribute with semicolon in its values, product sync for Facebook fails.

### Changes proposed in this Pull Request:

Introduce a filter for custom attribute value to remove semicolon and allow to redefine such a behaviour.

Closes #2063.

### Detailed test instructions:

1. Create variable product with at least one custom attribute which has value with semicolon in it.

<img width="1223" alt="Edit_product_“V-Neck_T-Shirt_UTF8_Compatible”_‹_WordPress-Facebook_—_WordPress" src="https://user-images.githubusercontent.com/9010963/165276730-8f53542c-c85f-4131-9ec9-9de5244ca965.png">

2. Sync product to Facebook and see product was not synced, but WooCommerce > Status > Logs has Facebook-for-woocommerce log with records about sync failure.

<img width="1524" alt="Cursor_and_WooCommerce_status_‹_WordPress-Facebook_—_WordPress" src="https://user-images.githubusercontent.com/9010963/165276915-aeec8cca-5cb9-425c-9fc1-94d3af3598d9.png">

3. Pull the new code and repeat the procedure. You should now see the product appear to Facebook with no semicolon in attribute value and no errors in corresponding logs appear.

<img width="1523" alt="WooCommerce_status_‹_WordPress-Facebook_—_WordPress" src="https://user-images.githubusercontent.com/9010963/165277153-be728305-250d-4d75-8e69-760059467403.png">

<img width="1066" alt="_4__Facebook" src="https://user-images.githubusercontent.com/9010963/165277189-6cdba312-cfbc-4a21-a060-5dcd08268347.png">

### Changelog entry

> Fix - remove semicolon from custom attribute value
