### PR TITLE
Fix - Trigger InitiateCheckout event when site uses checkout block

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -126,6 +126,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			// InitiateCheckout events
 			add_action( 'woocommerce_after_checkout_form', array( $this, 'inject_initiate_checkout_event' ) );
+			// InitiateCheckout events for checkout block.
+			add_action( 'woocommerce_blocks_checkout_enqueue_data', array( $this, 'inject_initiate_checkout_event' ) );
 			// Purchase and Subscribe events
 			add_action( 'woocommerce_checkout_update_order_meta', array( $this, 'inject_purchase_event' ) );
 			add_action( 'woocommerce_thankyou', array( $this, 'inject_purchase_event' ), 40 );
@@ -511,7 +513,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			} else {
 				$content_type = 'product';
 			}
-			
+
 			if ( WC_Facebookcommerce_Utils::is_variable_type( $product->get_type() ) ) {
                             $product_price = $product->get_variation_price( 'min' );
                         } else {
@@ -900,7 +902,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			foreach ( $order->get_items() as $item ) {
 
 				$product = $item->get_product();
-				
+
 				if ( $product ) {
 					$product_ids[]   = \WC_Facebookcommerce_Utils::get_fb_content_ids( $product );
 					$product_names[] = $product->get_name();
@@ -1050,7 +1052,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			} catch ( Framework\SV_WC_API_Exception $exception ) {
 
 				$success = false;
-				
+
 				facebook_for_woocommerce()->log( 'Could not send Pixel event: ' . $exception->getMessage() );
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Facebook for Woocommerce plugin should trigger 'InitiateCheckout' when entering the /checkout/ page. But it shows only page views in the case of a Checkout page that uses a WC Checkout block.

Closes #2048.

I am running inject_initiate_checkout_event on the `woocommerce_blocks_checkout_enqueue_data` action hook as well now -- forcing initiate checkout in case of check out page that uses the WC checkout block.

### Detailed test instructions:
1. Install the WooCommerce Blocks extension and add the checkout block to a page.
2. Navigate to the newly created checkout page. Check if the `InitiateCheckout` is triggered using the  Google Chrome Facebook Pixel helper extension. 

### Additional details:

I am aware we're still using the deprecated `__experimental_woocommerce_blocks_checkout_update_order_meta` action which might throw a warning. I am looking at that issue separately - https://github.com/woocommerce/facebook-for-woocommerce/issues/2123

### Changelog entry

> Fix - Trigger InitiateCheckout event when site uses checkout block.