### PR TITLE
Tweak - Update the __experimental_woocommerce_blocks_checkout_update_order_meta action to woocommerce_blocks_checkout_update_order_meta

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -131,7 +131,14 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			add_action( 'woocommerce_thankyou', array( $this, 'inject_purchase_event' ), 40 );
 
 			// Checkout update order meta from the Checkout Block.
-			add_action( '__experimental_woocommerce_blocks_checkout_update_order_meta', array( $this, 'inject_order_meta_event_for_checkout_block_flow' ) );
+			if ( version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '7.2.0', '>=' ) ) {
+				add_action( 'woocommerce_store_api_checkout_update_order_meta', array( $this, 'inject_order_meta_event_for_checkout_block_flow' ), 10, 1 );
+			} elseif ( version_compare( \Automattic\WooCommerce\Blocks\Package::get_version(), '6.3.0', '>=' ) ) {
+				add_action( 'woocommerce_blocks_checkout_update_order_meta', array( $this, 'inject_order_meta_event_for_checkout_block_flow' ), 10, 1 );
+			} else {
+				add_action( '__experimental_woocommerce_blocks_checkout_update_order_meta', array( $this, 'inject_order_meta_event_for_checkout_block_flow' ), 10, 1 );
+			}
+
 
 			// TODO move this in some 3rd party plugin integrations handler at some point {FN 2020-03-20}
 			add_action( 'wpcf7_contact_form', array( $this, 'inject_lead_event_hook' ), 11 );
@@ -511,7 +518,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			} else {
 				$content_type = 'product';
 			}
-			
+
 			if ( WC_Facebookcommerce_Utils::is_variable_type( $product->get_type() ) ) {
                             $product_price = $product->get_variation_price( 'min' );
                         } else {
@@ -900,7 +907,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			foreach ( $order->get_items() as $item ) {
 
 				$product = $item->get_product();
-				
+
 				if ( $product ) {
 					$product_ids[]   = \WC_Facebookcommerce_Utils::get_fb_content_ids( $product );
 					$product_names[] = $product->get_name();
@@ -950,18 +957,27 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		/**
 		 * Inject order meta gor WooCommerce Checkout Blocks flow.
 		 * The blocks flow does not trigger the woocommerce_checkout_update_order_meta so we can't rely on it.
-		 * The Checkout Block has its own ( so far ) experimental hook that allows us to inject the meta at
-		 * the appropriate moment: __experimental_woocommerce_blocks_checkout_update_order_meta.
+		 * The Checkout Block has its own hook that allows us to inject the meta at
+		 * the appropriate moment: woocommerce_store_api_checkout_update_order_meta.
+		 *
+		 * Note: __experimental_woocommerce_blocks_checkout_update_order_meta has been deprecated
+		 * as of WooCommerce Blocks 6.3.0
 		 *
 		 *  @since 2.6.6
 		 *
-		 *  @param WC_Order $order Order object.
+		 *  @param WC_Order|int $the_order Order object or id.
 		 */
-		public function inject_order_meta_event_for_checkout_block_flow( $order ) {
+		public function inject_order_meta_event_for_checkout_block_flow( $the_order ) {
 
 			$event_name = 'Purchase';
 
 			if ( ! $this->is_pixel_enabled() || $this->pixel->is_last_event( $event_name ) ) {
+				return;
+			}
+
+			$order = wc_get_order($the_order);
+
+			if ( ! $order ) {
 				return;
 			}
 
@@ -1050,7 +1066,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			} catch ( Framework\SV_WC_API_Exception $exception ) {
 
 				$success = false;
-				
+
 				facebook_for_woocommerce()->log( 'Could not send Pixel event: ' . $exception->getMessage() );
 			}
 


### PR DESCRIPTION
❗ make sure #2197 is merged first to avoid merge conflicts.

### Changes proposed in this Pull Request:

The woocommerce-gutenberg-products-block plugin has update the __experimental_woocommerce_blocks_checkout_update_order_meta action to woocommerce_blocks_checkout_update_order_meta

If the old action is used we are logging in deprecation notices. In this PR I've updated the action to the preferred action.

I am also providing backward compatibility for older versions of WooCommerce Blocks.

For reference: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5008

Closes #2123.

_Replace this with a good description of your changes & reasoning._

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:

1. Set up Facebook for WooCommerce and connect to FB.
2. Install the WooCommerce Blocks extension and add the checkout block to a page.
3. Navigate to the newly created checkout page. Complete purchase and Check if the Purchase is triggered using the Google Chrome Facebook Pixel helper extension.
4. Check in the wp_postmeta and confirm that meta_key `_wc_facebook_for_woocommerce_order_placed` has been set for the new order.
5. Confirm that no deprecation notices are logged.


### Changelog entry

> Tweak - Update the __experimental_woocommerce_blocks_checkout_update_order_meta action
