### PR TITLE
Bump tested to WordPress 6.0 and WooCommerce 6.5

### DIFF
--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -13,9 +13,9 @@
  * Author URI: https://www.facebook.com/
  * Version: 2.6.13
  * Text Domain: facebook-for-woocommerce
- * Tested up to: 5.9
+ * Tested up to: 6.0
  * WC requires at least: 3.5.0
- * WC tested up to: 6.0
+ * WC tested up to: 6.5
  * Requires PHP: 7.0
  *
  * @package FacebookCommerce


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Bumping the WooCommerce and WordPress tested up to tags to 6.5 and 6.0 after testing with **WooCommerce 6.5.0-rc.1** and **WordPress 6.0.0-beta.1**.


### Changelog entry

> Tweak - WC 6.5 compatibility.
> Tweak - WordPress 6.0 compatibility.