### PR TITLE
Fix sales start time offset issue.

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -376,13 +376,13 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			intval( round( $this->get_price_plus_tax( $sale_price ) * 100 ) );
 
 			$sale_start =
-			( $date     = get_post_meta( $this->id, '_sale_price_dates_from', true ) )
-			? date_i18n( 'Y-m-d', $date ) . self::MIN_TIME
+			( $date     = $this->woo_product->get_date_on_sale_from() )
+			? date_i18n( 'Y-m-d', $date->getOffsetTimestamp() ) . self::MIN_TIME
 			: self::MIN_DATE_1 . self::MIN_TIME;
 
 			$sale_end =
-			( $date   = get_post_meta( $this->id, '_sale_price_dates_to', true ) )
-			? date_i18n( 'Y-m-d', $date ) . self::MAX_TIME
+			( $date   = $this->woo_product->get_date_on_sale_to() )
+			? date_i18n( 'Y-m-d', $date->getOffsetTimestamp() ) . self::MAX_TIME
 			: self::MAX_DATE . self::MAX_TIME;
 
 			// check if sale is expired and sale time range is valid

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -377,12 +377,12 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 
 			$sale_start =
 			( $date     = $this->woo_product->get_date_on_sale_from() )
-			? date_i18n( 'Y-m-d', $date->getOffsetTimestamp() ) . self::MIN_TIME
+			? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
 			: self::MIN_DATE_1 . self::MIN_TIME;
 
 			$sale_end =
 			( $date   = $this->woo_product->get_date_on_sale_to() )
-			? date_i18n( 'Y-m-d', $date->getOffsetTimestamp() ) . self::MAX_TIME
+			? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
 			: self::MAX_DATE . self::MAX_TIME;
 
 			// check if sale is expired and sale time range is valid


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WooCommerce normalizes the timestamp value for the sales_start_date and sales_post_date values before saving them in the post_meta table. By simply getting the _sale_price_dates_from post meta, we receive a timestamp with the timezone subtracted.  As a result, the sales start time sync to FB is incorrect (usually by plus or minus a day) for specific time zones. I tested with UTC+10h30.

To fix this issue, I am building the $sale_start and $sale_end strings with the offset timestamp instead of the raw value from the DB.

Closes #1755.



### Detailed test instructions:

1. Change your store/site timezone to be further from UTC. E.g., UTC+10:30
2. Create/edit a product in WooCommerce, schedule a sales period for a variation item or a product

![Screenshot 2022-05-12 at 17 20 54](https://user-images.githubusercontent.com/4209011/168110496-18428215-a7bc-4da4-b677-878bcf17af9b.jpg)

Save and update.
3. Before this change you would have noticed after the changes have been synced with FB, the start date would be a day off. After this change, verify the product in your FB catalog, and the "Sale price start date" values should match the date set in WooCommerce.

![Screenshot 2022-05-12 at 17 29 19](https://user-images.githubusercontent.com/4209011/168112575-3c629103-e3ce-4f45-a0e8-4a63b83e0ac3.jpg)


### Changelog entry

> Fix - Wrong sale price start date getting synced to  FB Catalog.
