### PR TITLE
Fix - Brand isn't synced instead it's using website name

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -564,8 +564,17 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			$categories =
 			WC_Facebookcommerce_Utils::get_product_categories( $id );
 
-			$brand = get_the_term_list( $id, 'product_brand', '', ', ' );
-			$brand = is_wp_error( $brand ) || ! $brand ? wp_strip_all_tags( WC_Facebookcommerce_Utils::get_store_name() ) : WC_Facebookcommerce_Utils::clean_string( $brand );
+			// Get brand attribute.
+			$brand = get_post_meta( $id,Products::ENHANCED_CATALOG_ATTRIBUTES_META_KEY_PREFIX . "brand", true );
+			$brand_taxonomy = get_the_term_list( $id, 'product_brand', '', ', ' );
+
+			if ( $brand ) {
+				$brand = WC_Facebookcommerce_Utils::clean_string( $brand );
+			} elseif ( !is_wp_error( $brand_taxonomy ) && $brand_taxonomy ) {
+				$brand = WC_Facebookcommerce_Utils::clean_string( $brand_taxonomy );
+			} else {
+				$brand = wp_strip_all_tags( WC_Facebookcommerce_Utils::get_store_name() );
+			}
 
 			if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
 				$product_data = array(


### PR DESCRIPTION

### Changes proposed in this Pull Request:

 If the FB brand attribute is set on a product, this should take precedence over the brand taxonomy or the website name. when syncing the brand attribute value.

![Screenshot 2022-05-13 at 18 19 21](https://user-images.githubusercontent.com/4209011/168325484-2feebf78-1645-404a-ad03-6a1809eb3cba.jpg)


Closes #2006.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

![Screenshot 2022-05-13 at 17 50 53](https://user-images.githubusercontent.com/4209011/168326163-b0945d60-3e40-4725-8b04-ee21f2c42d24.jpg)


### Detailed test instructions:
1. Create/edit a product and then on the Facebook tab, complete the Google product category, and the corresponding Category Specific Attributes, and fill out the details including the Brand field.
2. Update. the value for the brand attribute should be the value configured and not the website name as it was before

### Changelog entry

>  Fix - Syncing brand FB attribute instead of the website name
