### PR TITLE
Fix - WooCommerce Catalog Visibility - product with limited visibility settings are not synced to FB. 

### DIFF
--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -231,7 +231,7 @@ class ProductValidator {
 		$product = $this->product_parent ? $this->product_parent : $this->product;
 
 		if ( ! $product->is_visible() ) {
-			throw new ProductExcludedException( __( 'This product cannot be synced to Facebook because it is hidden from your store catalog..', 'facebook-for-woocommerce' ) );
+			throw new ProductExcludedException( __( 'This product cannot be synced to Facebook because it is hidden from your store catalog.', 'facebook-for-woocommerce' ) );
 		}
 	}
 

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -230,8 +230,8 @@ class ProductValidator {
 	protected function validate_product_visibility() {
 		$product = $this->product_parent ? $this->product_parent : $this->product;
 
-		if ( 'visible' !== $product->get_catalog_visibility() ) {
-			throw new ProductExcludedException( __( 'Product is hidden from catalog and search.', 'facebook-for-woocommerce' ) );
+		if ( ! $product->is_visible() ) {
+			throw new ProductExcludedException( __( 'This product cannot be synced to Facebook because it is hidden from your store catalog..', 'facebook-for-woocommerce' ) );
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We do not sync products to FB unless the WooCommerce catalog visibility for a product is set to Shop and Search results. When a product is hidden in the WC shop or, [in some instances](https://wordpress.org/support/topic/products-with-shop-only-visibility-do-not-sync/), hidden from the search and shown in the shop (or vice versa). This is because of this [check](https://github.com/woocommerce/facebook-for-woocommerce/blob/3c2a42de5f8eb162984c243fad1f12952f994af9/includes/ProductSync/ProductValidator.php#L233-L235) which prevents products hidden in search and shown in catalog from syncing.

I updated the validate_product_visibility() method to allow sync when visibility is set to "shop only" and updated the exception message.

Fixes #1961.



- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

Update product visibility to **search results only** or **hidden**

![Screenshot 2022-05-17 at 16 38 20](https://user-images.githubusercontent.com/4209011/168838214-479e5550-40aa-4b7b-9b57-0784db596b4b.jpg)

The following shows in the meta box and the changes are not synced: 

![Screenshot 2022-05-17 at 16 29 35](https://user-images.githubusercontent.com/4209011/168837881-5f85478e-5ef9-4821-a542-b11b76e54677.jpg)

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create/ update a product, then update product visibility to **search results only** or **hidden**. A message is shown on the product sync meta box and the product changes are not synced.
2. Set WC Catalog Visibility settings to ** Shop only **. The product should sync to the FB catalog.


### Additional details:

I decided not to change the  Sync / Do Not Sync options behavior and stick with the rule that only products visible in WooCommerce should be displayed on FB. I now include partial visibility as well.

### Changelog entry

> Fix - allow products with "shop only" WooCommerce catalog visibility to sync to FB.