### PR TITLE
Handle sale_price for feed when sale_price is not set for products.

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -354,16 +354,13 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			return $description;
 		}
 
+		/**
+		 * @param array $product_data
+		 * @param bool $for_items_batch
+		 *
+		 * @return array
+		 */
 		public function add_sale_price( $product_data, $for_items_batch = false ) {
-
-			// initialise sale price
-			if ( $for_items_batch ) {
-				$product_data['sale_price_effective_date'] = self::MIN_DATE_1 . self::MIN_TIME . '/' . self::MIN_DATE_2 . self::MAX_TIME;
-			} else {
-				$product_data['sale_price_start_date'] = self::MIN_DATE_1 . self::MIN_TIME;
-				$product_data['sale_price_end_date']   = self::MIN_DATE_2 . self::MAX_TIME;
-			}
-			$product_data['sale_price'] = $product_data['price'];
 
 			$sale_price = $this->woo_product->get_sale_price();
 

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -569,6 +569,17 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 				$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
 			}
 
+			// Sale price, only format if we have a sale price set for the product, else leave as empty ('').
+			$sale_price                = static::get_value_from_product_data( $product_data, 'sale_price', '' );
+			$sale_price_effective_date = '';
+			if ( is_numeric( $sale_price ) && $sale_price > 0 ) {
+				$sale_price_effective_date = static::get_value_from_product_data( $product_data, 'sale_price_start_date' ) . '/' . $this->get_value_from_product_data( $product_data, 'sale_price_end_date' );
+				$sale_price                = static::format_price_for_feed(
+					$sale_price,
+					static::get_value_from_product_data( $product_data, 'currency' )
+				);
+			}
+
 			return $product_data['retailer_id'] . ',' .
 			static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'name' ) ) . ',' .
 			static::format_string_for_feed( static::get_value_from_product_data( $product_data, 'description' ) ) . ',' .
@@ -584,12 +595,8 @@ if ( ! class_exists( 'WC_Facebook_Product_Feed' ) ) :
 			$item_group_id . ',' .
 			static::get_value_from_product_data( $product_data, 'checkout_url' ) . ',' .
 			static::format_additional_image_url( static::get_value_from_product_data( $product_data, 'additional_image_urls' ) ) . ',' .
-			static::get_value_from_product_data( $product_data, 'sale_price_start_date' ) . '/' .
-			static::get_value_from_product_data( $product_data, 'sale_price_end_date' ) . ',' .
-			static::format_price_for_feed(
-				static::get_value_from_product_data( $product_data, 'sale_price', 0 ),
-				static::get_value_from_product_data( $product_data, 'currency' )
-			) . ',' .
+			$sale_price_effective_date . ',' .
+			$sale_price . ',' .
 			'new' . ',' .
 			static::get_value_from_product_data( $product_data, 'visibility' ) . ',' .
 			static::get_value_from_product_data( $product_data, 'gender' ) . ',' .


### PR DESCRIPTION
This is a refresh of PR #1986 

### Changes proposed in this Pull Request:


Currently, the feed sets `sale_price`  the same as the `price` causing products to be on sale, this PR removes sets default `sale_price` and `sale_price_effective_date` to `''` (empty) when the product is not on sale.

Closes #1833.


### Detailed test instructions:


1. Checkout this branch 
2. Make sure you have a few products with _sale price_ set
2. We want to generate a new feed file, this can be accomplished by updating this line and changing `Heartbeat::HOURLY` to `init`

https://github.com/woocommerce/facebook-for-woocommerce/blob/fd5720a72aea6b8452123641de4a2c0020028a33/includes/Products/Feed.php#L58-L59

3. Reload the site, and go to `https://MYSITE/wp-admin/tools.php?page=action-scheduler&status=pending`. You should have a task called _facebook_for_woocommerce_start_feed_generation_, let's manually run it.


<img width="1480" alt="Screen Shot 2021-06-03 at 01 55 16" src="https://user-images.githubusercontent.com/532402/120608826-da8a1200-c40e-11eb-89ad-ef0209158912.png">

4. Feed file should be generating now, you can validate this by browsing path: _/wp-content/facebook_for_woocommerce/_, there's should be a file with _temp_ word on it. Wait until the file is completed and _temp_ is removed
5. Open it on numbers.app or your text editor, you can validate `sale_price` and `sale_price_effective_date` column are empty for products without a _sale price_
<img width="384" alt="Screen Shot 2021-06-03 at 01 59 54" src="https://user-images.githubusercontent.com/532402/120609504-7582ec00-c40f-11eb-9106-9080a949cf51.png">
6. Now we'll check feed is valid for FB, go to your FB Catalog's settings, and upload the new file manually
<img width="1658" alt="Screen Shot 2021-06-03 at 02 04 47" src="https://user-images.githubusercontent.com/532402/120610367-52a50780-c410-11eb-924a-0197880794e1.png">
<img width="1014" alt="Screen Shot 2021-06-03 at 02 05 36" src="https://user-images.githubusercontent.com/532402/120610373-53d63480-c410-11eb-9494-256203771936.png">

7. Finally, let's valid the product doesn't have the sale price on FB.
<img width="836" alt="Screen Shot 2021-06-03 at 02 07 35" src="https://user-images.githubusercontent.com/532402/120610595-9435b280-c410-11eb-8f7e-945b8c991885.png">

### Changelog entry

> Fix - Do not set `sale_price` when the product is not on sale.

