### PR TITLE
Not show the removed from sync confirm modal for unpublished product.

### DIFF
--- a/assets/js/admin/products-admin.js
+++ b/assets/js/admin/products-admin.js
@@ -407,10 +407,11 @@ jQuery( document ).ready( function( $ ) {
 
 			let syncValuesStatus = $syncModeSelect.map( function ( index, selectElement ) {
 
-				let $syncMode     = $( selectElement );
-				let syncModeValue = $syncMode.val();
+				let $syncMode     	   = $( selectElement );
+				let syncModeValue 	   = $syncMode.val();
+				let isProductPublished = !! facebook_for_woocommerce_products_admin.is_product_published;
 
-				return 'sync_disabled' === syncModeValue && syncModeValue !== $syncMode.attr( 'data-original-value' );
+				return isProductPublished && 'sync_disabled' === syncModeValue && syncModeValue !== $syncMode.attr( 'data-original-value' );
 			} ).toArray();
 
 			return syncValuesStatus.indexOf( true ) > -1;

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -200,6 +200,7 @@ class Admin {
 						'enhanced_attribute_page_type_edit_category' => \SkyVerge\WooCommerce\Facebook\Admin\Enhanced_Catalog_Attribute_Fields::PAGE_TYPE_EDIT_CATEGORY,
 						'enhanced_attribute_page_type_add_category' => \SkyVerge\WooCommerce\Facebook\Admin\Enhanced_Catalog_Attribute_Fields::PAGE_TYPE_ADD_CATEGORY,
 						'enhanced_attribute_page_type_edit_product' => \SkyVerge\WooCommerce\Facebook\Admin\Enhanced_Catalog_Attribute_Fields::PAGE_TYPE_EDIT_PRODUCT,
+						'is_product_published' 			  => $this->is_current_product_published(),
 						'is_sync_enabled_for_product'     => $this->is_sync_enabled_for_current_product(),
 						'set_product_visibility_nonce'    => wp_create_nonce( 'set-products-visibility' ),
 						'set_product_sync_prompt_nonce'   => wp_create_nonce( 'set-product-sync-prompt' ),
@@ -264,6 +265,24 @@ class Admin {
 		return Products::is_sync_enabled_for_product( $product );
 	}
 
+	/**
+	 * Determines whether the current product is published.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return bool
+	 */
+	private function is_current_product_published() {
+		global $post;
+
+		$product = wc_get_product( $post );
+
+		if ( ! $product instanceof \WC_Product ) {
+			return false;
+		}
+
+		return 'publish' === $product->get_status();
+	}
 
 	/**
 	 * Gets the markup for the message used in the product not ready modal.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When creating a new product, if a user selects the Facebook sync setting to Do not sync, a popup window appears saying: You're removing a product from the Facebook sync listed in your Facebook catalog. Would you like to delete the product from the Facebook catalog as well?. This modal is only valid for published products. 

This PR adds checks to ensure a product is published before displaying the "Removed from sync" confirm modal.

Closes #1975.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:

1. Create a new product
2. Navigate to Product data > Facebook > Facebook sync, select Do not sync from the dropdown
3. No popup appears
4. Edit a published product, then navigate to Product data > Facebook > Facebook sync, select Do not sync from the dropdown
5. The "Removed from sync" confirm modal is displayed.

![image](https://user-images.githubusercontent.com/4209011/169065405-4e4169b0-74b7-44b4-ba9d-1e957d0c3af7.png)

### Changelog entry

> Tweak - Not show the removed from sync confirm modal for unpublished products.
