### PR TITLE
Fix visibility parameter value for items if not visible.

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -155,7 +155,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	const FB_SHOP_PRODUCT_VISIBLE = 'published';
 
 	/** @var string the API flag to set a product as not visible in the Facebook shop */
-	const FB_SHOP_PRODUCT_HIDDEN = 'staging';
+	const FB_SHOP_PRODUCT_HIDDEN = 'hidden';
 
 	/** @var string @deprecated  */
 	const FB_CART_URL = 'fb_cart_url';

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -281,7 +281,7 @@ class Products {
 	 * @since 1.10.0
 	 *
 	 * @param \WC_Product $product product object
-	 * @param bool        $visibility true for 'published' or false for 'staging'
+	 * @param bool        $visibility true for 'published' or false for 'hidden'
 	 * @return bool success
 	 */
 	public static function set_product_visibility( \WC_Product $product, $visibility ) {

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -627,7 +627,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 				$product_data['checkout_url'] = $checkout_url;
 			}
 
-			// IF using WPML, set the product to staging unless it is in the
+			// IF using WPML, set the product to hidden unless it is in the
 			// default language. WPML >= 3.2 Supported.
 			if ( defined( 'ICL_LANGUAGE_CODE' ) ) {
 				if ( class_exists( 'WC_Facebook_WPML_Injector' ) && WC_Facebook_WPML_Injector::should_hide( $id ) ) {

--- a/tests/integration/Products/Sync/BackgroundTest.php
+++ b/tests/integration/Products/Sync/BackgroundTest.php
@@ -210,7 +210,7 @@ class BackgroundTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertIsString( $data['item_group_id'] );
 		$this->assertIsString( $data['sale_price'] );
 		$this->assertIsString( $data['link'] );
-		$this->assertTrue( in_array( $data['visibility'], [ 'published', 'staging' ], true ) );
+		$this->assertTrue( in_array( $data['visibility'], [ 'published', 'hidden' ], true ) );
 
 		// compare results with specific values from the test case
 		if ( isset( $request['retailer_id'] ) ) {

--- a/tests/integration/WC_Facebook_Product_Test.php
+++ b/tests/integration/WC_Facebook_Product_Test.php
@@ -165,7 +165,7 @@ class WC_Facebook_Product_Test extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @param mixed $price the regular price for the product
 	 * @param bool $is_visible whether the product should visible in the Facebook Shop
-	 * @param string $visibility 'staging' or 'published'
+	 * @param string $visibility 'hidden' or 'published'
 	 * @dataProvider provider_prepare_product_sets_product_visibility
 	 */
 	public function test_prepare_product_sets_product_visibility( $price, $is_visible, $visibility ) {


### PR DESCRIPTION
This is a refresh of #2011 

### Changes proposed in this Pull Request:

The hidden item's visibility value was wrong. I don't really know why it was staging when documentation clearly states that the values should be hidden or `published.


Closes #2009.

_Replace this with a good description of your changes & reasoning._

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1. Generate the feed with hidden items
2. Make sure that the feed file gets uploaded
3. Wait for the feed report
4. Check for the issue mentioned in #2009


### Changelog entry

>  Fix - Feed visibility field value for hidden items.

