### PR TITLE
Fix - Wrong Value Field in AddToCart Events

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -591,7 +591,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 					'content_name' => $this->get_cart_content_names(),
 					'content_type' => 'product',
 					'contents'     => $this->get_cart_contents(),
-					'value'        => $this->get_cart_total(),
+					'value'        => (float) $product->get_price() * $quantity,
 					'currency'     => get_woocommerce_currency(),
 				),
 				'user_data'   => $this->pixel->get_user_info(),

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -587,10 +587,17 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$event_data = array(
 				'event_name'  => 'AddToCart',
 				'custom_data' => array(
-					'content_ids'  => $this->get_cart_content_ids(),
-					'content_name' => $this->get_cart_content_names(),
+					'content_ids'  => wp_json_encode( \WC_Facebookcommerce_Utils::get_fb_content_ids( $product ) ),
+					'content_name' => $product->get_name(),
 					'content_type' => 'product',
-					'contents'     => $this->get_cart_contents(),
+					'contents'     => wp_json_encode(
+						array(
+							array(
+							"id"	   => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
+							"quantity" =>  $quantity,
+							),
+						)
+					),
 					'value'        => (float) $product->get_price() * $quantity,
 					'currency'     => get_woocommerce_currency(),
 				),
@@ -640,20 +647,35 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function add_add_to_cart_event_fragment( $fragments ) {
 
+			$product_id = isset( $_POST['product_id'] ) ? (int) $_POST['product_id'] : '';
+			$quantity   = isset( $_POST['quantity']) ? (int) $_POST['quantity'] : '';
+			$product 	= wc_get_product($product_id);
+
+			if ( ! $product instanceof \WC_Product || empty( $quantity ) ) {
+				return $fragments;
+			}
+
+
 			if ( $this->is_pixel_enabled() ) {
 
 				$params = array(
-					'content_ids'  => $this->get_cart_content_ids(),
-					'content_name' => $this->get_cart_content_names(),
+					'content_ids'  => wp_json_encode( \WC_Facebookcommerce_Utils::get_fb_content_ids( $product ) ),
+					'content_name' => $product->get_name(),
 					'content_type' => 'product',
-					'contents'     => $this->get_cart_contents(),
-					'value'        => $this->get_cart_total(),
+					'contents'     => wp_json_encode(
+						array(
+							array(
+								'id'       => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
+								'quantity' => 1,
+							),
+						)
+					),
+					'value'        => (float) $product->get_price() * $quantity,
 					'currency'     => get_woocommerce_currency(),
 				);
 
 				// send the event ID to prevent duplication
 				if ( ! empty( $event_id = WC()->session->get( 'facebook_for_woocommerce_add_to_cart_event_id' ) ) ) {
-
 					$params['event_id'] = $event_id;
 				}
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -593,8 +593,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 					'contents'     => wp_json_encode(
 						array(
 							array(
-							"id"	   => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
-							"quantity" =>  $quantity,
+								"id"	   => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
+								"quantity" =>  $quantity,
 							),
 						)
 					),
@@ -666,7 +666,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 						array(
 							array(
 								'id'       => \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ),
-								'quantity' => 1,
+								'quantity' => $quantity,
 							),
 						)
 					),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When triggering multiple AddToCart events from a website, the value field contains a cumulative sum of all the previous AddToCart events instead of the value of the current AddToCart only.

This has a significant impact on multiple tools in the Facebook Business Manager platform.
For example, when monitoring campaign metrics the total value for AddToCart events is much higher than the actual value in WooCommerce carts.
This is because each new AddToCart event contains the cumulative sum of prices of all products in the cart:

- First AddToCart event: 1 product, value=X
- Second AddToCart event: 2 products in cart, value=X+Y
- Third AddToCart event: 3 products in cart, value=X+Y+Z

This PR fixes this.

Closes #1847.

_Replace this with a good description of your changes & reasoning._

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check out this branch
2. Navigate to a product page, add an item to your cart and observe that the value amount in the AddToCart pixel event code matches the value of the item added to the cart.
3. Repeat this with another product and confirm the value matches the value of the item added to the cart and not the cart total.
4. Go to WP Admin -> WooCommerce -> Settings -> Products. Ensure the option “Redirect to the cart page after successful addition” is unchecked. and "Enable AJAX add to cart buttons on archives" is selected.
5. Go to the shop page and add an item to the cart, then inspect the source code (right click -> inspect) and locate the div with class "wc-facebook-pixel-event-placeholder". Confirm it contains the pixel script tag and the values are correct:

![Screenshot 2022-05-23 at 15 17 15](https://user-images.githubusercontent.com/4209011/169827991-1294205d-aec0-4c03-a4ed-a4051a91814b.jpg)
 

### Changelog entry

> Fix - Wrong Value Field in AddToCart Events
