### PR TITLE
Facebook Order sync action was not scheduled.

### DIFF
--- a/includes/Commerce.php
+++ b/includes/Commerce.php
@@ -111,11 +111,9 @@ class Commerce {
 	 *
 	 * @return bool whether the site is connected
 	 */
-	public function is_connected() {
+	public function is_connected(): bool {
 
-		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
-
-		$connected = (bool) strlen( $connection_handler->get_page_access_token() ) && ! empty( $connection_handler->get_commerce_manager_id() );
+		$connected = ! empty( facebook_for_woocommerce()->get_connection_handler()->get_page_access_token() );
 
 		/**
 		 * Filters whether the site is connected.

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -808,7 +808,7 @@ class Connection {
 	 * @return string
 	 */
 	public function get_commerce_manager_id() {
-
+		wc_deprecated_function( __METHOD__, '2.6.14' );
 		return get_option( self::OPTION_COMMERCE_MANAGER_ID, '' );
 	}
 
@@ -1081,7 +1081,7 @@ class Connection {
 	 * @param string $id the ID
 	 */
 	public function update_commerce_manager_id( $id ) {
-
+		wc_deprecated_function( __METHOD__, '2.6.14' );
 		update_option( self::OPTION_COMMERCE_MANAGER_ID, $id );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Some time ago `commerce manage id` option stopped to be set and turned the condition to evaluate to false when checking for Facebook order sync scheduled action. So fixing the sync scheduled action check condition. Besides `commerce manage id` appeared to be an unknown parameter, not a single doc has the reference to such a parameter name, the closest thing to `commerce manage id` is `commerce account id`, but still `commerce manage id` was not used anywhere else, so removing is an checking for page token to validate the connection should be sufficient. Orders fetching does not require `commerce manage id`, only page token.

Closes #2110.

### Detailed test instructions:

1. Before checking out the branch, go to WooCommerce > Scheduled Actions;
2. Search for wc_facebook_commerce_fetch_orders and see no results found;
![WooCommerce_status_‹_Regular-WordPress_—_WordPress](https://user-images.githubusercontent.com/9010963/170033506-f8dbf7ce-a781-4aee-86c5-449049966e2c.png)

3. Checkout the branch with the fix and repeat those two steps above;
4. You should see action scheduled;
![WooCommerce_status_‹_WordPress-Facebook_—_WordPress](https://user-images.githubusercontent.com/9010963/170033886-1a286f4f-2ecc-47e8-adf4-b8bb01161ddc.png)

### Changelog entry

> Fix - Facebook orders sync action is not scheduled.
