### PR TITLE
Address issue with pixel ajax events not working.

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -118,7 +118,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			// AddToCart while AJAX is enabled
 			add_action( 'woocommerce_ajax_added_to_cart', array( $this, 'add_filter_for_add_to_cart_fragments' ) );
 			// AddToCart while using redirect to cart page
-			if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
+			if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add', 'no' ) ) {
 				add_filter( 'woocommerce_add_to_cart_redirect', array( $this, 'set_last_product_added_to_cart_upon_redirect' ), 10, 2 );
 				add_action( 'woocommerce_ajax_added_to_cart', array( $this, 'set_last_product_added_to_cart_upon_ajax_redirect' ) );
 				add_action( 'woocommerce_after_cart', array( $this, 'inject_add_to_cart_redirect_event' ), 10, 2 );
@@ -629,7 +629,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function add_filter_for_add_to_cart_fragments() {
 
-			if ( 'no' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
+			if ( 'no' === get_option( 'woocommerce_cart_redirect_after_add', 'no' ) ) {
 				add_filter( 'woocommerce_add_to_cart_fragments', array( $this, 'add_add_to_cart_event_fragment' ) );
 			}
 		}
@@ -701,7 +701,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function add_filter_for_conditional_add_to_cart_fragment() {
 
-			if ( 'no' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
+			if ( 'no' === get_option( 'woocommerce_cart_redirect_after_add', 'no' ) ) {
 				add_filter( 'woocommerce_add_to_cart_fragments', array( $this, 'add_conditional_add_to_cart_event_fragment' ) );
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

FB Pixel is missing some ajax Add to cart events.

It seems to happen because this code here https://github.com/woocommerce/facebook-for-woocommerce/blob/master/facebook-commerce-events-tracker.php#L632 is checking only when the DB option of the Cart redirection has been saved because by default it returns false. This PR corrects the condition check.

Fixes #2219.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check out this branch
2. Go to WP Admin -> WooCommerce -> Settings -> Products. Ensure the option “Redirect to the cart page after successful addition” is unchecked. and "Enable AJAX add to cart buttons on archives" is selected.
3. Go to the shop page and add an item to the cart, then inspect the source code (right click -> inspect) and locate the div with class "wc-facebook-pixel-event-placeholder". Confirm it contains the pixel script tag and the values are correct:

![Screenshot 2022-05-23 at 15 17 15](https://user-images.githubusercontent.com/4209011/169827991-1294205d-aec0-4c03-a4ed-a4051a91814b.jpg)

4. Confirm that the events are present in the FB event manager. **Note:** As this is a client-side trigger, there might be a bit of a delay before the events are shown.

### Changelog entry

> Fix - FB Pixel is missing some ajax Add to cart events.
