### PR TITLE
Updating reference from old master branch

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -5,7 +5,7 @@ possible.
 ## Pull Requests
 We actively welcome your pull requests.
 
-1. Fork the repo and create your branch from `master`.
+1. Fork the repo and create your branch from `develop`.
 2. If you've added code that should be tested, add tests.
 3. If you've changed APIs, update the documentation.
 4. Make sure your code lints.

--- a/.github/php-coding-standards.yml
+++ b/.github/php-coding-standards.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - trunk
+      - develop
   pull_request:
 
 jobs:

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -3,7 +3,8 @@ name: PHP Coding Standards
 on:
   push:
     branches:
-      - master
+      - trunk
+      - develop
   pull_request:
 
 jobs:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updating references to master in documentation and GH actions.

See #1862.