### PR TITLE
Change to use custom actions of the github-actions package and enhance workflow config

### DIFF
--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -5,7 +5,13 @@ on:
     branches:
       - trunk
       - develop
+    paths:
+      - "**.php"
+      - .github/workflows/php-coding-standards.yml
   pull_request:
+    paths:
+      - "**.php"
+      - .github/workflows/php-coding-standards.yml
 
 jobs:
   phpcs:

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Prepare PHP
         uses: woocommerce/grow/prepare-php@actions-v1

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -13,6 +13,10 @@ on:
       - "**.php"
       - .github/workflows/php-coding-standards.yml
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   phpcs:
     name: PHP coding standards

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -8,21 +8,6 @@ on:
   pull_request:
 
 jobs:
-  # Runs PHP coding standards checks.
-  # Note: Inspired by https://github.com/WordPress/wordpress-develop/blob/master/.github/workflows/coding-standards.yml
-  #
-  # This was copied from woocommerce-gutenberg-products-block.
-  # Violations are reported inline with annotations.
-  #
-  # Performs the following steps:
-  # - Checks out the repository.
-  # - Configures caching for Composer.
-  # - Sets up PHP.
-  # - Logs debug information.
-  # - Installs Composer dependencies (from cache if possible).
-  # - Logs PHP_CodeSniffer debug information.
-  # - Runs PHPCS on the full codebase with warnings suppressed.
-  # - todo: Configure Slack notifications for failing scans.
   phpcs:
     name: PHP coding standards
     runs-on: ubuntu-latest
@@ -30,39 +15,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Set up Composer caching
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-composer-dependencies
+      - name: Prepare PHP
+        uses: woocommerce/grow/prepare-php@actions-v1
         with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          coverage: none
-          tools: composer, cs2pr, phpcs
+          tools: cs2pr
 
-      - name: Log debug information
-        run: |
-          php --version
-          composer --version
-      - name: Install Composer dependencies
-        run: |
-          composer install --prefer-dist --no-suggest --no-progress --no-ansi --no-interaction
-          echo "${PWD}/vendor/bin" >> $GITHUB_PATH
-      - name: Log PHPCS debug information
-        run: phpcs -i
+      - name: Log PHPCS information
+        run: vendor/bin/phpcs -i
 
       - name: Run PHPCS on all files
         run: npm run lint:php:pr --silent | cs2pr
 
       - name: Run PHPCS with PHP 5.2 on plugin loader file
-        run: phpcs facebook-for-woocommerce.php --runtime-set testVersion 5.2 -q -n --report=checkstyle
+        run: vendor/bin/phpcs facebook-for-woocommerce.php --runtime-set testVersion 5.2 -q -n --report=checkstyle

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -34,7 +34,7 @@ jobs:
         run: vendor/bin/phpcs -i
 
       - name: Run PHPCS on all files
-        run: npm run lint:php:pr --silent | cs2pr
+        run: vendor/bin/phpcs -q -n --report=checkstyle | cs2pr
 
       - name: Run PHPCS with PHP 5.2 on plugin loader file
         run: vendor/bin/phpcs facebook-for-woocommerce.php --runtime-set testVersion 5.2 -q -n --report=checkstyle

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Facebook for WooCommerce
 
+[![PHP Coding Standards](https://github.com/woocommerce/facebook-for-woocommerce/actions/workflows/php-coding-standards.yml/badge.svg)](https://github.com/woocommerce/facebook-for-woocommerce/actions/workflows/php-coding-standards.yml)
+
 This is the development repository for the Facebook for WooCommerce plugin.
 
 - [WooCommerce.com product page](https://woocommerce.com/products/facebook)

--- a/package.json
+++ b/package.json
@@ -17,9 +17,8 @@
   },
   "scripts": {
     "generate:category_attribute_json": "php bin/GenerateCategoryAttributeMapping.php",
-    "lint:php": "vendor/bin/phpcs . --extensions=php -p -s --colors ",
-    "lint:php:pr": "vendor/bin/phpcs . --extensions=php --warning-severity=0 --report=checkstyle ",
-    "lint:php:summary": "vendor/bin/phpcs . --extensions=php --colors --report=summary",
+    "lint:php": "vendor/bin/phpcs -p -s --colors",
+    "lint:php:summary": "vendor/bin/phpcs --colors --report=summary",
     "build:assets": "NODE_ENV=production wp-scripts build",
     "start": "wp-scripts start",
     "deploy:sake": "npm run build:assets && npx sake deploy --deployAssets=0",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,10 @@
 <ruleset name="WordPress Coding Standards">
 	<description>WooCommerce dev PHP_CodeSniffer ruleset.</description>
 
+	<!-- Check PHP files -->
+	<arg name="extensions" value="php"/>
+	<file>.</file>
+
 	<!-- Exclude paths -->
 	<exclude-pattern>/node_modules/*</exclude-pattern>
 	<exclude-pattern>/vendor/*</exclude-pattern>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

This PR is part of phase 7 of the migration plan in this comment - pb0Spc-2DL-p2#comment-5753.
- Replace the custom actions of `prepare-php` with Grow's `github-actions` package.
- Upgrade all `actions/checkout` in GitHub workflows to v3.
- Only run PHPCS workflow when the related files were changed.
- Set concurrency to cancel the previous workflow for the same branch.
- Add the badge of PHPCS check status to README.

### Detailed test instructions:

Go to the Checks tab of this PR to see if all checks work correctly.

### Changelog entry
