### PR TITLE
 Fix - Misaligned help icons on Product Categories > Google Product Categories form.

### DIFF
--- a/assets/css/admin/products-categories.css
+++ b/assets/css/admin/products-categories.css
@@ -12,3 +12,14 @@
 	float: none;
 	width: 100% !important;
 }
+
+tr[class*="term-wc_facebook_enhanced_catalog_attribute"]:not(.term-wc_facebook_enhanced_catalog_attributes_id-title-wrap) > th > label {
+	position: relative;
+	display: block;
+}
+
+tr[class*="term-wc_facebook_enhanced_catalog_attribute"]:not(.term-wc_facebook_enhanced_catalog_attributes_id-title-wrap) > th > label > span.woocommerce-help-tip {
+	position: absolute;
+	right: 15px;
+}
+

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -340,7 +340,7 @@ class Product_Categories {
 					<?php $this->render_enhanced_catalog_attributes_tooltip(); ?>
 				</label>
 			</div>
-			<table>
+			<table class="form-table">
 				<?php $enhanced_attribute_fields->render( $category_id ); ?>
 			</table>
 		<?php


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When adding or editing WooCommerce product categories, you can set default Google Product Categories data for the woo category. There are help icons (hover => help tooltip) for each field in the form, and these are not aligned horizontally. This PR fixes the alignment issue


Closes #1880.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

![Screenshot 2022-07-06 at 17 00 21](https://user-images.githubusercontent.com/4209011/177582423-3d4597bd-da15-448a-be57-31f9733d3a21.jpg)
![Screenshot 2022-07-06 at 17 00 08](https://user-images.githubusercontent.com/4209011/177582440-4510761d-e60a-47d1-b9b0-9feb289dfe65.jpg)
![Screenshot 2022-07-06 at 16 59 57](https://user-images.githubusercontent.com/4209011/177582449-55357db2-7937-4c72-ba7a-f5b7c8833d4a.jpg)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Ensure the site is connected to Facebook and Product sync is enabled.
2. Go to wp-admin > Products > Categories. Add a new category, or edit an existing category.
3. Set the first three levels of Google categories to enable the more detailed form.
4. Notice that the help icon alignment is now correct.

### Changelog entry

> Fix - Misaligned help icons on Product Categories > Google Product Categories form.
