### PR TITLE
Use wc placeholder url for empty images.

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -211,7 +211,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			$image_urls = array_values( $image_urls );
 
 			if ( empty( $image_urls ) ) {
-				$image_urls[] = facebook_for_woocommerce()->get_plugin_url() . '/assets/images/woocommerce-placeholder.png';
+				$image_urls[] = wc_placeholder_img_src();
 			}
 
 			return $image_urls;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When using a custom placeholder image in WooCommerce, configured under WooCommerce > Settings > Products > General, when the product syncs to Facebook it displays the default WooCommerce placeholder rather than the custom one. This PR fixes the issue by getting the wc placeholder image using the `wc_placeholder_img_src()` function.


Closes #2053.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

![Screenshot 2022-07-07 at 10 07 22](https://user-images.githubusercontent.com/4209011/177724111-5788f9cd-f1b0-442d-b911-76e9d3dd7a15.jpg)


### Detailed test instructions:

1. Set a custom placeholder image under WooCommerce > Settings > Products > General
2. Create a new product and don't assign an image to it, so it will use a placeholder image.
3. Sync product to Facebook
4. The correct placeholder image is reflected on both the site and FB shop. Note it takes about a couple of minutes for the image to show on FB.


### Changelog entry

> Fix - Syncing WC custom placeholder to Facebook shop.
