### PR TITLE
Fix Fatal error is_search() with custom query.

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -381,10 +381,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * Triggers Search for result pages (deduped)
 		 *
 		 * @internal
+		 *
+		 * @param WP_Query $query the query object
 		 */
-		public function inject_search_event() {
+		public function inject_search_event( $query ) {
 
-			if ( ! $this->is_pixel_enabled() ) {
+			if ( ! $this->is_pixel_enabled() || ! $query->is_main_query()  ) {
 				return;
 			}
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -386,7 +386,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function inject_search_event( $query ) {
 
-			if ( ! $this->is_pixel_enabled() || ! $query->is_main_query()  ) {
+			if ( ! $this->is_pixel_enabled() || ! $query->is_main_query() ) {
 				return;
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Custom queries in custom templates result in an error because inject_search_event ran on the `pre_get_posts` action calls is_search and this results in a fatal error. I added the query argument to check whether the hook is ran on the main search query.

Closes #1936.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Add the followed template file to your theme folder:
file: 
[page-sale.php.zip](https://github.com/woocommerce/facebook-for-woocommerce/files/9085564/page-sale.php.zip)

2. and create a page that uses the template:

![Screenshot 2022-07-11 at 17 50 30](https://user-images.githubusercontent.com/4209011/178305783-3cb6e2a0-719c-4109-bc35-63eac0680cc5.jpg)



3. Navigate to the newly created page, this should not cause a fatal error
4. Perform a search, and validate the Search FB Pixel event is triggered correctly

### Changelog entry

> Fix - is_search() causing fatal error when custom queries are used.
