### PR TITLE
Tweak/replace init hook with heartbeat system

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -135,11 +135,6 @@ class Connection {
 	 */
 	public function refresh_business_configuration() {
 
-		// only refresh once an hour
-		if ( get_transient( 'wc_facebook_business_configuration_refresh' ) ) {
-			return;
-		}
-
 		// bail if not connected
 		if ( ! $this->is_connected() ) {
 			return;
@@ -176,7 +171,6 @@ class Connection {
 			$this->get_plugin()->log( 'Could not refresh business configuration. ' . $exception->getMessage() );
 		}
 
-		set_transient( 'wc_facebook_business_configuration_refresh', time(), HOUR_IN_SECONDS );
 	}
 
 
@@ -424,8 +418,6 @@ class Connection {
 		update_option( \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID, '' );
 
 		facebook_for_woocommerce()->get_integration()->update_product_catalog_id( '' );
-
-		delete_transient( 'wc_facebook_business_configuration_refresh' );
 
 	}
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -11,6 +11,7 @@
 
 namespace SkyVerge\WooCommerce\Facebook\Handlers;
 
+use SkyVerge\WooCommerce\Facebook\Utilities\Heartbeat;
 use SkyVerge\WooCommerce\PluginFramework\v5_10_0\SV_WC_API_Exception;
 use SkyVerge\WooCommerce\PluginFramework\v5_10_0\SV_WC_Helper;
 use SkyVerge\WooCommerce\Facebook\API\Exceptions\Connect_WC_API_Exception;
@@ -109,9 +110,9 @@ class Connection {
 
 		$this->plugin = $plugin;
 
-		add_action( 'init', array( $this, 'refresh_business_configuration' ) );
+		add_action( Heartbeat::HOURLY, array( $this, 'refresh_business_configuration' ) );
 
-		add_action( 'admin_init', array( $this, 'refresh_installation_data' ) );
+		add_action( Heartbeat::DAILY, array( $this, 'refresh_installation_data' ) );
 
 		add_action( 'woocommerce_api_' . self::ACTION_CONNECT, array( $this, 'handle_connect' ) );
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -186,11 +186,6 @@ class Connection {
 			return;
 		}
 
-		// only refresh once a day
-		if ( get_transient( 'wc_facebook_connection_refresh' ) ) {
-			return;
-		}
-
 		try {
 
 			$this->update_installation_data();
@@ -200,7 +195,6 @@ class Connection {
 			$this->get_plugin()->log( 'Could not refresh installation data. ' . $exception->getMessage() );
 		}
 
-		set_transient( 'wc_facebook_connection_refresh', time(), DAY_IN_SECONDS );
 	}
 
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Implement an hourly cron heartbeat where setup tasks can be performed e.g. scheduling important actions. See https://github.com/woocommerce/facebook-for-woocommerce/issues/1952 for background and proposal.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

1. Check out `develop` and using Query Monitor check that the **refresh_business_configuration()** is called on every page load:

![Screenshot 2022-07-15 at 17 10 02](https://user-images.githubusercontent.com/4209011/179252319-2f86f0a2-db8d-4f5d-9081-b3875d1bdb14.jpg)

![Screenshot 2022-07-15 at 17 15 06](https://user-images.githubusercontent.com/4209011/179253161-2d352fd1-00df-4eee-a1e3-d148940b8127.jpg)

Or you can also verify this by checking in the queries the tab for the `get_option('_transient_wc_facebook_business_configuration_refresh')` caller

![Screenshot 2022-07-15 at 17 18 45](https://user-images.githubusercontent.com/4209011/179253776-b3dcb8d9-70e2-4c07-b756-992e13b12c8e.jpg)

and 

`get_option('_transient_wc_facebook_connection_refresh')` caller

![Screenshot 2022-07-15 at 17 19 51](https://user-images.githubusercontent.com/4209011/179254029-188f8bac-ee2c-4e1b-824e-66e40bfb74af.jpg)


2. Check out this branch and that will no longer happen

![Screenshot 2022-07-15 at 17 21 55](https://user-images.githubusercontent.com/4209011/179254391-2d9a39cc-d1fa-495b-91f7-b7d077722e8f.jpg)

#### To test refresh_business_configuration

1. Enable messenger configuration in the FB configuration:
![Screenshot 2022-07-15 at 17 48 10](https://user-images.githubusercontent.com/4209011/179260705-ba5037c5-2156-4939-847e-3bbc3b31f14c.jpg)

2. Go to the FB Connection settings and update the messenger 

Click on the View button:
![Screenshot 2022-07-15 at 17 55 04](https://user-images.githubusercontent.com/4209011/179261232-e6e16e6f-bbbc-41f8-ba57-eb6db7c46ebf.jpg)

then update plugin
![Screenshot 2022-07-15 at 17 55 34](https://user-images.githubusercontent.com/4209011/179261488-8af63fab-1cd1-4082-8118-274797f18357.jpg)

and update the locale value:

![Screenshot 2022-07-15 at 17 55 47](https://user-images.githubusercontent.com/4209011/179261702-8bd944dd-98f9-4a43-8b53-97110f12c967.jpg)


3. Install [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) and reschedule the `facebook_for_woocommerce_hourly_heartbeat_cron` task to run now.
4. Head to the option page: /wp-admin/options.php, the `wc_facebook_messenger_locale` should be updated.

#### To test refresh_installation_data
1. Navigate to /wp-admin/options.php and delete the `wc_facebook_page_id` and `wc_facebook_pixel_id`

![Screenshot 2022-07-15 at 18 06 11](https://user-images.githubusercontent.com/4209011/179262892-5aa4877c-5e01-4c40-ac0f-08f0f7fb78c4.jpg)

2. Head to [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) and reschedule the `facebook_for_woocommerce_daily_heartbeat_cron` task to run now.
3. go back to /wp-admin/options.php and notice the `wc_facebook_page_id` and `wc_facebook_pixel_id` values are set again:

![Screenshot 2022-07-15 at 18 09 06](https://user-images.githubusercontent.com/4209011/179263375-c6635e41-902d-4937-ba5c-9fd24854f3b4.jpg)

### Changelog entry

>  Tweak - Use the Heartbeat system to refresh the local business configuration data with the latest from Facebook
