### PR TITLE
Release 2.6.18

### DIFF
--- a/assets/css/admin/products-categories.css
+++ b/assets/css/admin/products-categories.css
@@ -12,3 +12,14 @@
 	float: none;
 	width: 100% !important;
 }
+
+tr[class*="term-wc_facebook_enhanced_catalog_attribute"]:not(.term-wc_facebook_enhanced_catalog_attributes_id-title-wrap) > th > label {
+	position: relative;
+	display: block;
+}
+
+tr[class*="term-wc_facebook_enhanced_catalog_attribute"]:not(.term-wc_facebook_enhanced_catalog_attributes_id-title-wrap) > th > label > span.woocommerce-help-tip {
+	position: absolute;
+	right: 15px;
+}
+

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-2022-xx-xx - version 2.6.18
+2022-07-19 - version 2.6.18
 * Fix - Misaligned help icons on Product Categories > Google Product Categories form.
 * Fix - Syncing WC custom placeholder to Facebook shop.
 * Fix - is_search() causing fatal error when custom queries are used.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** Facebook for WooCommerce Changelog ***
 
+2022-xx-xx - version 2.6.18
+* Fix - Misaligned help icons on Product Categories > Google Product Categories form.
+* Fix - Syncing WC custom placeholder to Facebook shop.
+* Fix - is_search() causing fatal error when custom queries are used.
+
 = 2.6.17 - 2022-07-06 =
 * Fix - Add allow-plugins directive and adjust phpcs GitHub workflow.
 * Fix - Scheduled product not synced when status becomes "publish".

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -381,10 +381,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * Triggers Search for result pages (deduped)
 		 *
 		 * @internal
+		 *
+		 * @param WP_Query $query the query object
 		 */
-		public function inject_search_event() {
+		public function inject_search_event( $query ) {
 
-			if ( ! $this->is_pixel_enabled() ) {
+			if ( ! $this->is_pixel_enabled() || ! $query->is_main_query() ) {
 				return;
 			}
 

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,7 +11,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 2.6.17
+ * Version: 2.6.18
  * Text Domain: facebook-for-woocommerce
  * Tested up to: 6.0
  * WC requires at least: 3.5.0
@@ -33,7 +33,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '2.6.17'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '2.6.18'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.0.0';

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -340,7 +340,7 @@ class Product_Categories {
 					<?php $this->render_enhanced_catalog_attributes_tooltip(); ?>
 				</label>
 			</div>
-			<table>
+			<table class="form-table">
 				<?php $enhanced_attribute_fields->render( $category_id ); ?>
 			</table>
 		<?php

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -211,7 +211,7 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 			$image_urls = array_values( $image_urls );
 
 			if ( empty( $image_urls ) ) {
-				$image_urls[] = facebook_for_woocommerce()->get_plugin_url() . '/assets/images/woocommerce-placeholder.png';
+				$image_urls[] = wc_placeholder_img_src();
 			}
 
 			return $image_urls;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.6.17",
+  "version": "2.6.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.6.17",
+  "version": "2.6.18",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 5.9
-Stable tag: 2.6.17
+Stable tag: 2.6.18
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later
@@ -39,7 +39,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= 2.6.18 - 2022-xx-xx =
+= 2.6.18 - 2022-07-19 =
 * Fix - Misaligned help icons on Product Categories > Google Product Categories form.
 * Fix - Syncing WC custom placeholder to Facebook shop.
 * Fix - is_search() causing fatal error when custom queries are used.

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,11 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
+= 2.6.18 - 2022-xx-xx =
+* Fix - Misaligned help icons on Product Categories > Google Product Categories form.
+* Fix - Syncing WC custom placeholder to Facebook shop.
+* Fix - is_search() causing fatal error when custom queries are used.
+
 = 2.6.17 - 2022-07-06 =
 * Fix - Add allow-plugins directive and adjust phpcs GitHub workflow.
 * Fix - Scheduled product not synced when status becomes "publish".


### PR DESCRIPTION
* Fix - Misaligned help icons on Product Categories > Google Product Categories form.
* Fix - Syncing WC custom placeholder to Facebook shop.
* Fix - is_search() causing fatal error when custom queries are used.