### PR TITLE
Changing WooCommerce FBE Flow(Channel) from COMMERCE_OFFSITE to DEFAULT

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -983,7 +983,7 @@ class Connection {
 				'currency'             => get_woocommerce_currency(),
 				'business_vertical'    => 'ECOMMERCE',
 				'domain'               => home_url(),
-				'channel'              => 'COMMERCE_OFFSITE',
+				'channel'              => 'DEFAULT',
 			),
 			'business_config' => array(
 				'business' => array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

_Removing shops from the WooCommerce Facebook Business Extension Flow._

- [✅] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Testing:

https://user-images.githubusercontent.com/17508935/180086018-ca9e533a-6d76-496c-8630-9aa8f52cddab.mp4

Part 1 of the video:
1. Spin up a Local Test WP Environment for WooCommerce
2. Install Facebook for WooCommerce plugin from plugin store
3. Go through the FBE onboarding from plugin
4. Shops are enabled on the flow (Select Commerce Account is available in the flow to enable shops)

Part 2:
1. Spin up a Local Test WP Environment for WooCommerce
2. Install local Facebook for WooCommerce plugin with local dev changes
3. Go through the FBE onboarding from plugin
4. Shops are not enabled in the flow (Only change is Commerce Account is not an asset that is selectable during the flow)

### Changelog entry

> Update - Facebook Business Extension flow from COMMERCE_OFFSITE to DEFAULT
