### PR TITLE
Filter whether to apply shortcode on string before syncing.

### DIFF
--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -165,7 +165,24 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		 * @return string
 		 */
 		public static function clean_string( $string ) {
-			$string = do_shortcode( $string );
+
+			/**
+			 * Filters whether the shortcodes should be applied for a string when syncing a product or be stripped out.
+			 *
+			 * @since x.x.x
+			 *
+			 * @param bool   $apply_shortcodes Shortcodes are applied if set to `true` and stripped out if set to `false`.
+			 * @param string $string           String to clean up.
+			 */
+			$apply_shortcodes = apply_filters( 'wc_facebook_string_apply_shortcodes', false, $string );
+			if ( $apply_shortcodes ) {
+				// Apply active shortcodes
+				$string = do_shortcode( $string );
+			} else {
+				// Strip out active shortcodes
+				$string = strip_shortcodes( $string );
+			}
+
 			$string = str_replace( array( '&amp%3B', '&amp;' ), '&', $string );
 			$string = str_replace( array( "\r", '&nbsp;', "\t" ), ' ', $string );
 			$string = wp_strip_all_tags( $string, false ); // true == remove line breaks


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We applied shortcodes on all strings (descriptions, titles, etc..) synced to FB. but due to a [WP Core bug](https://core.trac.wordpress.org/ticket/18408), the global $post variable is not reset if a shortcode runs a query. That essentially means that any shortcode that uses a query and set the global post with the loop in their code modifies $post and this alters some of the product's contents such as qty, permalink, description, etc...

This PR strips all shortcodes to be in line with our Marketing plugin (Pinterest, GLA) and provides a filter if users want to apply shortcodes.

Closes #2145.
Closes #2251.


- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

#### Video to reproduce

https://user-images.githubusercontent.com/4209011/180384977-6048b017-12f0-4379-845a-16f49b8119ce.mp4



### Detailed test instructions:

### To reproduce the issue:
1. Switch the develop branch
2. Download and install the [Insert PHP Code Snippet](https://wordpress.org/plugins/insert-php-code-snippet/) plugin
3. Create a snippet with the following code (mysite.local/wp-admin/admin.php?page=insert-php-code-snippet-manage):

```
<?php
    global $post;
    $a = new WP_Query('post_type=product');
    while($a->have_posts() ) : $a->the_post();
    endwhile;
    wp_reset_postdata();
```

![Screenshot 2022-07-21 at 16 57 42](https://user-images.githubusercontent.com/4209011/180246019-758d02a6-9da3-4247-918d-d902df73b620.jpg)

4. Edit a product syncing to FB and add the snippet short to the description field. Eg: [xyz-ips snippet="TestSnippet"]

5. Save the product and notice the price, the SKU value, and the product excerpt have been overridden by other data. 

### To test fix:

6. Switch to this branch, and edit another product, repeating steps 4 and 5.
7. The right data are saved, and the description is synced without the shortcode.
8. You can apply shortcodes by using the `wc_facebook_string_apply_shortcodes` filter. You can add `add_filter( 'wc_facebook_string_apply_shortcodes', '__return_true' );`


### Changelog entry

> Add  - `wc_facebook_string_apply_shortcodes` filter to check whether to apply shortcodes on a string before syncing.
