### PR TITLE
 Fix - Price not updating when the sale price is removed.

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -363,33 +363,33 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 		public function add_sale_price( $product_data, $for_items_batch = false ) {
 
 			$sale_price = $this->woo_product->get_sale_price();
-
-			// check if sale exist
-			if ( ! is_numeric( $sale_price ) ) {
-				return $product_data;
-			}
-
-			$sale_price =
-			intval( round( $this->get_price_plus_tax( $sale_price ) * 100 ) );
+			$sale_price_effective_date = '';
 
 			$sale_start =
-			( $date     = $this->woo_product->get_date_on_sale_from() )
-			? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
-			: self::MIN_DATE_1 . self::MIN_TIME;
+				( $date     = $this->woo_product->get_date_on_sale_from() )
+					? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
+					: self::MIN_DATE_1 . self::MIN_TIME;
 
 			$sale_end =
-			( $date   = $this->woo_product->get_date_on_sale_to() )
-			? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
-			: self::MAX_DATE . self::MAX_TIME;
+				( $date   = $this->woo_product->get_date_on_sale_to() )
+					? date_i18n( WC_DateTime::ATOM, $date->getOffsetTimestamp() )
+					: self::MAX_DATE . self::MAX_TIME;
+
+			// check if sale exist
+			if ( is_numeric( $sale_price ) && $sale_price > 0 ) {
+				$sale_price_effective_date = $sale_start . '/' . $sale_end;
+				$sale_price =
+					intval( round( $this->get_price_plus_tax( $sale_price ) * 100 ) );
+			}
 
 			// check if sale is expired and sale time range is valid
 			if ( $for_items_batch ) {
-				$product_data['sale_price_effective_date'] = $sale_start . '/' . $sale_end;
-				$product_data['sale_price']                = self::format_price_for_fb_items_batch( $sale_price );
+				$product_data['sale_price_effective_date'] = $sale_price_effective_date;
+				$product_data['sale_price']                = is_numeric( $sale_price ) ? self::format_price_for_fb_items_batch( $sale_price ) : "";
 			} else {
 				$product_data['sale_price_start_date'] = $sale_start;
 				$product_data['sale_price_end_date']   = $sale_end;
-				$product_data['sale_price']            = $sale_price;
+				$product_data['sale_price']            = is_numeric( $sale_price ) ? $sale_price : 0;
 			}
 
 			return $product_data;


### PR DESCRIPTION

### Changes proposed in this Pull Request:

If a user sets a sales price, the sale price is not cleared from FB when the sales price is removed from the product on the Woo store. This is because the sale_price index was not set on the products update. The changes in this PR now explicitly sets the sale_price index value, setting this to 0 when no sale is found.  

Closes #2261.


- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.



### Detailed test instructions:

1. Create/edit a product and set a sale price for the product. Observe that the product is synced to FB and the sale price is displayed correctly on the FB store.
2. Update the product, removing the sale price.
3. Go to FB, and the sale price is correctly updated on sync.

### Changelog entry

> Fix - Price not updating when the sale price is removed.
