### PR TITLE
Fix - Trashed products in WooCommerce remain listed on Facebook.

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -360,6 +360,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 				add_action( 'before_delete_post', array( $this, 'on_product_delete' ) );
 
+				// Ensure product is deleted from FB when moved to trash.
+				add_action( 'wp_trash_post', array( $this, 'on_product_delete' ) );
+
 				add_action( 'add_meta_boxes', 'SkyVerge\WooCommerce\Facebook\Admin\Product_Sync_Meta_Box::register', 10, 1 );
 
 				add_action(

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1116,7 +1116,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			// - new status is 'publish' regardless of old status, sync to Facebook
 			$this->on_product_publish( $product->get_id() );
 		} else {
-			$this->update_fb_visibility( $product->get_id(), $visibility );
+			$this->update_fb_visibility( $product, $visibility );
 		}
 	}
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -423,7 +423,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			3
 		);
 
-		add_action( 'untrashed_post', array( $this, 'fb_restore_untrashed_variable_product' ));
+		add_action( 'untrashed_post', array( $this, 'fb_restore_untrashed_variable_product' ) );
 
 		// Product Set hooks.
 		add_action( 'fb_wc_product_set_sync', array( $this, 'create_or_update_product_set_item' ), 99, 2 );

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1004,12 +1004,14 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		}
 
 		/**
-		 * bail if not enabled for sync, except if explicitly deleting from the metabox
+		 * Bail if not enabled for sync, except if explicitly deleting from the metabox or when deleting the
+		 * parent product ( Products::published_product_should_be_synced( $product ) will fail for the parent product
+		 * when deleting a variable product. This causes the fb_group_id to remain on the DB. )
 		 *
 		 * @see ajax_delete_fb_product()
 		 */
 		if ( ( ! wp_doing_ajax() || ! isset( $_POST['action'] ) || 'ajax_delete_fb_product' !== $_POST['action'] )
-			 && ! Products::published_product_should_be_synced( $product ) ) {
+			 && ! Products::published_product_should_be_synced( $product ) && ! $product->is_type( "variable" ) ) {
 
 			return;
 		}
@@ -1065,6 +1067,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		// clear out both item and group IDs
 		delete_post_meta( $product_id, self::FB_PRODUCT_ITEM_ID );
 		delete_post_meta( $product_id, self::FB_PRODUCT_GROUP_ID );
+
 	}
 
 
@@ -1104,10 +1107,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		if ( $visibility === self::FB_SHOP_PRODUCT_VISIBLE ) {
 			// - new status is 'publish' regardless of old status, sync to Facebook
 			$this->on_product_publish( $product->get_id() );
-		} else {
-			$this->update_fb_visibility( $product, $visibility );
 		}
-
 	}
 
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1217,6 +1217,10 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$woo_product = new \WC_Facebook_Product( $wp_id );
 		}
 
+		if ( ! $this->product_should_be_synced( $woo_product->woo_product ) ) {
+			return;
+		}
+
 		if ( $this->delete_on_out_of_stock( $wp_id, $woo_product->woo_product ) ) {
 			return;
 		}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1104,7 +1104,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			return;
 		}
 
-		if ( ! $product->is_type( 'variant' ) ) {
+		// Exclude variants. Product variables visibility is handled separately.
+		// @See fb_restore_untrashed_variable_product.
+		if ( $product->is_type( 'variant' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When a product is deleted in WooCommerce it remains on the shop page on Facebook. This PR makes a few changes in the way we handle deleted products:

- We run on_product_delete on the `wp_trash_post` action hook, allowing the product to be also removed from the FB catalog.
- Allow variable products to bypass the `published_product_should_be_synced` check, as this will always return false because some variation products might already be removed. 
- We also add in `fb_restore_untrashed_variable_product` function that runs on the `untrashed_post` action hook. This ensures variable products are correctly published after all the variations have been untrashed.


Closes #2256 .


### Detailed test instructions:

1. Create a product and sync it to Facebook
2. Trash the product from within WooCommerce
3. See product has also been removed on Facebook.
4. Restore the product; the product is recreated on Facebook.

### Changelog entry

> Fix - Ensure product is deleted from FB when moved to trash.
