### PR TITLE
Add branch-labels GH workflow

### DIFF
--- a/.github/workflows/branch-labels.yml
+++ b/.github/workflows/branch-labels.yml
@@ -1,0 +1,11 @@
+name: Set PR Labels
+
+on:
+  pull_request:
+    types: opened
+jobs:
+  SetLabels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set Labels
+        uses: woocommerce/grow/branch-label@actions-v1


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add branch-labels GH workflow,
to set `changelog: *` labels to PRs based on [conventional branch names](https://github.com/woocommerce/google-listings-and-ads/wiki/Working-With-Code#naming-branches).


### Screenshots:

![Screenshot of github entry about github-actions bot adding labels](https://user-images.githubusercontent.com/17435/184181580-f28ec683-1cc4-4b15-8c6a-8ecab4af0da4.png)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check the labels added for this PR.
2. Create a new PR branched from this one, with a conventional name: `(break|add|update|fix|tweak|dev|doc|release|hotfix)/(issue-number)-short-slug`
3. Check the labels added by `github-actions` bot.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Add branch-labels GH workflow.
