### PR TITLE
Gracefully handle `get_current_url` when `$_SERVER['HTTP_REFERER']` not present

### DIFF
--- a/includes/Events/Event.php
+++ b/includes/Events/Event.php
@@ -215,7 +215,7 @@ class Event {
 
 		if ( wp_doing_ajax() ) {
 
-			$url = $_SERVER['HTTP_REFERER'];
+			$url = wp_get_raw_referer();
 
 		} else {
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #1729.

Switch to using `wp_get_raw_referer()` instead of `$_SERVER['HTTP_REFERER']`. `wp_get_raw_referer()` was introduced in [WordPress 4.5.0](https://developer.wordpress.org/reference/functions/wp_get_raw_referer/) and it also accomodates AJAX calls that utilize the `wp_referer_field` functionality (which has been around since [2.0.4](https://developer.wordpress.org/reference/functions/wp_referer_field/))

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Additional details:

### Changelog entry

> Fix - `Undefined array key "HTTP_REFERER"` not longer happens when `new Event` is triggered from an AJAX call that doesn't include a referrer (likely due to browser configuration)
