### PR TITLE
Fix - Out of stock stock products in WooCommerce remain listed on Facebook

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1053,13 +1053,13 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				if ( $variation instanceof \WC_Product ) {
 					$retailer_ids[] = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $variation );
 				}
+				delete_post_meta( $variation_id, self::FB_PRODUCT_ITEM_ID );
 			}
 
 			// enqueue variations to be deleted in the background
 			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( $retailer_ids );
 
 			$this->delete_product_group( $product_id );
-
 		} else {
 
 			$this->delete_product_item( $product_id );
@@ -1198,8 +1198,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	function delete_on_out_of_stock( $wp_id, $woo_product ) {
 
 		if ( Products::product_should_be_deleted( $woo_product ) ) {
-
-			$this->delete_product_item( $wp_id );
+			$product = wc_get_product( $wp_id );
+			$this->delete_fb_product( $product );
 			return true;
 		}
 
@@ -1219,11 +1219,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$woo_product = new \WC_Facebook_Product( $wp_id );
 		}
 
-		if ( ! $this->product_should_be_synced( $woo_product->woo_product ) ) {
+		if ( $this->delete_on_out_of_stock( $wp_id, $woo_product->woo_product ) ) {
 			return;
 		}
 
-		if ( $this->delete_on_out_of_stock( $wp_id, $woo_product->woo_product ) ) {
+		if ( ! $this->product_should_be_synced( $woo_product->woo_product ) ) {
 			return;
 		}
 
@@ -1274,11 +1274,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$woo_product = new \WC_Facebook_Product( $wp_id, $parent_product );
 		}
 
-		if ( ! $this->product_should_be_synced( $woo_product->woo_product ) ) {
+		if ( $this->delete_on_out_of_stock( $wp_id, $woo_product->woo_product ) ) {
 			return;
 		}
 
-		if ( $this->delete_on_out_of_stock( $wp_id, $woo_product->woo_product ) ) {
+		if ( ! $this->product_should_be_synced( $woo_product->woo_product ) ) {
 			return;
 		}
 

--- a/includes/Products/Sync.php
+++ b/includes/Products/Sync.php
@@ -110,7 +110,7 @@ class Sync {
 	public function delete_products( array $retailer_ids ) {
 
 		foreach ( $retailer_ids as $retailer_id ) {
-			$this->requests[ $retailer_id ] = self::ACTION_DELETE;
+			$this->requests[ $this->get_product_index( $retailer_id ) ] = self::ACTION_DELETE;
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

If a user has checked the "Hide out of stock items from the catalog" option in WooCommerce (WooCommerce -> settings -> Products -> inventory), out-of-stock variable products are not deleted from Facebook. This PR fixes the logic to ensure the FB product is removed.


Closes #2277.


- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Make sure the "Hide out of stock items from the catalog" option in WooCommerce (WooCommerce -> settings -> Products -> inventory) is checked
2. Edit a simple product and set the stock quantity to 0.
3. The product should be removed from the FB catalog.
4. Repeat steps 2 and 3 with a variable product and observe that the product is removed from the catalog

### Changelog entry

> Fix - Remove out-of-stock products on Facebook when the "Hide out of stock items from the catalog" option in WooCommerce is checked.
