### PR TITLE
Fix - Incorrect content_name and content_ids for variable product when redirect to cart is enabled

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -772,13 +772,23 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function set_last_product_added_to_cart_upon_redirect( $redirect, $product = null ) {
 
-			if ( $product instanceof \WC_Product ) {
-				WC()->session->set( 'facebook_for_woocommerce_last_product_added_to_cart', $product->get_id() );
-			} elseif ( isset( $_GET['add-to-cart'] ) && is_numeric( $_GET['add-to-cart'] ) ) {
-				WC()->session->set( 'facebook_for_woocommerce_last_product_added_to_cart', (int) $_GET['add-to-cart'] );
+			// Bail if the session variable has been set.
+			if ( WC()->session->get( 'facebook_for_woocommerce_last_product_added_to_cart', 0 ) > 0 ) {
+				return $redirect;
 			}
 
+			$product_id = 0;
+
+			if ( $product instanceof \WC_Product ) {
+				$product_id = $_POST['variation_id'] ?? $product->get_id();
+			} elseif ( isset( $_GET['add-to-cart'] ) && is_numeric( $_GET['add-to-cart'] ) ) {
+				$product_id = $_GET['add-to-cart'];
+			}
+
+			WC()->session->set( 'facebook_for_woocommerce_last_product_added_to_cart', (int) $product_id );
+
 			return $redirect;
+
 		}
 
 


### PR DESCRIPTION

### Changes proposed in this Pull Request:

When Redirect to the cart page after successful addition is enabled, the content_name and content_ids parameters on the AddToCart event will contain the variable product name and ID instead of the individual variation because `inject_add_to_cart_redirect_event` would only pass the parent_id to when calling the `inject_add_to_cart_event` method. 

I propose setting the `facebook_for_woocommerce_last_product_added_to_cart` session variable to the variation id when a variation in added to the cart.

Also `set_last_product_added_to_cart_upon_redirect` is called multiple times, I added a check to ensure that the session variable is not overriden.


Closes #2276.


- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

![Screenshot 2022-08-24 at 15 29 25](https://user-images.githubusercontent.com/4209011/186431773-90b86d59-0b9d-42da-84ca-32a60e62c3d0.jpg)


### Detailed test instructions:

1. Create a variable product
2. Go to WooCommerce > Settings > Products and enable Redirect to the cart page after successful addition
3. Add one of the variations to cart
4. See if the content_name and content_ids on the AddToCart event are correct. i.e Example Product - Variation 1 (See screenshot above.)

### Changelog entry

> Fix - Ensure content_name and content_ids addToCart pixel event properties are correct for variable products when redirect to cart is enabled in WooCommerce.
