### PR TITLE
Fix - Adding an excluded category doesn't remove that category synced products

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1031,7 +1031,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 *
 	 * @param \WC_Product $product WooCommerce product object
 	 */
-	private function delete_fb_product( $product ) {
+	public function delete_fb_product( $product ) {
 
 		$product_id = $product->get_id();
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -245,7 +245,7 @@ class Products {
 	 */
 	public static function product_should_be_deleted( \WC_Product $product ) {
 
-		return ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $product->is_in_stock() ) || ! facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_product_terms_check();;
+		return ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $product->is_in_stock() ) || ! facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_product_terms_check();
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -235,7 +235,8 @@ class Products {
 	/**
 	 * Determines whether the given product should be removed from the catalog.
 	 *
-	 * A product should be removed if it is no longer in stock and the user has opted-in to hide products that are out of stock.
+	 * A product should be removed if it is no longer in stock and the user has opted-in to hide products that are out of stock,
+	 * or belongs to an excluded category.
 	 *
 	 * @since 2.0.0
 	 *
@@ -244,7 +245,7 @@ class Products {
 	 */
 	public static function product_should_be_deleted( \WC_Product $product ) {
 
-		return 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $product->is_in_stock() || ! facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_product_terms_check();;
+		return ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $product->is_in_stock() ) || ! facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_product_terms_check();;
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -101,6 +101,12 @@ class Products {
 					$product->update_meta_data( self::SYNC_ENABLED_META_KEY, $enabled );
 					$product->save_meta_data();
 				}
+
+				// Remove excluded product from FB.
+				if ( "no" === $enabled && self::product_should_be_deleted( $product ) ) {
+					facebook_for_woocommerce()->get_integration()->delete_fb_product( $product );
+				}
+
 			}//end if
 		}//end foreach
 	}
@@ -238,7 +244,7 @@ class Products {
 	 */
 	public static function product_should_be_deleted( \WC_Product $product ) {
 
-		return 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $product->is_in_stock();
+		return 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) && ! $product->is_in_stock() || ! facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_product_terms_check();;
 	}
 
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

After syncing products, if you exclude a category it doesn't remove the products from that category. The logic excludes the product from future syncs but doesn't remove the excluded product from the FB catalog, potentially causing products to linger in the FB catalog (#2129 ). This PR fixes the issue.


Closes #2259.


- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1. Sync all your products
2. See the products are in facebook normally
3. Add one excluded category and resync
4. Products should now be removed from the facebook catalog.


### Changelog entry

> Fix - Adding an excluded category doesn't remove that category synced products
