### PR TITLE
Fix - 2171 Cannot disable Facebook Messenger

### DIFF
--- a/includes/Admin/Settings_Screens/Messenger.php
+++ b/includes/Admin/Settings_Screens/Messenger.php
@@ -28,10 +28,6 @@ class Messenger extends Admin\Abstract_Settings_Screen {
 	const ID = 'messenger';
 
 
-	/** @var null|Configuration\Messenger */
-	private $remote_configuration;
-
-
 	/**
 	 * Connection constructor.
 	 */
@@ -72,11 +68,7 @@ class Messenger extends Admin\Abstract_Settings_Screen {
 	 */
 	public function render_locale_field( $field ) {
 
-		if ( ! $this->remote_configuration ) {
-			return;
-		}
-
-		$configured_locale = $this->remote_configuration->get_default_locale();
+		$configured_locale = get_option( \WC_Facebookcommerce_Integration::SETTING_MESSENGER_LOCALE, '' );;
 		$supported_locales = Locale::get_supported_locales();
 
 		if ( ! empty( $supported_locales[ $configured_locale ] ) ) {
@@ -140,7 +132,7 @@ class Messenger extends Admin\Abstract_Settings_Screen {
 	 */
 	public function get_settings() {
 
-		$is_enabled = $this->remote_configuration && $this->remote_configuration->is_enabled();
+		$is_enabled = get_option( \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER, 'no' );
 
 		$settings = array(
 
@@ -155,12 +147,12 @@ class Messenger extends Admin\Abstract_Settings_Screen {
 				'type'    => 'checkbox',
 				'desc'    => __( 'Enable and customize Facebook Messenger on your store', 'facebook-for-woocommerce' ),
 				'default' => 'no',
-				'value'   => $is_enabled ? 'yes' : 'no',
+				'value'   => $is_enabled,
 			),
 		);
 
 		// only add the static configuration display if messenger is enabled
-		if ( $is_enabled ) {
+		if ( 'yes' === $is_enabled ) {
 
 			$settings[] = array(
 				'title' => __( 'Language', 'facebook-for-woocommerce' ),
@@ -195,68 +187,6 @@ class Messenger extends Admin\Abstract_Settings_Screen {
 			'</a>'
 		);
 	}
-
-
-	/**
-	 * Renders the settings page.
-	 *
-	 * This is overridden to pull the latest FBE configuration so the settings can be populated correctly.
-	 *
-	 * @since 2.0.0
-	 */
-	public function render() {
-
-		// if not connected, don't try and retrieve any settings and just fall back to standard display
-		if ( ! facebook_for_woocommerce()->get_connection_handler()->is_connected() ) {
-			parent::render();
-			return;
-		}
-
-		$plugin = facebook_for_woocommerce();
-
-		try {
-
-			$response = $plugin->get_api()->get_business_configuration( $plugin->get_connection_handler()->get_external_business_id() );
-
-			$configuration = $response->get_messenger_configuration();
-
-			if ( ! $configuration ) {
-				throw new Framework\SV_WC_API_Exception( 'Could not retrieve latest messenger configuration' );
-			}
-
-			update_option( \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER, wc_bool_to_string( $configuration->is_enabled() ) );
-
-			if ( $default_locale = $configuration->get_default_locale() ) {
-				update_option( \WC_Facebookcommerce_Integration::SETTING_MESSENGER_LOCALE, $default_locale );
-			}
-
-			// set the remote configuration so other methods can use its values
-			$this->remote_configuration = $configuration;
-
-			parent::render();
-
-		} catch ( Framework\SV_WC_API_Exception $exception ) {
-
-			?>
-			<div class="notice notice-error">
-				<p>
-					<?php
-					printf(
-					/* translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag */
-						esc_html__( 'There was an error communicating with the Facebook Business Extension. %1$sClick here%2$s to manage your Messenger settings.', 'facebook-for-woocommerce' ),
-						'<a href="' . esc_url( $plugin->get_connection_handler()->get_manage_url() ) . '" target="_blank">',
-						'</a>'
-					);
-					?>
-				</p>
-			</div>
-			<?php
-
-			// always log this error, regardless of debug setting
-			$plugin->log( 'Could not display messenger settings. ' . $exception->getMessage() );
-		}
-	}
-
 
 	/**
 	 * Saves the settings.
@@ -302,9 +232,23 @@ class Messenger extends Admin\Abstract_Settings_Screen {
 				$configuration->set_enabled( $setting_enabled );
 				$configuration->add_domain( home_url( '/' ) );
 
-				$plugin->get_api()->update_messenger_configuration( $external_business_id, $configuration );
+				try {
+					$plugin->get_api()->update_messenger_configuration( $external_business_id, $configuration );
+
+					update_option( \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER, wc_bool_to_string( $configuration->is_enabled() ) );
+
+					if ( $default_locale = $configuration->get_default_locale() ) {
+						update_option( \WC_Facebookcommerce_Integration::SETTING_MESSENGER_LOCALE, $default_locale );
+					}
+				} catch ( Framework\SV_WC_API_Exception $exception ) {
+
+					// always log this error, regardless of debug setting
+					$plugin->log( 'Could not display messenger settings. ' . $exception->getMessage() );
+
+				}
 
 				delete_transient( 'wc_facebook_business_configuration_refresh' );
+
 			}
 
 			// save any real settings


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When I navigate to WooCommerce > Marketing > Facebook > Messenger and disable Enable Messenger, the settings do not persist after selecting Save Changes. This is because of a bug in the FBE API that would not persist this setting when set to False (https://github.com/woocommerce/facebook-for-woocommerce/issues/2171#issuecomment-1112127764). We reported this issue to the FBE team, and it doesn't look like they're planning on addressing this anytime soon. 

This PR is a workaround that addresses the problem by treating `wc_facebook_enable_messenger` as a local configuration that the user can update by saving the Messenger Configuration screen. The `wc_facebook_enable_messenger`  was previously updated by making an API call on the render method. However, because the FBE API did not persist the data, the `wc_facebook_enable_messenger` option would be overridden again and again, making it difficult for the user to disable the FB Messenger setting unless they deleted the config on their FB page.


Fixes #2171.


- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1. Navigate to WooCommerce > Marketing > Facebook > Messenger
2. If Enable Messenger is disabled, enable it and save settings.
3. Disable Enable Messenger and save settings.
4. Enable Messenger remains disabled, and the chat plugin does not load on the front end.


### Changelog entry

> Fix - When disabling Enable Messenger on the Messenger setting page, the setting does not persist after selecting Save Changes
