### PR TITLE
Add check to make sure page property exists.

### DIFF
--- a/includes/API/FBE/Installation/Read/Response.php
+++ b/includes/API/FBE/Installation/Read/Response.php
@@ -84,9 +84,7 @@ class Response extends API\Response {
 	 */
 	public function get_page_id() {
 
-		$pages = ! empty( $this->get_data()->pages ) ? $this->get_data()->pages : '';
-
-		if ( empty( $pages ) ) {
+		if ( empty( $pages = $this->get_data()->pages ) ) {
 			return '';
 		}
 

--- a/includes/API/FBE/Installation/Read/Response.php
+++ b/includes/API/FBE/Installation/Read/Response.php
@@ -84,11 +84,14 @@ class Response extends API\Response {
 	 */
 	public function get_page_id() {
 
-		$pages = $this->get_data()->pages;
+		$pages = ! empty( $this->get_data()->pages ) ? $this->get_data()->pages : '';
 
-		return ! empty( $pages ) && is_array( $pages ) ? current( $pages ) : '';
+		if ( empty( $pages ) ) {
+			return '';
+		}
+
+		return is_array( $pages ) ? current( $pages ) : $pages;
 	}
-
 
 	/**
 	 * Gets Instagram Business ID.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2282.

User reported a PHP notice in the error log file:

```
PHP Notice:  Undefined property: stdClass::$pages in /***domain***/wp-content/plugins/facebook-for-woocommerce/includes/API/FBE/Installation/Read/Response.php on line 87
```
I wasn't able to reproduce this since I don't have access to [WP Rocket](https://wp-rocket.me/), but I can see that we assume `$this->get_data()`	has the `pages` property. I added an additional check to prevent this error and also to keep this method consistent with [other getter methods](https://github.com/woocommerce/facebook-for-woocommerce/blob/8a2438e60d0f9290580a89848b3e60374981b47c/includes/API/FBE/Installation/Read/Response.php#L100-L109) in the class.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

Check the steps to reproduce in #2282 and confirm the issue is fixed

### Changelog entry

> Fix - PHP notice thrown by get_page_id() in facebook-for-woocommerce/includes/API/FBE/Installation/Read/Response.php
