### PR TITLE
Release 2.6.22

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,12 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 2.6.22 - 2022-09-06 =
+* Fix - Adding an excluded category doesn't remove that category synced products.
+* Fix - Ensure content_name and content_ids addToCart pixel event properties are correct for variable products when redirect to cart is enabled in WooCommerce.
+* Fix - Remove out-of-stock products on Facebook when the "Hide out of stock items from the catalog" option in WooCommerce is checked.
+* Tweak - WC 6.9 compatibility.
+* Update - Facebook Business Extension flow from COMMERCE_OFFSITE to DEFAULT.
+
 = 2.6.21 - 2022-08-16 =
 * Dev - Add branch-labels GH workflow.
 * Fix - `Undefined array key "HTTP_REFERER"` not longer happens when `new Event` is triggered from an AJAX call that doesn't include a referrer (likely due to browser configuration).

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,11 +11,11 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 2.6.21
+ * Version: 2.6.22
  * Text Domain: facebook-for-woocommerce
  * Tested up to: 6.0
  * WC requires at least: 3.5.0
- * WC tested up to: 6.8
+ * WC tested up to: 6.9
  * Requires PHP: 7.0
  *
  * @package FacebookCommerce
@@ -33,7 +33,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '2.6.21'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '2.6.22'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.0.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.6.21",
+  "version": "2.6.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.6.21",
+  "version": "2.6.22",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 6.0
-Stable tag: 2.6.21
+Stable tag: 2.6.22
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,13 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
+= 2.6.22 - 2022-09-06 =
+* Fix - Adding an excluded category doesn't remove that category synced products.
+* Fix - Ensure content_name and content_ids addToCart pixel event properties are correct for variable products when redirect to cart is enabled in WooCommerce.
+* Fix - Remove out-of-stock products on Facebook when the "Hide out of stock items from the catalog" option in WooCommerce is checked.
+* Tweak - WC 6.9 compatibility.
+* Update - Facebook Business Extension flow from COMMERCE_OFFSITE to DEFAULT.
+
 = 2.6.21 - 2022-08-16 =
 * Dev - Add branch-labels GH workflow.
 * Fix - `Undefined array key "HTTP_REFERER"` not longer happens when `new Event` is triggered from an AJAX call that doesn't include a referrer (likely due to browser configuration).


### PR DESCRIPTION
* Fix - Adding an excluded category doesn't remove that category synced products.
* Fix - Ensure content_name and content_ids addToCart pixel event properties are correct for variable products when redirect to cart is enabled in WooCommerce.
* Fix - Remove out-of-stock products on Facebook when the "Hide out of stock items from the catalog" option in WooCommerce is checked.
* Tweak - WC 6.9 compatibility.
* Update - Facebook Business Extension flow from COMMERCE_OFFSITE to DEFAULT.