### PR TITLE
Show warning when creating product set with excluded categories.

### DIFF
--- a/assets/js/admin/product-sets-admin.js
+++ b/assets/js/admin/product-sets-admin.js
@@ -27,4 +27,42 @@ jQuery( document ).ready( function( $ ) {
 
 	}
 
+	let $submitButton = $( 'form[id="addtag"] input[name="submit"]' );
+
+	$submitButton.on( 'click', function( e ) {
+
+		let $selectedCategories = $('#_wc_facebook_product_cats').val();
+		let excludedCategoryIDs   = [];
+
+		if ( window.facebook_for_woocommerce_product_sets && window.facebook_for_woocommerce_product_sets.excluded_category_ids ) {
+			excludedCategoryIDs = window.facebook_for_woocommerce_product_sets.excluded_category_ids;
+		}
+
+		if ( $selectedCategories.length > 0 && excludedCategoryIDs.length > 0 ) {
+			if ( hasExcludedCategories( $selectedCategories, excludedCategoryIDs ) ) {
+				alert( facebook_for_woocommerce_product_sets.excluded_category_warning_message );
+			}
+		}
+
+	});
+
 } );
+
+/**
+ * Checks if selected categories contains any excluded categories.
+ *
+ * @param selectedCategories Array of submitted category ids
+ * @param excludedCategoryIDs Array category ids excluded from sync.
+ * @returns {boolean}
+ */
+function hasExcludedCategories( selectedCategories, excludedCategoryIDs ) {
+
+	let counter = 0;
+
+	for ( let i = 0; i < excludedCategoryIDs.length; i++ ) {
+		if ( excludedCategoryIDs.includes( excludedCategoryIDs[i] ) ) counter++;
+	}
+
+	return counter > 0;
+
+}

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -173,6 +173,16 @@ class Admin {
 					\WC_Facebookcommerce::PLUGIN_VERSION,
 					true
 				);
+
+				wp_localize_script(
+					'facebook-for-woocommerce-product-sets',
+					'facebook_for_woocommerce_product_sets',
+					array(
+
+						'excluded_category_ids'             => facebook_for_woocommerce()->get_integration()->get_excluded_product_category_ids(),
+						'excluded_category_warning_message' => __( 'You have selected one or more categories currently excluded from the Facebook sync. Products belonging to the excluded categories will not be added to your FB product set.', 'facebook-for-woocommerce' ),
+					)
+				);
 			}
 
 			if ( 'product' === $current_screen->id || 'edit-product' === $current_screen->id ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2258.

The initial issue was created because it was possible to create a FB product set for a category excluded from Sync. This issue has been addressed by #2280. but the product set would be created is created in WooCommerce without not a warning to tell the user that the excluded product will not be added to the FB set.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

![Screenshot 2022-09-06 at 19 35 16](https://user-images.githubusercontent.com/4209011/188702339-b15dc7e8-4af3-4670-9f2d-143a8078cc72.jpg)



### Detailed test instructions:

1. Go to Facebook -> Sync Products and add an excluded category (example: hoodies)
2. Go to Product Sets and add a new set with that excluded category
3. An alert warns the user the products will not be synced.
4. The excluded category(e)s products are not added in a set.


### Additional details:
Note: You will need to build the JS assets by running `npm run build:assets` on your local environment.

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

### Changelog entry

> Add - Show warning when creating product set with excluded categories.
