### PR TITLE
The hearbeat cron shouldn't update messenger config.

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -148,24 +148,6 @@ class Connection {
 				$response->is_ig_cta_enabled()
 			);
 
-			// update the messenger settings
-			if ( $messenger_configuration = $response->get_messenger_configuration() ) {
-
-				// store the local "enabled" setting
-				update_option( \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER, wc_bool_to_string( $messenger_configuration->is_enabled() ) );
-
-				if ( $default_locale = $messenger_configuration->get_default_locale() ) {
-					update_option( \WC_Facebookcommerce_Integration::SETTING_MESSENGER_LOCALE, sanitize_text_field( $default_locale ) );
-				}
-
-				// if the site's domain is somehow missing from the allowed domains, re-add it
-				if ( $messenger_configuration->is_enabled() && ! in_array( home_url( '/' ), $messenger_configuration->get_domains(), true ) ) {
-
-					$messenger_configuration->add_domain( home_url( '/' ) );
-
-					$this->get_plugin()->get_api()->update_messenger_configuration( $this->get_external_business_id(), $messenger_configuration );
-				}
-			}
 		} catch ( SV_WC_API_Exception $exception ) {
 
 			$this->get_plugin()->log( 'Could not refresh business configuration. ' . $exception->getMessage() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We recently decided to keep the messenger `wc_facebook_enable_messenger` setting localized, regardless of the option configured on the FBE dashboard. 

The `refresh_business_configuration` process which runs hourly would update the option based on what's configured on FB, thus overriding the local option. This PR removes the code to update the messenger settings


Related to #2171.


- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:


1. Navigate to WooCommerce > Marketing > Facebook > Messenger
2. If Enable Messenger is disabled, enable it and save settings.
3. Disable Enable Messenger and save settings.
4. Enable Messenger remains disabled, and the chat plugin does not load on the front end.
5. Using [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/) and reschedule the facebook_for_woocommerce_daily_heartbeat_cron task to run now.
6. Observe that the `wc_facebook_enable_messenger` option is not overridden.


### Changelog entry

> Fix - Messenger settings are no longer overridden after business config refresh.
