### PR TITLE
Track purchase event flag in session variable instead post meta table.

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -918,10 +918,10 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			}
 
 			// use a session flag to ensure an order is tracked with any payment method, also when the order is placed through AJAX
-			$order_placed_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_order_placed';
+			$order_placed_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_order_placed_' . $order_id;
 
 			// use a session flag to ensure a Purchase event is not tracked multiple times
-			$purchase_tracked_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_purchase_tracked';
+			$purchase_tracked_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_purchase_tracked' . $order_id;
 
 			// when saving the order meta data: add a flag to mark the order tracked
 			if ( 'woocommerce_checkout_update_order_meta' === current_action() ) {
@@ -1015,7 +1015,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
-			$order_placed_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_order_placed';
+			$order_placed_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_order_placed_' . $order->get_id();
 			WC()->session->set( $order_placed_session_flag, 'yes' );
 
 		}

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -917,21 +917,20 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
-			// use an order meta to ensure an order is tracked with any payment method, also when the order is placed through AJAX
-			$order_placed_meta = '_wc_' . facebook_for_woocommerce()->get_id() . '_order_placed';
+			// use a session flag to ensure an order is tracked with any payment method, also when the order is placed through AJAX
+			$order_placed_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_order_placed';
 
-			// use an order meta to ensure a Purchase event is not tracked multiple times
-			$purchase_tracked_meta = '_wc_' . facebook_for_woocommerce()->get_id() . '_purchase_tracked';
+			// use a session flag to ensure a Purchase event is not tracked multiple times
+			$purchase_tracked_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_purchase_tracked';
 
 			// when saving the order meta data: add a flag to mark the order tracked
 			if ( 'woocommerce_checkout_update_order_meta' === current_action() ) {
-				$order->update_meta_data( $order_placed_meta, 'yes' );
-				$order->save_meta_data();
+				WC()->session->set( $order_placed_session_flag, 'yes' );
 				return;
 			}
 
 			// bail if by the time we are on the thank you page the meta has not been set or we already tracked a Purchase event
-			if ( 'yes' !== $order->get_meta( $order_placed_meta ) || 'yes' === $order->get_meta( $purchase_tracked_meta ) ) {
+			if ( 'yes' !== WC()->session->get( $order_placed_session_flag, 'no' ) || 'yes' === WC()->session->get( $purchase_tracked_session_flag, 'no' ) ) {
 				return;
 			}
 
@@ -986,8 +985,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$this->inject_subscribe_event( $order_id );
 
 			// mark the order as tracked
-			$order->update_meta_data( $purchase_tracked_meta, 'yes' );
-			$order->save_meta_data();
+			WC()->session->set( $purchase_tracked_session_flag, 'yes' );
 		}
 
 		/**
@@ -1017,9 +1015,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
-			$order_placed_meta = '_wc_' . facebook_for_woocommerce()->get_id() . '_order_placed';
-			$order->update_meta_data( $order_placed_meta, 'yes' );
-			$order->save_meta_data();
+			$order_placed_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_order_placed';
+			WC()->session->set( $order_placed_session_flag, 'yes' );
+
 		}
 
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -921,7 +921,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$order_placed_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_order_placed_' . $order_id;
 
 			// use a session flag to ensure a Purchase event is not tracked multiple times
-			$purchase_tracked_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_purchase_tracked' . $order_id;
+			$purchase_tracked_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_purchase_tracked_' . $order_id;
 
 			// when saving the order meta data: add a flag to mark the order tracked
 			if ( 'woocommerce_checkout_update_order_meta' === current_action() ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We're using _wc_facebook_for_woocommerce_order_placed and _wc_facebook_for_woocommerce_purchase_tracked to stop duplicate purchase events from firing. These values are not cleared and may pile in the users' DB. This PR moves these flags to session variables.

Closes #2125.


- [x ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.



### Detailed test instructions:

1. Complete a purchase.
2. Observe the Pixel purchase event is tracked.
3. Refresh the thank you page. The `inject_purchase_event` method should exit, and no additional purchase events tracked.


### Changelog entry

> Fix - Track purchase event flag in session variable instead post meta table.
