### PR TITLE
Release/2.6.23

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 *** Facebook for WooCommerce Changelog ***
-z
+
 = 2.6.22 - 2022-09-06 =
 * Fix - Adding an excluded category doesn't remove that category synced products.
 * Fix - Ensure content_name and content_ids addToCart pixel event properties are correct for variable products when redirect to cart is enabled in WooCommerce.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-2022-09-13 - version 2.6.23
+2022-xx-xx - version X.X.X
 * Add - Show warning when creating product set with excluded categories.
 * Fix - Messenger settings are no longer overridden after business config refresh.
 * Fix - PHP notice thrown by get_page_id() in facebook-for-woocommerce/includes/API/FBE/Installation/Read/Response.php.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-2022-xx-xx - version X.X.X
+2022-09-13 - version 2.6.23
 * Add - Show warning when creating product set with excluded categories.
 * Fix - Messenger settings are no longer overridden after business config refresh.
 * Fix - PHP notice thrown by get_page_id() in facebook-for-woocommerce/includes/API/FBE/Installation/Read/Response.php.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,11 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 2.6.23 - 2022-09-13 =
+* Add - Show warning when creating product set with excluded categories.
+* Fix - Messenger settings are no longer overridden after business config refresh.
+* Fix - PHP notice thrown by get_page_id() in facebook-for-woocommerce/includes/API/FBE/Installation/Read/Response.php.
+* Fix - When disabling Enable Messenger on the Messenger setting page, the setting does not persist after selecting Save Changes.
+
 = 2.6.22 - 2022-09-06 =
 * Fix - Adding an excluded category doesn't remove that category synced products.
 * Fix - Ensure content_name and content_ids addToCart pixel event properties are correct for variable products when redirect to cart is enabled in WooCommerce.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,11 +1,5 @@
 *** Facebook for WooCommerce Changelog ***
-
-2022-xx-xx - version X.X.X
-* Add - Show warning when creating product set with excluded categories.
-* Fix - Messenger settings are no longer overridden after business config refresh.
-* Fix - PHP notice thrown by get_page_id() in facebook-for-woocommerce/includes/API/FBE/Installation/Read/Response.php.
-* Fix - When disabling Enable Messenger on the Messenger setting page, the setting does not persist after selecting Save Changes.
-
+z
 = 2.6.22 - 2022-09-06 =
 * Fix - Adding an excluded category doesn't remove that category synced products.
 * Fix - Ensure content_name and content_ids addToCart pixel event properties are correct for variable products when redirect to cart is enabled in WooCommerce.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-= 2022-xx-xx - version X.X.X =
+2022-xx-xx - version X.X.X
 * Add - Show warning when creating product set with excluded categories.
 * Fix - Messenger settings are no longer overridden after business config refresh.
 * Fix - PHP notice thrown by get_page_id() in facebook-for-woocommerce/includes/API/FBE/Installation/Read/Response.php.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-= 2.6.23 - 2022-09-13 =
+= 2022-xx-xx - version X.X.X =
 * Add - Show warning when creating product set with excluded categories.
 * Fix - Messenger settings are no longer overridden after business config refresh.
 * Fix - PHP notice thrown by get_page_id() in facebook-for-woocommerce/includes/API/FBE/Installation/Read/Response.php.

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,7 +11,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 2.6.22
+ * Version: 2.6.23
  * Text Domain: facebook-for-woocommerce
  * Tested up to: 6.0
  * WC requires at least: 3.5.0
@@ -33,7 +33,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '2.6.22'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '2.6.23'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.0.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.6.22",
+  "version": "2.6.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.6.22",
+  "version": "2.6.23",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 6.0
-Stable tag: 2.6.22
+Stable tag: 2.6.23
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= 2.6.23 - 2022-09-13 =
+= X.X.X - 2022-xx-xx =
 * Add - Show warning when creating product set with excluded categories.
 * Fix - Messenger settings are no longer overridden after business config refresh.
 * Fix - PHP notice thrown by get_page_id() in facebook-for-woocommerce/includes/API/FBE/Installation/Read/Response.php.

--- a/readme.txt
+++ b/readme.txt
@@ -39,7 +39,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= X.X.X - 2022-xx-xx =
+= 2.6.23 - 2022-09-13 =
 * Add - Show warning when creating product set with excluded categories.
 * Fix - Messenger settings are no longer overridden after business config refresh.
 * Fix - PHP notice thrown by get_page_id() in facebook-for-woocommerce/includes/API/FBE/Installation/Read/Response.php.

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,12 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
+= 2.6.23 - 2022-09-13 =
+* Add - Show warning when creating product set with excluded categories.
+* Fix - Messenger settings are no longer overridden after business config refresh.
+* Fix - PHP notice thrown by get_page_id() in facebook-for-woocommerce/includes/API/FBE/Installation/Read/Response.php.
+* Fix - When disabling Enable Messenger on the Messenger setting page, the setting does not persist after selecting Save Changes.
+
 = 2.6.22 - 2022-09-06 =
 * Fix - Adding an excluded category doesn't remove that category synced products.
 * Fix - Ensure content_name and content_ids addToCart pixel event properties are correct for variable products when redirect to cart is enabled in WooCommerce.

--- a/readme.txt
+++ b/readme.txt
@@ -39,12 +39,6 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= X.X.X - 2022-xx-xx =
-* Add - Show warning when creating product set with excluded categories.
-* Fix - Messenger settings are no longer overridden after business config refresh.
-* Fix - PHP notice thrown by get_page_id() in facebook-for-woocommerce/includes/API/FBE/Installation/Read/Response.php.
-* Fix - When disabling Enable Messenger on the Messenger setting page, the setting does not persist after selecting Save Changes.
-
 = 2.6.22 - 2022-09-06 =
 * Fix - Adding an excluded category doesn't remove that category synced products.
 * Fix - Ensure content_name and content_ids addToCart pixel event properties are correct for variable products when redirect to cart is enabled in WooCommerce.


### PR DESCRIPTION
* Add - Show warning when creating product set with excluded categories.
* Fix - Messenger settings are no longer overridden after business config refresh.
* Fix - PHP notice thrown by get_page_id() in facebook-for-woocommerce/includes/API/FBE/Installation/Read/Response.php.
* Fix - When disabling Enable Messenger on the Messenger setting page, the setting does not persist after selecting Save Changes.