### PR TITLE
Adding new filter to allow customizing a product group's default variation

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1485,12 +1485,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		);
 
 		// Figure out the matching default variation.
-		$default_product_fbid = apply_filters(
-			'wc_facebook_product_group_default_variation',
-			$this->get_product_group_default_variation( $woo_product, $fb_product_group_id ),
-			$woo_product,
-			$fb_product_group_id
-		);
+		$default_product_fbid = $this->get_product_group_default_variation( $woo_product, $fb_product_group_id );
 
 		if ( $default_product_fbid ) {
 			$product_group_data['default_product_id'] = $default_product_fbid;
@@ -1530,51 +1525,68 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	private function get_product_group_default_variation( $woo_product, $fb_product_group_id ) {
 
 		$default_attributes = $woo_product->woo_product->get_default_attributes( 'edit' );
-
-		if ( empty( $default_attributes ) ) {
-			return null;
-		}
-
 		$default_variation = null;
+		
 		// Fetch variations that exist in the catalog.
 		$existing_catalog_variations              = $this->find_variation_product_item_ids( $fb_product_group_id );
 		$existing_catalog_variations_retailer_ids = array_keys( $existing_catalog_variations );
+		
 		// All woocommerce variations for the product.
 		$product_variations                       = $woo_product->woo_product->get_available_variations();
+		
+		if ( ! empty( $default_attributes ) ) {
 
-		$best_match_count = 0;
-		foreach ( $product_variations as $variation ) {
+			$best_match_count = 0;
+			foreach ( $product_variations as $variation ) {
 
-			$fb_retailer_id = WC_Facebookcommerce_Utils::get_fb_retailer_id(
-				wc_get_product(
-					$variation['variation_id']
-				)
-			);
+				$fb_retailer_id = WC_Facebookcommerce_Utils::get_fb_retailer_id(
+					wc_get_product(
+						$variation['variation_id']
+					)
+				);
 
-			// Check if currently processed variation exist in the catalog.
-			if ( ! in_array( $fb_retailer_id, $existing_catalog_variations_retailer_ids ) ) {
-				continue;
+				// Check if currently processed variation exist in the catalog.
+				if ( ! in_array( $fb_retailer_id, $existing_catalog_variations_retailer_ids ) ) {
+					continue;
+				}
+
+				$variation_attributes       = $this->get_product_variation_attributes( $variation );
+				$variation_attributes_count = count( $variation_attributes );
+				$matching_attributes_count  = count( array_intersect_assoc( $default_attributes, $variation_attributes ) );
+
+				// Check how much current variation matches the selected default attributes.
+				if ( $matching_attributes_count === $variation_attributes_count ) {
+					// We found a perfect match;
+					$default_variation = $existing_catalog_variations[ $fb_retailer_id ];
+					break;
+				} else if ( $matching_attributes_count > $best_match_count ) {
+					// We found a better match.
+					$default_variation = $existing_catalog_variations[ $fb_retailer_id ];
+				}
+
 			}
-
-			$variation_attributes       = $this->get_product_variation_attributes( $variation );
-			$variation_attributes_count = count( $variation_attributes );
-			$matching_attributes_count  = count( array_intersect_assoc( $default_attributes, $variation_attributes ) );
-
-			// Check how much current variation matches the selected default attributes.
-			if ( $matching_attributes_count === $variation_attributes_count ) {
-				// We found a perfect match;
-				$default_variation = $existing_catalog_variations[ $fb_retailer_id ];
-				break;
-			} else if ( $matching_attributes_count > $best_match_count ) {
-				// We found a better match.
-				$default_variation = $existing_catalog_variations[ $fb_retailer_id ];
-			}
-
 		}
-
-		return $default_variation;
+		
+		/**
+		 * Filter product group default variation.
+		 * This can be used to customize the choice of a default variation (e.g. choose one with the lowest price).
+		 *
+		 * @since x.x.x
+		 * @param integer|null Facebook Catalog variation id.
+		 * @param \WC_Facebook_Product WooCommerce product.
+		 * @param string product group ID.
+		 * @param array List of available WC_Product variations.
+		 * @param array List of Product Item IDs indexed by the variation's retailer ID.
+		 */
+		return apply_filters(
+			'wc_facebook_product_group_default_variation',
+			$default_variation,
+			$woo_product,
+			$fb_product_group_id,
+			$product_variations,
+			$existing_catalog_variations
+		);
 	}
-
 
 	/**
 	 * Parses given product variation for it's attributes

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1485,7 +1485,12 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		);
 
 		// Figure out the matching default variation.
-		$default_product_fbid = $this->get_product_group_default_variation( $woo_product, $fb_product_group_id );
+		$default_product_fbid = apply_filters(
+			'wc_facebook_product_group_default_variation',
+			$this->get_product_group_default_variation( $woo_product, $fb_product_group_id ),
+			$woo_product,
+			$fb_product_group_id
+		);
 
 		if ( $default_product_fbid ) {
 			$product_group_data['default_product_id'] = $default_product_fbid;


### PR DESCRIPTION
### Changes proposed in this Pull Request:
Today a product group's default variation is chosen based only on the default attributes of the product. If a listing has no default attributes then there is no way to set a default variation.
This affects the way that product prices are displayed in an Instagram shop connected to the Facebook feed (the prices are basically random - confusing the users).
This filter will allow advanced users to customize the selection based on other factors like price or custom attributes.

### Changelog entry
> Add - New filter (wc_facebook_product_group_default_variation) to allow customizing a product group's default variation

