### PR TITLE
Add wc_facebook_should_sync_product filter.

### DIFF
--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -2,6 +2,7 @@
 
 namespace SkyVerge\WooCommerce\Facebook\ProductSync;
 
+use SkyVerge\WooCommerce\Facebook\Commerce;
 use SkyVerge\WooCommerce\Facebook\Products;
 use WC_Facebook_Product;
 use WC_Product;
@@ -105,6 +106,19 @@ class ProductValidator {
 	 * @throws ProductExcludedException If product should not be synced.
 	 */
 	public function validate() {
+
+		/**
+		 * Filters whether a product should be synced to FB.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param WC_Product $product the product object.
+		 *
+		 */
+		if ( ! apply_filters( 'wc_facebook_should_sync_product', $this->product, $this ) ) {
+			throw new ProductExcludedException( __( 'Product excluded by wc_facebook_should_sync_product filter.', 'facebook-for-woocommerce' ));
+		}
+
 		$this->validate_sync_enabled_globally();
 		$this->validate_product_status();
 		$this->validate_product_stock_status();

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -274,7 +274,7 @@ class ProductValidator {
 		 * @param WC_Product $product the product object.
 		 */
 		if ( ! apply_filters( 'wc_facebook_should_sync_product', $this->product, $this ) ) {
-			throw new ProductExcludedException( __( 'Product excluded by wc_facebook_should_sync_product filter.', 'facebook-for-woocommerce' ));
+			throw new ProductExcludedException( __( 'Product excluded by wc_facebook_should_sync_product filter.', 'facebook-for-woocommerce' ) );
 		}
 
 		if ( $this->product->is_type( 'variable' ) ) {

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -273,7 +273,7 @@ class ProductValidator {
 		 *
 		 * @param WC_Product $product the product object.
 		 */
-		if ( ! apply_filters( 'wc_facebook_should_sync_product', $this->product, $this ) ) {
+		if ( ! apply_filters( 'wc_facebook_should_sync_product', true, $this->product ) ) {
 			throw new ProductExcludedException( __( 'Product excluded by wc_facebook_should_sync_product filter.', 'facebook-for-woocommerce' ) );
 		}
 

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -2,7 +2,6 @@
 
 namespace SkyVerge\WooCommerce\Facebook\ProductSync;
 
-use SkyVerge\WooCommerce\Facebook\Commerce;
 use SkyVerge\WooCommerce\Facebook\Products;
 use WC_Facebook_Product;
 use WC_Product;
@@ -106,19 +105,6 @@ class ProductValidator {
 	 * @throws ProductExcludedException If product should not be synced.
 	 */
 	public function validate() {
-
-		/**
-		 * Filters whether a product should be synced to FB.
-		 *
-		 * @since x.x.x
-		 *
-		 * @param WC_Product $product the product object.
-		 *
-		 */
-		if ( ! apply_filters( 'wc_facebook_should_sync_product', $this->product, $this ) ) {
-			throw new ProductExcludedException( __( 'Product excluded by wc_facebook_should_sync_product filter.', 'facebook-for-woocommerce' ));
-		}
-
 		$this->validate_sync_enabled_globally();
 		$this->validate_product_status();
 		$this->validate_product_stock_status();
@@ -279,6 +265,18 @@ class ProductValidator {
 	 */
 	protected function validate_product_sync_field() {
 		$invalid_exception = new ProductExcludedException( __( 'Sync disabled in product field.', 'facebook-for-woocommerce' ) );
+
+		/**
+		 * Filters whether a product should be synced to FB.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param WC_Product $product the product object.
+		 *
+		 */
+		if ( ! apply_filters( 'wc_facebook_should_sync_product', $this->product, $this ) ) {
+			throw $invalid_exception;
+		}
 
 		if ( $this->product->is_type( 'variable' ) ) {
 			foreach ( $this->product->get_children() as $child_id ) {

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -272,10 +272,9 @@ class ProductValidator {
 		 * @since x.x.x
 		 *
 		 * @param WC_Product $product the product object.
-		 *
 		 */
 		if ( ! apply_filters( 'wc_facebook_should_sync_product', $this->product, $this ) ) {
-			throw $invalid_exception;
+			throw new ProductExcludedException( __( 'Product excluded by wc_facebook_should_sync_product filter.', 'facebook-for-woocommerce' ));
 		}
 
 		if ( $this->product->is_type( 'variable' ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Provides a filter to disable sync for a product's filter, allowing devs/merchants to filter the products that should or should not be synchronized. 

This filter has been added to the `validate_product_sync_field` method to allow devs/merchants to treat products as "sync disabled programmatically".

Closes #2003.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.



### Detailed test instructions:

1. Make changes to a product and confirm the changes are synced to FB.
2. Add e.g. add_filter('wc_facebook_should_sync_product', '__return_false', 10); to functions.php
3. Confirm changes are not synced

### Changelog entry

> Add - wc_facebook_should_sync_product filter.
