### PR TITLE
Switch to Jetpack autoloader. (#1996 PR refresh)

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -143,7 +143,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			);
 
 			if ( \WC_Facebookcommerce_Utils::isWoocommerceIntegration() ) {
-				require_once __DIR__ . '/vendor/autoload.php';
+				require_once __DIR__ . '/vendor/autoload_packages.php';
 
 				include_once 'facebook-commerce.php';
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "skyverge/wc-plugin-framework": "5.10.0",
     "composer/installers": "~1.0",
     "php": ">=5.6",
-    "woocommerce/action-scheduler-job-framework": "2.0.0"
+    "woocommerce/action-scheduler-job-framework": "2.0.0",
+    "automattic/jetpack-autoloader": "^2.11"
   },
   "require-dev": {
     "woocommerce/woocommerce-sniffs": "0.1.0",
@@ -36,7 +37,8 @@
   "config": {
     "allow-plugins": {
       "composer/installers": true,
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "automattic/jetpack-autoloader": true
     }
   },
   "archive": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,59 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc0b1fec55a7b501413ca5b55cfa00b9",
+    "content-hash": "fcf5e5a81e47faf7d4fb60d5f31c2681",
     "packages": [
+        {
+            "name": "automattic/jetpack-autoloader",
+            "version": "v2.11.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-autoloader.git",
+                "reference": "0d0835f25c67a814f6f64e0538d8cfa46d7aad70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/0d0835f25c67a814f6f64e0538d8cfa46d7aad70",
+                "reference": "0d0835f25c67a814f6f64e0538d8cfa46d7aad70",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "^3.2",
+                "yoast/phpunit-polyfills": "1.0.3"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "autotagger": true,
+                "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin",
+                "mirror-repo": "Automattic/jetpack-autoloader",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-autoloader/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "2.11.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Autoloader\\": "src"
+                },
+                "classmap": [
+                    "src/AutoloadGenerator.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Creates a custom autoloader for a plugin or theme.",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.11.10"
+            },
+            "time": "2022-10-05T17:57:35+00:00"
+        },
         {
             "name": "composer/installers",
             "version": "v1.12.0",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Because we are going ahead with using a separate [Action Scheduler Job Framework package](https://github.com/woocommerce/action-scheduler-job-framework) we need to ensure that the latest version of the package is loaded into WordPress. [Jetpack Autoloader](https://github.com/Automattic/jetpack-autoloader) was built to solve this problem.

Jetpack autoloader is also used broadly by Woo and Automattic.

Closes #1956.


- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:
1. Checkout branch
2. Run `composer install && composer dump-autoload -o`
3. Load a few Facebook plugin admin pages locally

You can also run something like this to check that various classes are loading. (Copied from https://github.com/woocommerce/facebook-for-woocommerce/pull/1919).

```php
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Locale::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\AJAX::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Handlers\Connection::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Integrations\Integrations::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Product_Categories::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Products::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Commerce::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Products\Feed::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Products\FBCategories::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Products\Stock::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Products\Sync::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Products\Sync\Background::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\ProductSets\Sync::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Debug\ProfilingLogger::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Debug\ProfilingLoggerProcess::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Utilities\Shipment::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Utilities\Tracker::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Events\Event::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Events\Normalizer::class ) );
var_dump( class_exists( \SkyVerge\WooCommerce\Facebook\Events\AAMSettings::class ) );
var_dump( class_exists( \Automattic\WooCommerce\ActionSchedulerJobFramework\AbstractJob::class ) );
```

### Changelog entry

> Dev - Replace composer autoloader with Jetpack autoloader