### PR TITLE
Set catagory attribute to taxonomy value rather than product.

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -231,14 +231,14 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				}
 			}
 
-			$categories = WC_Facebookcommerce_Utils::get_product_categories( get_the_ID() );
+			$category = get_queried_object();
 
 			$event_name = 'ViewCategory';
 			$event_data = array(
 				'event_name'  => $event_name,
 				'custom_data' => array(
-					'content_name'     => $categories['name'],
-					'content_category' => $categories['categories'],
+					'content_name'     => $category->name,
+					'content_category' => $category->name,
 					'content_ids'      => json_encode( array_slice( $product_ids, 0, 10 ) ),
 					'content_type'     => $content_type,
 					'contents'         => $contents,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As shown by @kaushikasomaiya [here](https://github.com/woocommerce/facebook-for-woocommerce/issues/1777#issuecomment-1036153244), content name and category seemed to be pulled from the last product shown on the category page.

At this line:

https://github.com/woocommerce/facebook-for-woocommerce/blob/c9323789da042829cfe77cefd9c6dfcf322398cd/facebook-commerce-events-tracker.php#L234

get_the_ID() will return the id of the last product of the $products array. So the categories used are those of this last product instead of the taxonomy value. This PR corrects this by getting the category name from the queried_object.

Relates to #1777.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:

1. Checkout this branch
2. Navigate to a product category page
3. See if the content_name and content_category on the ViewCategory event are correct.

### Changelog entry

> Fix - Fix content_name and content_category attributes set on ViewCategory pixel events.
