### PR TITLE
Rename JobRegistry to JobManager.

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -95,8 +95,8 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		/** @var \SkyVerge\WooCommerce\Facebook\Tracker */
 		private $tracker;
 
-		/** @var \SkyVerge\WooCommerce\Facebook\Jobs\JobRegistry */
-		public $job_registry;
+		/** @var \SkyVerge\WooCommerce\Facebook\Jobs\JobManager */
+		public $job_manager;
 
 		/** @var Heartbeat */
 		public $heartbeat;
@@ -196,8 +196,8 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 				$this->tracker = new \SkyVerge\WooCommerce\Facebook\Utilities\Tracker();
 
 				// Init jobs
-				$this->job_registry = new \SkyVerge\WooCommerce\Facebook\Jobs\JobRegistry();
-				add_action( 'init', [ $this->job_registry, 'init' ] );
+				$this->job_manager = new \SkyVerge\WooCommerce\Facebook\Jobs\JobManager();
+				add_action( 'init', [ $this->job_manager, 'init' ] );
 
 				// load admin handlers, before admin_init
 				if ( is_admin() ) {

--- a/includes/Jobs/JobManager.php
+++ b/includes/Jobs/JobManager.php
@@ -8,11 +8,11 @@ use Automattic\WooCommerce\ActionSchedulerJobFramework\Proxies\ActionScheduler;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Class JobRegistry
+ * Class JobManager
  *
  * @since 2.5.0
  */
-class JobRegistry {
+class JobManager {
 
 	/**
 	 * @var GenerateProductFeed

--- a/includes/Products/Feed.php
+++ b/includes/Products/Feed.php
@@ -148,7 +148,7 @@ class Feed {
 	public function regenerate_feed() {
 		// Maybe use new ( experimental ), feed generation framework.
 		if ( facebook_for_woocommerce()->get_integration()->is_new_style_feed_generation_enabled() ) {
-			$generate_feed_job = facebook_for_woocommerce()->job_registry->generate_product_feed_job;
+			$generate_feed_job = facebook_for_woocommerce()->job_manager->generate_product_feed_job;
 			$generate_feed_job->queue_start();
 		} else {
 			$feed_handler = new \WC_Facebook_Product_Feed();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

closes #1968 

To avoid confusion with the Registry design pattern, I rename the class to JobManager.  I want to implement background processing for sending events to conversion API, so I thought I'd start with this change.


- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout this branch, run `composer dump-autoload`
2. Verify the testing steps in #2099

### Changelog entry

> Dev - Rename JobRegistry to JobManager.
