### PR TITLE
defer sending server side api events.

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -43,6 +43,10 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		/** @var array with events tracked */
 		private $tracked_events;
 
+		/** @var array array with epnding events */
+		private $pending_events = [];
+
+
 		/** @var AAMSettings aam settings instance, used to filter advanced matching fields*/
 		private $aam_settings;
 
@@ -141,9 +145,11 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				add_action( '__experimental_woocommerce_blocks_checkout_update_order_meta', array( $this, 'inject_order_meta_event_for_checkout_block_flow' ), 10, 1 );
 			}
 
-
 			// TODO move this in some 3rd party plugin integrations handler at some point {FN 2020-03-20}
 			add_action( 'wpcf7_contact_form', array( $this, 'inject_lead_event_hook' ), 11 );
+
+			add_action( 'shutdown', array( $this, 'send_pending_events' ) );
+
 		}
 
 
@@ -248,7 +254,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			$event = new Event( $event_data );
 
-			$this->send_api_event( $event );
+			$this->send_api_event( $event, false );
 
 			$event_data['event_id'] = $event->get_id();
 
@@ -554,7 +560,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			$event = new Event( $event_data );
 
-			$this->send_api_event( $event );
+			$this->send_api_event( $event, false );
 
 			$event_data['event_id'] = $event->get_id();
 
@@ -608,7 +614,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			$event = new SkyVerge\WooCommerce\Facebook\Events\Event( $event_data );
 
-			$this->send_api_event( $event );
+			$this->send_api_event( $event, false );
 
 			// send the event ID to prevent duplication
 			$event_data['event_id'] = $event->get_id();
@@ -881,7 +887,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			$event = new Event( $event_data );
 
-			$this->send_api_event( $event );
+			$this->send_api_event( $event, false );
 
 			$event_data['event_id'] = $event->get_id();
 
@@ -1086,25 +1092,29 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * @since 2.0.0
 		 *
 		 * @param Event $event event object
-		 * @return bool
+		 * @param bool $send_now optional, defaults to true
 		 */
-		protected function send_api_event( Event $event ) {
+		protected function send_api_event( Event $event, bool $send_now = true ) {
 			$this->tracked_events[] = $event;
 
-			try {
+			if ( $send_now ) {
 
-				facebook_for_woocommerce()->get_api()->send_pixel_events( facebook_for_woocommerce()->get_integration()->get_facebook_pixel_id(), array( $event ) );
+				try {
 
-				$success = true;
+					facebook_for_woocommerce()->get_api()->send_pixel_events( facebook_for_woocommerce()->get_integration()->get_facebook_pixel_id(), array( $event ) );
 
-			} catch ( Framework\SV_WC_API_Exception $exception ) {
+				} catch ( Framework\SV_WC_API_Exception $exception ) {
 
-				$success = false;
+					facebook_for_woocommerce()->log( 'Could not send Pixel event: ' . $exception->getMessage() );
+				}
 
-				facebook_for_woocommerce()->log( 'Could not send Pixel event: ' . $exception->getMessage() );
+			} else {
+
+				$this->pending_events[] = $event;
+
 			}
 
-			return $success;
+
 		}
 
 
@@ -1256,6 +1266,32 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function get_tracked_events() {
 			return $this->tracked_events;
+		}
+
+		/**
+		 * Gets the pending events awaiting to be sent
+		 *
+		 * @return array
+		 */
+		public function get_pending_events() {
+			return $this->pending_events;
+		}
+
+		/**
+		 * Send pending events.
+		 */
+		public function send_pending_events() {
+
+			$pending_events = facebook_for_woocommerce()->get_integration()->events_tracker->get_pending_events();
+
+			if ( empty( $pending_events ) ) {
+				return;
+			}
+
+			foreach ( $pending_events as $event ) {
+
+				$this->send_api_event( $event);
+			}
 		}
 
 	}

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -46,7 +46,6 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		/** @var array array with epnding events */
 		private $pending_events = [];
 
-
 		/** @var AAMSettings aam settings instance, used to filter advanced matching fields*/
 		private $aam_settings;
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1289,7 +1289,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			foreach ( $pending_events as $event ) {
 
-				$this->send_api_event( $event);
+				$this->send_api_event( $event );
 			}
 		}
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1281,7 +1281,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function send_pending_events() {
 
-			$pending_events = facebook_for_woocommerce()->get_integration()->events_tracker->get_pending_events();
+			$pending_events = $this->get_pending_events();
 
 			if ( empty( $pending_events ) ) {
 				return;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Sending pixel events uses blocking PHP code, which means generating the user-requested page gets paused while the event data is handled by the graph.facebook.com server. Measuring the code execution shows that the send_api_event method seems to slow down the generating page between 0.5-6 seconds, depending on how fast the Facebook server answers to the API requests. 

This PR adds options to defer sending server-side API events until after the page has been generated.

Closes #1675.

_Replace this with a good description of your changes & reasoning._

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:

1. Use something like New Relic or Tideways to profile execution of pages that injects Facebook tracking (e.g. single product or product category). Alternatively use something like [Lighthouse](https://pagespeed.web.dev/).
2. Compare the results on this branch with the results on the `develop` branch

### Changelog entry

> Fix - Server side sending of pixel events blocks generating pages 
