### PR TITLE
Fix google-product-category-fields-loads.js loading on every page.

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -35,6 +35,9 @@ class Admin {
 	/** @var \Admin\Product_Categories the product category admin handler */
 	protected $product_categories;
 
+	/** @var array screens ids where to include scripts */
+	protected $screen_ids = [];
+
 
 	/**
 	 * Admin constructor.
@@ -42,6 +45,15 @@ class Admin {
 	 * @since 1.10.0
 	 */
 	public function __construct() {
+
+		$this->screen_ids = [
+			'product',
+			'edit-product',
+			'woocommerce_page_wc-facebook',
+			'marketing_page_wc-facebook',
+			'edit-product_cat',
+			'shop_order',
+		];
 
 		// enqueue admin scripts
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
@@ -130,16 +142,9 @@ class Admin {
 	public function enqueue_scripts() {
 		global $current_screen;
 
-		$modal_screens = array(
-			'product',
-			'edit-product',
-			'edit-product_cat',
-			'shop_order',
-		);
-
 		if ( isset( $current_screen->id ) ) {
 
-			if ( in_array( $current_screen->id, $modal_screens, true ) || facebook_for_woocommerce()->is_plugin_settings() ) {
+			if ( in_array( $current_screen->id, $this->screen_ids, true ) || facebook_for_woocommerce()->is_plugin_settings() ) {
 
 				// enqueue modal functions
 				wp_enqueue_script(
@@ -228,7 +233,7 @@ class Admin {
 
 			}//end if
 
-			if ( 'edit-product_cat' === $current_screen->id || 'product_cat' === $current_screen->id ) {
+			if ( in_array( $current_screen->id, $this->screen_ids ) ) {
 
 				wp_enqueue_script(
 					'wc-facebook-google-product-category-fields',
@@ -1608,17 +1613,8 @@ class Admin {
 	public function render_modal_template() {
 		global $current_screen;
 
-		$modal_screens = array(
-			'product',
-			'edit-product',
-			'woocommerce_page_wc-facebook',
-			'marketing_page_wc-facebook',
-			'edit-product_cat',
-			'shop_order',
-		);
-
 		// bail if not on the products, product edit, or settings screen
-		if ( ! $current_screen || ! in_array( $current_screen->id, $modal_screens, true ) ) {
+		if ( ! $current_screen || ! in_array( $current_screen->id, $this->screen_ids, true ) ) {
 			return;
 		}
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -153,6 +153,26 @@ class Admin {
 					array( 'jquery', 'wc-backbone-modal', 'jquery-blockui' ),
 					\WC_Facebookcommerce::PLUGIN_VERSION
 				);
+
+				// enqueue google product category select
+				wp_enqueue_script(
+					'wc-facebook-google-product-category-fields',
+					facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/google-product-category-fields.js',
+					array( 'jquery' ),
+					\WC_Facebookcommerce::PLUGIN_VERSION
+				);
+
+				wp_localize_script(
+					'wc-facebook-google-product-category-fields',
+					'facebook_for_woocommerce_google_product_category',
+					array(
+						'i18n' => array(
+							'top_level_dropdown_placeholder' => __( 'Search main categories...', 'facebook-for-woocommerce' ),
+							'second_level_empty_dropdown_placeholder' => __( 'Choose a main category', 'facebook-for-woocommerce' ),
+							'general_dropdown_placeholder'   => __( 'Choose a category', 'facebook-for-woocommerce' ),
+						),
+					)
+				);
 			}
 
 			if ( 'edit-fb_product_set' === $current_screen->id ) {
@@ -233,31 +253,7 @@ class Admin {
 
 			}//end if
 
-			if ( in_array( $current_screen->id, $this->screen_ids ) ) {
-
-				wp_enqueue_script(
-					'wc-facebook-google-product-category-fields',
-					facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/google-product-category-fields.js',
-					array( 'jquery' ),
-					\WC_Facebookcommerce::PLUGIN_VERSION
-				);
-
-				wp_localize_script(
-					'wc-facebook-google-product-category-fields',
-					'facebook_for_woocommerce_google_product_category',
-					array(
-						'i18n' => array(
-							'top_level_dropdown_placeholder' => __( 'Search main categories...', 'facebook-for-woocommerce' ),
-							'second_level_empty_dropdown_placeholder' => __( 'Choose a main category', 'facebook-for-woocommerce' ),
-							'general_dropdown_placeholder'   => __( 'Choose a category', 'facebook-for-woocommerce' ),
-						),
-					)
-				);
-			}
-
-
 			if ( facebook_for_woocommerce()->is_plugin_settings() ) {
-
 				wp_enqueue_style( 'woocommerce_admin_styles' );
 				wp_enqueue_script( 'wc-enhanced-select' );
 			}

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -228,6 +228,29 @@ class Admin {
 
 			}//end if
 
+			if ( 'edit-product_cat' === $current_screen->id || 'product_cat' === $current_screen->id ) {
+
+				wp_enqueue_script(
+					'wc-facebook-google-product-category-fields',
+					facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/google-product-category-fields.js',
+					array( 'jquery' ),
+					\WC_Facebookcommerce::PLUGIN_VERSION
+				);
+
+				wp_localize_script(
+					'wc-facebook-google-product-category-fields',
+					'facebook_for_woocommerce_google_product_category',
+					array(
+						'i18n' => array(
+							'top_level_dropdown_placeholder' => __( 'Search main categories...', 'facebook-for-woocommerce' ),
+							'second_level_empty_dropdown_placeholder' => __( 'Choose a main category', 'facebook-for-woocommerce' ),
+							'general_dropdown_placeholder'   => __( 'Choose a category', 'facebook-for-woocommerce' ),
+						),
+					)
+				);
+			}
+
+
 			if ( facebook_for_woocommerce()->is_plugin_settings() ) {
 
 				wp_enqueue_style( 'woocommerce_admin_styles' );
@@ -235,24 +258,6 @@ class Admin {
 			}
 		}//end if
 
-		wp_enqueue_script(
-			'wc-facebook-google-product-category-fields',
-			facebook_for_woocommerce()->get_asset_build_dir_url() . '/admin/google-product-category-fields.js',
-			array( 'jquery' ),
-			\WC_Facebookcommerce::PLUGIN_VERSION
-		);
-
-		wp_localize_script(
-			'wc-facebook-google-product-category-fields',
-			'facebook_for_woocommerce_google_product_category',
-			array(
-				'i18n' => array(
-					'top_level_dropdown_placeholder' => __( 'Search main categories...', 'facebook-for-woocommerce' ),
-					'second_level_empty_dropdown_placeholder' => __( 'Choose a main category', 'facebook-for-woocommerce' ),
-					'general_dropdown_placeholder'   => __( 'Choose a category', 'facebook-for-woocommerce' ),
-				),
-			)
-		);
 	}
 
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #1949 .

admin/google-product-category-fields.js currently loads on all admin pages. This PR restricts it to the product_cat and edit-product_cat screens where it's needed for the google product category fields.

Issue #1949 makes other recommendations such as adding an async/defer attribute and moving the script to the footer, which I decided against because it would mean delaying the init execution which impacts UX:

https://github.com/woocommerce/facebook-for-woocommerce/blob/5156a45c02672057476573f0b79c58084f20f10f/includes/Admin/Google_Product_Category_Field.php#L30-L38

I also decided not to make changes to infobanner assets as we still need to evaluate whether this is currently needed. See #1981 

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1. Check out this branch.
2. Navigate to the admin dashboard, confirm google-product-category-fields-loads.js does not load on all page
3. Navigate to Admin -> Product -> Categories, confirm the google fields work as expected

### Changelog entry

> Fix - Ensure google-product-category-fields-loads.js loads only on the product category screens.
