### PR TITLE
Ensure bundles are not treated as virtual product on product_sync

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -883,7 +883,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		$sync_mode    = isset( $_POST['wc_facebook_sync_mode'] ) ? $_POST['wc_facebook_sync_mode'] : Admin::SYNC_MODE_SYNC_DISABLED;
 		$sync_enabled = Admin::SYNC_MODE_SYNC_DISABLED !== $sync_mode;
 
-		if ( Admin::SYNC_MODE_SYNC_AND_SHOW === $sync_mode && $product->is_virtual() ) {
+		if ( Admin::SYNC_MODE_SYNC_AND_SHOW === $sync_mode && $product->is_virtual() && 'bundle' !== $product->get_type() ) {
 			// force to Sync and hide
 			$sync_mode = Admin::SYNC_MODE_SYNC_AND_HIDE;
 		}
@@ -1526,14 +1526,14 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		$default_attributes = $woo_product->woo_product->get_default_attributes( 'edit' );
 		$default_variation = null;
-		
+
 		// Fetch variations that exist in the catalog.
 		$existing_catalog_variations              = $this->find_variation_product_item_ids( $fb_product_group_id );
 		$existing_catalog_variations_retailer_ids = array_keys( $existing_catalog_variations );
-		
+
 		// All woocommerce variations for the product.
 		$product_variations                       = $woo_product->woo_product->get_available_variations();
-		
+
 		if ( ! empty( $default_attributes ) ) {
 
 			$best_match_count = 0;
@@ -1566,7 +1566,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 			}
 		}
-		
+
 		/**
 		 * Filter product group default variation.
 		 * This can be used to customize the choice of a default variation (e.g. choose one with the lowest price).

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -637,7 +637,9 @@ if ( ! class_exists( 'WC_Facebook_Product' ) ) :
 
 			// Exclude variations that are "virtual" products from export to Facebook &&
 			// No Visibility Option for Variations
-			if ( true === $this->get_virtual() ) {
+			// get_virtual() returns true for "unassembled bundles", so we exclude
+			// bundles from this check.
+			if ( true === $this->get_virtual() && 'bundle' !== $this->get_type() ) {
 				$product_data['visibility'] = \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN;
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WC_Product::is_virtual() returns a false positive for unassembled bundle products. This PR adds a check to ensure bundle products are not hidden unless explicitly marked as hidden.

Closes #1769.


- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1. Start with [Product Bundles](https://woocommerce.com/products/product-bundles/) and [Facebook for WooCommerce](https://woocommerce.com/products/facebook/)  connected and synced with a FB catalog;
2. Create a bundled product with the default settings — in my case I have added two simple products to the bundle;
3. In the Facebook settings for that product, switch Facebook sync to Sync and show in the catalog and save the changes
4. See that the change wasn't saved;
5. Go to Facebook's Catalog Manager > All Items (in the filters) and see that the bundled product is there but not visible 
6. Switch to this branch and go back to step 4 and save
7. Observe the changes remain, and the product is now visible on Facebook's Catalog Manager


### Changelog entry

> Fix - Ensure bundles are not treated as virtual products on product_sync
