### PR TITLE
Fix duplicate InitiateCheckout when using checkout block.

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -850,7 +850,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function inject_initiate_checkout_event() {
 
-			if ( ! $this->is_pixel_enabled() || $this->pixel->is_last_event( 'InitiateCheckout' ) ) {
+			if ( ! $this->is_pixel_enabled() || WC()->cart->get_cart_contents_count() === 0 || $this->pixel->is_last_event( 'InitiateCheckout' ) ) {
 				return;
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When using checkout WC Block, initiateCheckout event is triggered on the order received page. This causes an incomplete event to be sent to Facebook causing a warning. This PR adds an additional check to confirm the cart is not empty.


Closes #2348 .

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:

1. Ensure checkout form uses Checkout WC Block
2. Add product to cart and navigate to checkout. Using the [Facebook Pixel Helper](https://chrome.google.com/webstore/detail/facebook-pixel-helper/fdgfkebogiimcoedlicjlajpkdmockpc?hl=en) chrome extension, confirm the initiateCheckout event is properly triggered.
3. Confirm the  initiateCheckout event is not triggered a second time on the order received page


### Additional details:

I came across this issue while investigating #2075.

### Changelog entry

> Fix - duplicate InitiateCheckout when using checkout block.
