### PR TITLE
Fix - Ensure the enhanced product enhance catalog attributes value is unslashed before saving in the post_meta table

### DIFF
--- a/includes/Products.php
+++ b/includes/Products.php
@@ -1120,7 +1120,7 @@ class Products {
 		if ( self::get_enhanced_catalog_attribute( $attribute_key, $product ) === $value ) {
 			return;
 		}
-		$product->update_meta_data( self::ENHANCED_CATALOG_ATTRIBUTES_META_KEY_PREFIX . $attribute_key, $value );
+		$product->update_meta_data( self::ENHANCED_CATALOG_ATTRIBUTES_META_KEY_PREFIX . $attribute_key, wp_unslash( $value ) );
 		$product->save_meta_data();
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:


Closes #2353.

A user reported post_meta row filled with backslashes (\). Upon investigation, we notice that if the category attribute value contains a special char (",) such as quotes or backslashes, the value is escaped causing the backslashes to duplicate indefinitely.

We directly read the product enhanced catalog attribute from the $_POST global before saving it to the post_meta table. WordPress adds slashes to $_POST/$_GET/$_REQUEST/$_COOKIE regardless of what get_magic_quotes_gpc() returns (See https://developer.wordpress.org/reference/functions/stripslashes_deep/#user-contributed-notes).

This PR ensures attribute value is unslashed before saving.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1. Edit/create a variable product
2. Open the Facebook tab
3. Select Google product categories. Eg.: Apparel & Accessories -> Clothing -> Shirts & Tops
4. Set one of the Category Specific Attributes attributes to a value with an escaped character (quote " or backslash \). Eg. Size -> Large (40\41) or Medium: ("35 to 40")
5. Save and confirm no backslash is added to the attribute value.


### Changelog entry

> Fix - Ensure the enhanced product enhance catalog attributes value is unslashed before saving in the post_meta table
