### PR TITLE
Fix - Sync product set when the term name changes.

### DIFF
--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -72,6 +72,15 @@ class Sync {
 	protected static $prev_product_set = array();
 
 	/**
+	 * Product's Product Set Previous Name
+	 *
+	 * @since x.x.x
+	 *
+	 * @var string
+	 */
+	protected static $prev_product_name = "";
+
+	/**
 	 * Product's Product Set New List
 	 *
 	 * @since 2.3.0
@@ -79,6 +88,15 @@ class Sync {
 	 * @var array
 	 */
 	protected static $new_product_set = array();
+
+	/**
+	 * Product's Product Set Previous Name
+	 *
+	 * @since x.x.x
+	 *
+	 * @var string
+	 */
+	protected static $new_product_name = "";
 
 	/**
 	 * Categories field name
@@ -122,7 +140,7 @@ class Sync {
 		// product set hooks, compare taxonomies the lists before and after saving product to see if must sync
 		add_action( 'created_fb_product_set', array( $this, 'fb_product_set_hook_before' ), 1 );
 		add_action( 'created_fb_product_set', array( $this, 'fb_product_set_hook_after' ), 99 );
-		add_action( 'edited_fb_product_set', array( $this, 'fb_product_set_hook_before' ), 1 );
+		add_action( 'edit_fb_product_set', array( $this, 'fb_product_set_hook_before' ), 1 );
 		add_action( 'edited_fb_product_set', array( $this, 'fb_product_set_hook_after' ), 99 );
 
 		// product cat and product set delete hooks, remove or check if must remove any product set
@@ -240,6 +258,7 @@ class Sync {
 	 */
 	public function fb_product_set_hook_before( $term_id ) {
 		self::$prev_product_cat = get_term_meta( $term_id, $this->categories_field, true );
+		self::$prev_product_name = get_term( $term_id )->name;
 	}
 
 
@@ -252,7 +271,8 @@ class Sync {
 	 */
 	public function fb_product_set_hook_after( $term_id ) {
 		self::$new_product_cat = get_term_meta( $term_id, $this->categories_field, true );
-		if ( ! empty( $this->get_all_diff( 'product_cat' ) ) ) {
+		self::$new_product_name = get_term( $term_id )->name;
+		if ( ! empty( $this->get_all_diff( 'product_cat' ) ) || self::$prev_product_name !== self::$new_product_name ) {
 			$this->maybe_sync_product_set( $term_id );
 		}
 	}

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -90,7 +90,7 @@ class Sync {
 	protected static $new_product_set = array();
 
 	/**
-	 * Product's Product Set Previous Name
+	 * Product's Product Set New Name
 	 *
 	 * @since x.x.x
 	 *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When a product set name is modified on the site, the change isn't automatically synced to the Facebook catalog. (Changes to set titles are only pushed when new products are added to the set). 

This PR allows product sets' title to be synced on update.


Closes #2344.

_Replace this with a good description of your changes & reasoning._

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1. Create a product set in Products > FB Product Sets
2. Allow the set to sync to Facebook
3. Edit the set name (title) in WooCommerce
4. Notice the new name is correctly synced to the Facebook catalog

### Changelog entry

> Fix - Sync product set when the term name changes.
