### PR TITLE
Redirect the users to advertise tab of the plugin when FBE is installed

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -1013,6 +1013,19 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 
 			return admin_url( 'admin.php?page=wc-facebook' );
 		}
+		
+		/**
+         * Gets the advertise tab page URL.
+         *
+         * @since x.x.x
+         *
+         * @return string
+         */
+        public function get_advertise_tab_url() {
+			
+			return admin_url( 'admin.php?page=wc-facebook&tab=advertise' );
+        }
+
 
 
 		/**

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -310,7 +310,7 @@ class Connection {
 			set_transient( 'wc_facebook_connection_failed', time(), 30 );
 		}
 
-		wp_safe_redirect( facebook_for_woocommerce()->get_settings_url() );
+		wp_safe_redirect( facebook_for_woocommerce()->get_advertise_tab_url() );
 		exit;
 	}
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -304,6 +304,7 @@ class Connection {
 			set_transient( 'wc_facebook_connection_failed', time(), 30 );
 
 			wp_safe_redirect( facebook_for_woocommerce()->get_settings_url() );
+			exit;
 
 		} catch ( Connect_WC_API_Exception $exception ) {
 			$message = $this->prepare_connect_server_message_for_user_display( $exception->getMessage() );
@@ -313,6 +314,7 @@ class Connection {
 			set_transient( 'wc_facebook_connection_failed', time(), 30 );
 
 			wp_safe_redirect( facebook_for_woocommerce()->get_settings_url() );
+			exit;
 
 		}
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -302,12 +302,18 @@ class Connection {
 			facebook_for_woocommerce()->log( sprintf( 'Connection failed: %s', $exception->getMessage() ) );
 
 			set_transient( 'wc_facebook_connection_failed', time(), 30 );
+
+			wp_safe_redirect( facebook_for_woocommerce()->get_settings_url() );
+
 		} catch ( Connect_WC_API_Exception $exception ) {
 			$message = $this->prepare_connect_server_message_for_user_display( $exception->getMessage() );
 
 			facebook_for_woocommerce()->log( sprintf( 'Failed to connect to Facebook. Reason: %s', $message ), 'facebook_for_woocommerce_connect' );
 
 			set_transient( 'wc_facebook_connection_failed', time(), 30 );
+
+			wp_safe_redirect( facebook_for_woocommerce()->get_settings_url() );
+
 		}
 
 		wp_safe_redirect( facebook_for_woocommerce()->get_advertise_tab_url() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:
When FBE is successfully installed, instead of redirecting the user to settings tab redirect them to the advertise tab.

### Screenshots:
Tested with Local App running WooCommerce 7


https://user-images.githubusercontent.com/17508935/200050471-ad88e022-ab69-47d7-952e-5baaf919a0a4.mov



### Changelog entry
> Update - On successful FBE install users will be redirected to Advertise tab of the plugin

