### PR TITLE
Release/2.6.30

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 2.6.30 - 2022-11-09 =
+* Fix - Add backward compatibility for WC 6.1, 6.2, and 6.3 versions.
+* Fix - Sync product set when the term name changes.
+
 = 2.6.29 - 2022-11-08 =
 * Add - Facebook Product Set under the Marketing menu.
 * Add - HPOS Compatibility.

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,7 +11,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 2.6.29
+ * Version: 2.6.30
  * Text Domain: facebook-for-woocommerce
  * Tested up to: 6.1
  * WC requires at least: 5.3
@@ -44,7 +44,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '2.6.29'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '2.6.30'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.0.0';

--- a/includes/ProductSets/Sync.php
+++ b/includes/ProductSets/Sync.php
@@ -74,7 +74,7 @@ class Sync {
 	/**
 	 * Product's Product Set Previous Name
 	 *
-	 * @since x.x.x
+	 * @since 2.6.30
 	 *
 	 * @var string
 	 */
@@ -92,7 +92,7 @@ class Sync {
 	/**
 	 * Product's Product Set New Name
 	 *
-	 * @since x.x.x
+	 * @since 2.6.30
 	 *
 	 * @var string
 	 */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.6.29",
+  "version": "2.6.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "2.6.29",
+  "version": "2.6.30",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,10 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
+= 2.6.30 - 2022-11-09 =
+* Fix - Add backward compatibility for WC 6.1, 6.2, and 6.3 versions.
+* Fix - Sync product set when the term name changes.
+
 = 2.6.29 - 2022-11-08 =
 * Add - Facebook Product Set under the Marketing menu.
 * Add - HPOS Compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 6.1
-Stable tag: 2.6.29
+Stable tag: 2.6.30
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later


### PR DESCRIPTION
<!-- Release notes generated using configuration in .github/release.yml at 2.6.30 -->

## What's Changed
### [Fix] Fixes 🛠
* Fix - Sync product set when the term name changes. by @rawdreeg in https://github.com/woocommerce/facebook-for-woocommerce/pull/2355
* Adds backward compatibility for WC 6.1, 6.2, 6.3. (#2362) by @ibndawood in https://github.com/woocommerce/facebook-for-woocommerce/pull/2363


**Full Changelog**: https://github.com/woocommerce/facebook-for-woocommerce/compare/2.6.29...2.6.30