### PR TITLE
Fix - Facebook Product ID is different from what Facebook ID actually is

### DIFF
--- a/includes/Admin/Product_Sync_Meta_Box.php
+++ b/includes/Admin/Product_Sync_Meta_Box.php
@@ -69,7 +69,7 @@ class Product_Sync_Meta_Box {
 			if ( $fb_product->woo_product->is_type( 'variable' ) ) {
 				$fb_product_id = $fb_integration->get_product_fbid( $fb_integration::FB_PRODUCT_GROUP_ID, $post->ID, $fb_product->woo_product );
 			} else {
-				$fb_product_id = $fb_integration->get_product_fbid($fb_integration::FB_PRODUCT_ITEM_ID, $post->ID, $fb_product->woo_product);
+				$fb_product_id = $fb_integration->get_product_fbid( $fb_integration::FB_PRODUCT_ITEM_ID, $post->ID, $fb_product->woo_product );
 			}
 		}
 		?>

--- a/includes/Admin/Product_Sync_Meta_Box.php
+++ b/includes/Admin/Product_Sync_Meta_Box.php
@@ -52,7 +52,7 @@ class Product_Sync_Meta_Box {
 
 		$fb_integration      = facebook_for_woocommerce()->get_integration();
 		$fb_product          = new \WC_Facebook_Product( $post->ID );
-		$fb_product_group_id = null;
+		$fb_product_id = null;
 		$should_sync         = true;
 		$no_sync_reason      = '';
 
@@ -65,24 +65,28 @@ class Product_Sync_Meta_Box {
 			}
 		}
 
-		if ( $should_sync || $fb_product->woo_product->is_type( 'variable' ) ) {
-			$fb_product_group_id = $fb_integration->get_product_fbid( $fb_integration::FB_PRODUCT_GROUP_ID, $post->ID, $fb_product->woo_product );
+		if ( $should_sync ){
+			if ($fb_product->woo_product->is_type( 'variable' ) ){
+				$fb_product_id = $fb_integration->get_product_fbid($fb_integration::FB_PRODUCT_GROUP_ID, $post->ID, $fb_product->woo_product);
+			} else {
+				$fb_product_id = $fb_integration->get_product_fbid($fb_integration::FB_PRODUCT_ITEM_ID, $post->ID, $fb_product->woo_product);
+			}
 		}
 		?>
 			<span id="fb_metadata">
 		<?php
 
-		if ( $fb_product_group_id ) {
+		if ( $fb_product_id ) {
 
 			?>
 
 			<?php echo esc_html__( 'Facebook ID:', 'facebook-for-woocommerce' ); ?>
-			<a href="https://facebook.com/<?php echo esc_attr( $fb_product_group_id ); ?>" target="_blank"><?php echo esc_html( $fb_product_group_id ); ?></a>
+			<a href="https://facebook.com/<?php echo esc_attr( $fb_product_id ); ?>" target="_blank"><?php echo esc_html( $fb_product_id ); ?></a>
 
 			<?php if ( \WC_Facebookcommerce_Utils::is_variable_type( $fb_product->get_type() ) ) : ?>
 
 				<?php
-				$product_item_ids_by_variation_id = $fb_integration->get_variation_product_item_ids( $fb_product, $fb_product_group_id );
+				$product_item_ids_by_variation_id = $fb_integration->get_variation_product_item_ids( $fb_product, $fb_product_id );
 				if ( $product_item_ids_by_variation_id ) :
 					?>
 

--- a/includes/Admin/Product_Sync_Meta_Box.php
+++ b/includes/Admin/Product_Sync_Meta_Box.php
@@ -65,8 +65,8 @@ class Product_Sync_Meta_Box {
 			}
 		}
 
-		if ( $should_sync ){
-			if ($fb_product->woo_product->is_type( 'variable' ) ){
+		if ( $should_sync ) {
+			if ( $fb_product->woo_product->is_type( 'variable' ) ) {
 				$fb_product_id = $fb_integration->get_product_fbid($fb_integration::FB_PRODUCT_GROUP_ID, $post->ID, $fb_product->woo_product);
 			} else {
 				$fb_product_id = $fb_integration->get_product_fbid($fb_integration::FB_PRODUCT_ITEM_ID, $post->ID, $fb_product->woo_product);

--- a/includes/Admin/Product_Sync_Meta_Box.php
+++ b/includes/Admin/Product_Sync_Meta_Box.php
@@ -52,7 +52,7 @@ class Product_Sync_Meta_Box {
 
 		$fb_integration      = facebook_for_woocommerce()->get_integration();
 		$fb_product          = new \WC_Facebook_Product( $post->ID );
-		$fb_product_id = null;
+		$fb_product_id       = null;
 		$should_sync         = true;
 		$no_sync_reason      = '';
 

--- a/includes/Admin/Product_Sync_Meta_Box.php
+++ b/includes/Admin/Product_Sync_Meta_Box.php
@@ -67,7 +67,7 @@ class Product_Sync_Meta_Box {
 
 		if ( $should_sync ) {
 			if ( $fb_product->woo_product->is_type( 'variable' ) ) {
-				$fb_product_id = $fb_integration->get_product_fbid($fb_integration::FB_PRODUCT_GROUP_ID, $post->ID, $fb_product->woo_product);
+				$fb_product_id = $fb_integration->get_product_fbid( $fb_integration::FB_PRODUCT_GROUP_ID, $post->ID, $fb_product->woo_product );
 			} else {
 				$fb_product_id = $fb_integration->get_product_fbid($fb_integration::FB_PRODUCT_ITEM_ID, $post->ID, $fb_product->woo_product);
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2374.

The Facebook Product ID displayed in the product sync meta box is different from what Facebook ID really is.  Because the code did not handle behavior for simple products, this PR fixes that. 


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:


1. Follow the reproduction steps described in  #2374.
2. Ensure the product id displayed when editing a synced product matches the product id on the FB catalog.


### Changelog entry

> Fix - Facebook Product ID is different from what Facebook ID actually is
