### PR TITLE
Update API version set in the fbAsyncInit script in Advertise tab.

### DIFF
--- a/includes/Admin/Settings_Screens/Advertise.php
+++ b/includes/Admin/Settings_Screens/Advertise.php
@@ -13,7 +13,7 @@ namespace WooCommerce\Facebook\Admin\Settings_Screens;
 
 defined( 'ABSPATH' ) or exit;
 
-use WooCommerce\Facebook\Api;
+use WooCommerce\Facebook\API;
 use WooCommerce\Facebook\Locale;
 use WooCommerce\Facebook\Admin\Abstract_Settings_Screen;
 
@@ -85,7 +85,7 @@ class Advertise extends Abstract_Settings_Screen {
 					appId            : '<?php echo esc_js( $connection_handler->get_client_id() ); ?>',
 					autoLogAppEvents : true,
 					xfbml            : true,
-					version          : '<?php echo esc_js( Api::API_VERSION )?>',
+					version          : '<?php echo esc_js( API::API_VERSION )?>',
 				} );
 			};
 		</script>

--- a/includes/Admin/Settings_Screens/Advertise.php
+++ b/includes/Admin/Settings_Screens/Advertise.php
@@ -13,6 +13,7 @@ namespace WooCommerce\Facebook\Admin\Settings_Screens;
 
 defined( 'ABSPATH' ) or exit;
 
+use WooCommerce\Facebook\Api;
 use WooCommerce\Facebook\Locale;
 use WooCommerce\Facebook\Admin\Abstract_Settings_Screen;
 
@@ -84,7 +85,7 @@ class Advertise extends Abstract_Settings_Screen {
 					appId            : '<?php echo esc_js( $connection_handler->get_client_id() ); ?>',
 					autoLogAppEvents : true,
 					xfbml            : true,
-					version          : 'v8.0', // Note: This expires on November 1 2022
+					version          : '<?php echo esc_js( Api::API_VERSION )?>',
 				} );
 			};
 		</script>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The FB API version set in the fbAsyncInit script in Advertise tab fell out of date. I suggest setting this to the Api:: API_VERSION constant so that this doesn't happen again.

Closes #2373.

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1.  Ensure Facebook for WooCommerce is installed and connected to an account with Ad account.
2.  Navigate to Admin Dashboard -> Marketing -> Facebook -> Advertise.
3. Confirm the tab is loading correct.
4. Inspect the page source code and confirm that the version used in the fbAsyncInit script in v13.0:
![Screenshot 2022-11-17 at 08 39 38](https://user-images.githubusercontent.com/4209011/202374833-80e4a263-1e05-4f59-8e43-cd4add0e62c1.jpg)


### Changelog entry

> Tweak - Update the API version set in the fbAsyncInit script in Advertise tab.
