### PR TITLE
Release 3.0.2

### DIFF
--- a/.github/workflows/php-unit-tests.yml
+++ b/.github/workflows/php-unit-tests.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: PHP8, PHPUnit9 with WordPress v5.9+
         if: matrix.php >= 8
-        run: composer require phpunit/phpunit "^9.5" --dev --update-with-all-dependencies
+        run: composer require phpunit/phpunit "^8" --dev --update-with-all-dependencies
 
       - name: Run PHP unit tests
         run: composer test-unit

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-= 3.0.2 - 2022-xx-xx =
+= 3.0.2 - 2022-11-18 =
 * Fix - Properly handle API exceptions
 * Fix - Set correct PHP version in plugin header
 * Dev - Add ArrayAccess implementation to JSONResponse class

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 3.0.2 - 2022-xx-xx =
+* Fix - Properly handle API exceptions
+* Fix - Set correct PHP version in plugin header
+* Dev - Add ArrayAccess implementation to JSONResponse class
+
 = 3.0.1 - 2022-11-17 =
 * Fix - Wrong path to the fbutils.php file.
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     }
   ],
   "require": {
-    "php": ">=7.4",
+    "php": ">=7.2",
     "woocommerce/action-scheduler-job-framework": "2.0.0",
     "composer/installers": "~1.0"
   },
@@ -28,7 +28,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.4.30"
+      "php": "7.2"
     },
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84034b15f53b5242ff4e514cf3710967",
+    "content-hash": "0a69aaf33922caca408f0ef0445f8a0f",
     "packages": [
         {
             "name": "composer/installers",
@@ -486,16 +486,16 @@
         },
         {
             "name": "gettext/languages",
-            "version": "2.9.0",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-gettext/Languages.git",
-                "reference": "ed56dd2c7f4024cc953ed180d25f02f2640e3ffa"
+                "reference": "4d61d67fe83a2ad85959fe6133d6d9ba7dddd1ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/ed56dd2c7f4024cc953ed180d25f02f2640e3ffa",
-                "reference": "ed56dd2c7f4024cc953ed180d25f02f2640e3ffa",
+                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/4d61d67fe83a2ad85959fe6133d6d9ba7dddd1ab",
+                "reference": "4d61d67fe83a2ad85959fe6133d6d9ba7dddd1ab",
                 "shasum": ""
             },
             "require": {
@@ -544,7 +544,7 @@
             ],
             "support": {
                 "issues": "https://github.com/php-gettext/Languages/issues",
-                "source": "https://github.com/php-gettext/Languages/tree/2.9.0"
+                "source": "https://github.com/php-gettext/Languages/tree/2.10.0"
             },
             "funding": [
                 {
@@ -556,7 +556,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-11-11T17:30:39+00:00"
+            "time": "2022-10-18T15:00:10+00:00"
         },
         {
             "name": "mck89/peast",
@@ -2214,89 +2214,21 @@
             "time": "2022-06-18T07:21:10+00:00"
         },
         {
-            "name": "symfony/deprecation-contracts",
-            "version": "v2.5.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "reference": "e8b495ea28c1d97b5e0c121748d6f9b53d075c66",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "2.5-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.2"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-01-02T09:53:40+00:00"
-        },
-        {
             "name": "symfony/finder",
-            "version": "v5.4.11",
+            "version": "v4.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "7872a66f57caffa2916a584db1aa7f12adc76f8c"
+                "reference": "66bd787edb5e42ff59d3523f623895af05043e4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/7872a66f57caffa2916a584db1aa7f12adc76f8c",
-                "reference": "7872a66f57caffa2916a584db1aa7f12adc76f8c",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/66bd787edb5e42ff59d3523f623895af05043e4f",
+                "reference": "66bd787edb5e42ff59d3523f623895af05043e4f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "php": ">=7.1.3",
                 "symfony/polyfill-php80": "^1.16"
             },
             "type": "library",
@@ -2325,7 +2257,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v5.4.11"
+                "source": "https://github.com/symfony/finder/tree/v4.4.44"
             },
             "funding": [
                 {
@@ -2341,20 +2273,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-29T07:37:50+00:00"
+            "time": "2022-07-29T07:35:46+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace"
+                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/cfa0ae98841b9e461207c13ab093d76b0fa7bace",
-                "reference": "cfa0ae98841b9e461207c13ab093d76b0fa7bace",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
+                "reference": "7a6ff3f1959bb01aefccb463a0f2cd3d3d2fd936",
                 "shasum": ""
             },
             "require": {
@@ -2363,7 +2295,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2408,7 +2340,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -2424,7 +2356,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-10T07:21:04+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2655,16 +2587,16 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.15",
+            "version": "v0.11.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "b6edd35988892ea1451392eb7a26d9dbe98c836d"
+                "reference": "c32e51a5c9993ad40591bc426b21f5422a5ed293"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/b6edd35988892ea1451392eb7a26d9dbe98c836d",
-                "reference": "b6edd35988892ea1451392eb7a26d9dbe98c836d",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/c32e51a5c9993ad40591bc426b21f5422a5ed293",
+                "reference": "c32e51a5c9993ad40591bc426b21f5422a5ed293",
                 "shasum": ""
             },
             "require": {
@@ -2703,22 +2635,22 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.15"
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.16"
             },
-            "time": "2022-08-15T10:15:55+00:00"
+            "time": "2022-11-03T15:19:26+00:00"
         },
         {
             "name": "wp-cli/wp-cli",
-            "version": "v2.7.0",
+            "version": "v2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "832b7635a39b4e468c634572baaab2710a55d88b"
+                "reference": "1ddc754f1c15e56fb2cdd1a4e82bd0ec6ca32a76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/832b7635a39b4e468c634572baaab2710a55d88b",
-                "reference": "832b7635a39b4e468c634572baaab2710a55d88b",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/1ddc754f1c15e56fb2cdd1a4e82bd0ec6ca32a76",
+                "reference": "1ddc754f1c15e56fb2cdd1a4e82bd0ec6ca32a76",
                 "shasum": ""
             },
             "require": {
@@ -2749,7 +2681,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7.x-dev"
+                    "dev-master": "2.8.x-dev"
                 }
             },
             "autoload": {
@@ -2776,7 +2708,7 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2022-10-12T05:13:17+00:00"
+            "time": "2022-10-17T23:10:42+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -2831,16 +2763,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada"
+                "reference": "3c621ff5429d2b1ff96dc5808ad6cde99d31ea4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/5ea3536428944955f969bc764bbe09738e151ada",
-                "reference": "5ea3536428944955f969bc764bbe09738e151ada",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/3c621ff5429d2b1ff96dc5808ad6cde99d31ea4c",
+                "reference": "3c621ff5429d2b1ff96dc5808ad6cde99d31ea4c",
                 "shasum": ""
             },
             "require": {
@@ -2848,7 +2780,7 @@
                 "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
             },
             "require-dev": {
-                "yoast/yoastcs": "^2.2.0"
+                "yoast/yoastcs": "^2.2.1"
             },
             "type": "library",
             "extra": {
@@ -2888,7 +2820,7 @@
                 "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2021-11-23T01:37:03+00:00"
+            "time": "2022-11-16T09:07:52+00:00"
         }
     ],
     "aliases": [],
@@ -2897,11 +2829,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4"
+        "php": ">=7.2"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.4.30"
+        "php": "7.2"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1989,7 +1989,12 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			throw new PluginException( __( 'A product sync is in progress. Please wait until the sync finishes before starting a new one.', 'facebook-for-woocommerce' ) );
 		}
 
-		$catalog = $this->facebook_for_woocommerce->get_api()->get_catalog( $this->get_product_catalog_id() );
+		try {
+			$catalog = $this->facebook_for_woocommerce->get_api()->get_catalog($this->get_product_catalog_id());
+		} catch ( ApiException $e ) {
+			$message = sprintf( 'There was an error trying to delete a product set item: %s', $e->getMessage() );
+			facebook_for_woocommerce()->log( $message );
+		}
 		if ( $catalog->id ) {
 			WC_Facebookcommerce_Utils::log( 'Not syncing, invalid product catalog!' );
 			WC_Facebookcommerce_Utils::fblog(

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -10,12 +10,10 @@
  */
 
 use WooCommerce\Facebook\Admin;
-use WooCommerce\Facebook\API;
 use WooCommerce\Facebook\Events\AAMSettings;
 use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
 use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Framework\Plugin\Exception as PluginException;
-use WooCommerce\Facebook\Handlers\Connection;
 use WooCommerce\Facebook\Products;
 use WooCommerce\Facebook\Products\Feed;
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -2789,7 +2789,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			// sync product with all variations
 			$this->facebook_for_woocommerce->get_products_sync_handler()->create_or_update_products( $product_ids );
 		} else {
-			$fb_product_item_id = $this->get_product_fbid( self::FB_PRODUCT_ITEM_ID, $product_id );
+			$fb_product_item_id = $this->get_product_fbid( self::FB_PRODUCT_ITEM_ID, $product->get_id() );
 			if ( ! $fb_product_item_id ) {
 				\WC_Facebookcommerce_Utils::fblog( $fb_product_item_id . " doesn't exist but underwent a visibility transform.", [], true );
 				 return;

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -579,7 +579,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			} while ( $response = $this->facebook_for_woocommerce->get_api()->next( $response, 2 ) );
 		} catch ( ApiException $e ) {
 			$message = sprintf( 'There was an error trying to find the IDs for Product Items in the Product Group %s: %s', $product_group_id, $e->getMessage() );
-			facebook_for_woocommerce()->log( $message );
+			WC_Facebookcommerce_Utils::log( $message );
 		}
 		return $product_item_ids;
 	}
@@ -1221,7 +1221,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			}
 		} catch ( ApiException $e ) {
 			$message = sprintf( 'There was an error trying to create the product group: %s', $e->getMessage() );
-			facebook_for_woocommerce()->log( $message );
+			WC_Facebookcommerce_Utils::log( $message );
 		}
 		return null;
 	}
@@ -1286,7 +1286,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			}
 		} catch ( ApiException $e ) {
 			$message = sprintf( 'There was an error trying to update Product Group %s: %s', $fb_product_group_id, $e->getMessage() );
-			facebook_for_woocommerce()->log( $message );
+			WC_Facebookcommerce_Utils::log( $message );
 		}
 	}
 
@@ -1314,7 +1314,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			}
 		} catch ( ApiException $e ) {
 			$message = sprintf( 'There was an error trying to create a product item: %s', $e->getMessage() );
-			facebook_for_woocommerce()->log( $message );
+			WC_Facebookcommerce_Utils::log( $message );
 		}
 		return '';
 	}
@@ -1445,7 +1445,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			}
 		} catch ( ApiException $e ) {
 			$message = sprintf( 'There was an error trying to update a product item: %s', $e->getMessage() );
-			facebook_for_woocommerce()->log( $message );
+			WC_Facebookcommerce_Utils::log( $message );
 		}
 	}
 
@@ -1479,7 +1479,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			}
 		} catch ( ApiException $e ) {
 			$message = sprintf( 'There was an error trying to create/update a product set: %s', $e->getMessage() );
-			facebook_for_woocommerce()->log( $message );
+			WC_Facebookcommerce_Utils::log( $message );
 		}
 	}
 
@@ -1497,7 +1497,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$this->facebook_for_woocommerce->get_api()->delete_product_set_item( $fb_product_set_id, $allow_live_deletion );
 		} catch ( ApiException $e ) {
 			$message = sprintf( 'There was an error trying to delete a product set item: %s', $e->getMessage() );
-			facebook_for_woocommerce()->log( $message );
+			WC_Facebookcommerce_Utils::log( $message );
 		}
 	}
 
@@ -1991,7 +1991,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$catalog = $this->facebook_for_woocommerce->get_api()->get_catalog($this->get_product_catalog_id());
 		} catch ( ApiException $e ) {
 			$message = sprintf( 'There was an error trying to delete a product set item: %s', $e->getMessage() );
-			facebook_for_woocommerce()->log( $message );
+			WC_Facebookcommerce_Utils::log( $message );
 		}
 		if ( $catalog->id ) {
 			WC_Facebookcommerce_Utils::log( 'Not syncing, invalid product catalog!' );
@@ -2748,10 +2748,10 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		if ( $fb_product_item_id ) {
 			try {
 				$pi_result = $this->facebook_for_woocommerce->get_api()->delete_product_item( $fb_product_item_id );
-				\WC_Facebookcommerce_Utils::log( $pi_result );
+				WC_Facebookcommerce_Utils::log( $pi_result );
 			} catch ( ApiException $e ) {
 				$message = sprintf( 'There was an error trying to delete a product set item: %s', $e->getMessage() );
-				facebook_for_woocommerce()->log( $message );
+				WC_Facebookcommerce_Utils::log( $message );
 			}
 		}
 	}
@@ -2769,10 +2769,10 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			// TODO: replace with a call to API::delete_product_group() {WV 2020-05-26}
 			try {
 				$pg_result = $this->facebook_for_woocommerce->get_api()->delete_product_group( $product_group_id );
-				\WC_Facebookcommerce_Utils::log( $pg_result );
+				WC_Facebookcommerce_Utils::log( $pg_result );
 			} catch ( ApiException $e ) {
 				$message = sprintf( 'There was an error trying to delete a product group: %s', $e->getMessage() );
-				facebook_for_woocommerce()->log( $message );
+				WC_Facebookcommerce_Utils::log( $message );
 			}
 		}
 	}
@@ -2843,7 +2843,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				}
 			} catch ( ApiException $e ) {
 				$message = sprintf( 'There was an error trying to update product item: %s', $e->getMessage() );
-				facebook_for_woocommerce()->log( $message );
+				WC_Facebookcommerce_Utils::log( $message );
 			}
 		}
 	}

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,7 +11,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.0.1
+ * Version: 3.0.2
  * Text Domain: facebook-for-woocommerce
  * Tested up to: 6.1
  * WC requires at least: 5.3
@@ -44,7 +44,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '3.0.1'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '3.0.2'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.0.0';

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -16,7 +16,7 @@
  * Tested up to: 6.1
  * WC requires at least: 5.3
  * WC tested up to: 5.4
- * Requires PHP: 7.0
+ * Requires PHP: 7.2
  *
  * @package FacebookCommerce
  */

--- a/includes/API/Catalog/Product_Item/Response.php
+++ b/includes/API/Catalog/Product_Item/Response.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -11,17 +10,16 @@
 
 namespace WooCommerce\Facebook\API\Catalog\Product_Item;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
-use WooCommerce\Facebook\API;
+use WooCommerce\Facebook\API\Response as BaseResponse;
 
 /**
  * Response object for API requests that return a Product Item.
  *
  * @since 2.0.0
  */
-class Response extends API\Response {
-
+class Response extends BaseResponse {
 
 	/**
 	 * Gets the Product Item group ID.
@@ -31,15 +29,6 @@ class Response extends API\Response {
 	 * @return string
 	 */
 	public function get_group_id() {
-
-		$product_group_id = '';
-
-		if ( isset( $this->response_data->product_group->id ) ) {
-			$product_group_id = $this->response_data->product_group->id;
-		}
-
-		return $product_group_id;
+		return $this->response_data['product_group']['id'] ?? '';
 	}
-
-
 }

--- a/includes/API/Response.php
+++ b/includes/API/Response.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -13,7 +12,7 @@ namespace WooCommerce\Facebook\API;
 
 use WooCommerce\Facebook\Framework\Api\JSONResponse;
 
-defined( 'ABSPATH' ) or exit;
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Base API response object

--- a/includes/API/Traits/Paginated_Response.php
+++ b/includes/API/Traits/Paginated_Response.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -7,12 +6,15 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @package FacebookCommerce
+ *
+ * phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
  */
 
 namespace WooCommerce\Facebook\API\Traits;
 
-defined( 'ABSPATH' ) or exit;
+use stdClass;
 
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Helper methods to traverse Graph API paged results.
@@ -23,13 +25,11 @@ defined( 'ABSPATH' ) or exit;
  */
 trait Paginated_Response {
 
-
-	/** @var string number of pages retrieved from this response */
+	/** @var int number of pages retrieved from this response */
 	private $pages_retrieved = 1;
 
-	/** @var mixed decoded response data */
+	/** @var array decoded response data */
 	public $response_data;
-
 
 	/**
 	 * Sets the number of pages retrieved from this response.
@@ -39,10 +39,8 @@ trait Paginated_Response {
 	 * @param int $pages_retrieved
 	 */
 	public function set_pages_retrieved( $pages_retrieved ) {
-
 		$this->pages_retrieved = $pages_retrieved;
 	}
-
 
 	/**
 	 * Gets the number of pages retrieved from this response.
@@ -52,10 +50,8 @@ trait Paginated_Response {
 	 * @return int
 	 */
 	public function get_pages_retrieved() {
-
 		return $this->pages_retrieved;
 	}
-
 
 	/**
 	 * Gets the response data.
@@ -65,10 +61,8 @@ trait Paginated_Response {
 	 * @return array
 	 */
 	public function get_data() {
-
-		return ! empty( $this->response_data->data ) ? $this->response_data->data : array();
+		return $this->response_data['data'] ?? [];
 	}
-
 
 	/**
 	 * Gets the pagination data.
@@ -78,10 +72,8 @@ trait Paginated_Response {
 	 * @return object
 	 */
 	public function get_pagination_data() {
-
-		return ! empty( $this->response_data->paging ) ? $this->response_data->paging : new \stdClass();
+		return $this->response_data['paging'] ?? new stdClass();
 	}
-
 
 	/**
 	 * Gets the API endpoint for the next page of results.
@@ -91,22 +83,17 @@ trait Paginated_Response {
 	 * @return string
 	 */
 	public function get_next_page_endpoint() {
-
-		return ! empty( $this->get_pagination_data()->next ) ? $this->get_pagination_data()->next : '';
+		return $this->get_pagination_data()->next ?? '';
 	}
-
 
 	/**
 	 * Gets the API endpoint for the previous page of results.
 	 *
 	 * @since 2.0.0
 	 *
-	 * @param string
+	 * @return string
 	 */
 	public function get_previous_page_endpoint() {
-
-		return ! empty( $this->get_pagination_data()->previous ) ? $this->get_pagination_data()->previous : '';
+		return $this->get_pagination_data()->previous ?? '';
 	}
-
-
 }

--- a/includes/Commerce/Orders.php
+++ b/includes/Commerce/Orders.php
@@ -652,24 +652,23 @@ class Orders {
 	 */
 	public function add_order_refund( \WC_Order_Refund $refund, $reason_code ) {
 
-		$plugin = facebook_for_woocommerce();
-
-		$api = $plugin->get_api( $plugin->get_connection_handler()->get_page_access_token() );
-
-		$valid_reason_codes = array(
-			self::REFUND_REASON_BUYERS_REMORSE,
-			self::REFUND_REASON_DAMAGED_GOODS,
-			self::REFUND_REASON_NOT_AS_DESCRIBED,
-			self::REFUND_REASON_QUALITY_ISSUE,
-			self::REFUND_REASON_OTHER,
-			self::REFUND_REASON_WRONG_ITEM,
-		);
-
-		if ( ! in_array( $reason_code, $valid_reason_codes, true ) ) {
-			$reason_code = self::REFUND_REASON_OTHER;
-		}
-
 		try {
+			$plugin = facebook_for_woocommerce();
+
+			$api = $plugin->get_api( $plugin->get_connection_handler()->get_page_access_token() );
+
+			$valid_reason_codes = array(
+				self::REFUND_REASON_BUYERS_REMORSE,
+				self::REFUND_REASON_DAMAGED_GOODS,
+				self::REFUND_REASON_NOT_AS_DESCRIBED,
+				self::REFUND_REASON_QUALITY_ISSUE,
+				self::REFUND_REASON_OTHER,
+				self::REFUND_REASON_WRONG_ITEM,
+			);
+
+			if ( ! in_array( $reason_code, $valid_reason_codes, true ) ) {
+				$reason_code = self::REFUND_REASON_OTHER;
+			}
 
 			$parent_order = wc_get_order( $refund->get_parent_id() );
 
@@ -797,17 +796,17 @@ class Orders {
 	 */
 	public function cancel_order( \WC_Order $order, $reason_code ) {
 
-		$plugin = facebook_for_woocommerce();
-
-		$api = $plugin->get_api( $plugin->get_connection_handler()->get_page_access_token() );
-
-		$valid_reason_codes = array_keys( $this->get_cancellation_reasons() );
-
-		if ( ! in_array( $reason_code, $valid_reason_codes, true ) ) {
-			$reason_code = self::CANCEL_REASON_OTHER;
-		}
-
 		try {
+
+			$plugin = facebook_for_woocommerce();
+
+			$api = $plugin->get_api( $plugin->get_connection_handler()->get_page_access_token() );
+
+			$valid_reason_codes = array_keys( $this->get_cancellation_reasons() );
+
+			if ( ! in_array( $reason_code, $valid_reason_codes, true ) ) {
+				$reason_code = self::CANCEL_REASON_OTHER;
+			}
 
 			$remote_id = $order->get_meta( self::REMOTE_ID_META_KEY );
 

--- a/includes/Feed/FeedConfigurationDetection.php
+++ b/includes/Feed/FeedConfigurationDetection.php
@@ -87,7 +87,7 @@ class FeedConfigurationDetection {
 				break;
 			}
 
-			if ( ! array_key_exists( 'latest_upload', $metadata ) || ! array_key_exists( 'start_time', $metadata['latest_upload'] ) ) {
+			if ( ! $metadata || ! array_key_exists( 'latest_upload', $metadata ) || ! array_key_exists( 'start_time', $metadata['latest_upload'] ) ) {
 				continue;
 			}
 			$metadata['latest_upload_time'] = strtotime( $metadata['latest_upload']['start_time'] );
@@ -140,6 +140,12 @@ class FeedConfigurationDetection {
 
 			// Get more detailed metadata about the most recent feed upload.
 			$upload_metadata = $this->get_feed_upload_metadata( $latest_upload['id'] );
+
+			// If no metadata is available, we can't track any more details.
+			if ( ! $upload_metadata ) {
+				$info['active-feed']['latest-upload'] = $upload;
+				return $info;
+			}
 
 			$upload['error-count']         = $upload_metadata['error_count'];
 			$upload['warning-count']       = $upload_metadata['warning_count'];

--- a/includes/Feed/FeedConfigurationDetection.php
+++ b/includes/Feed/FeedConfigurationDetection.php
@@ -177,7 +177,7 @@ class FeedConfigurationDetection {
 		try {
 			$response = facebook_for_woocommerce()->get_api()->read_feeds($product_catalog_id);
 		} catch ( \Exception $e ) {
-			$message = sprintf( 'There was an error trying to update product item: %s', $e->getMessage() );
+			$message = sprintf( 'There was an error trying to get feed nodes for catalog: %s', $e->getMessage() );
 			facebook_for_woocommerce()->log( $message );
 			return array();
 		}
@@ -196,7 +196,7 @@ class FeedConfigurationDetection {
 		try {
 			$response = facebook_for_woocommerce()->get_api()->read_feed($feed_id);
 		} catch ( \Exception $e ) {
-			$message = sprintf( 'There was an error trying to update product item: %s', $e->getMessage() );
+			$message = sprintf( 'There was an error trying to get feed metadata: %s', $e->getMessage() );
 			facebook_for_woocommerce()->log( $message );
 			return false;
 		}
@@ -214,7 +214,7 @@ class FeedConfigurationDetection {
 		try {
 			$response = facebook_for_woocommerce()->get_api()->read_upload($upload_id);
 		} catch ( \Exception $e ) {
-			$message = sprintf( 'There was an error trying to update product item: %s', $e->getMessage() );
+			$message = sprintf( 'There was an error trying to get feed upload metadata: %s', $e->getMessage() );
 			facebook_for_woocommerce()->log( $message );
 			return false;
 		}

--- a/includes/Feed/FeedConfigurationDetection.php
+++ b/includes/Feed/FeedConfigurationDetection.php
@@ -6,8 +6,11 @@ namespace WooCommerce\Facebook\Feed;
 defined( 'ABSPATH' ) || exit;
 
 use Error;
+use Exception;
+use WC_Facebookcommerce_Utils;
 use WooCommerce\Facebook\API\Exceptions\Request_Limit_Reached;
-use WooCommerce\Facebook\Framework\Api\Exception;
+use WooCommerce\Facebook\API\Response;
+use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
 use WooCommerce\Facebook\Products\Feed;
 use WooCommerce\Facebook\Utilities\Heartbeat;
 
@@ -80,20 +83,33 @@ class FeedConfigurationDetection {
 		 */
 		$active_feed_metadata = array();
 		foreach ( $feed_nodes as $feed ) {
-			$metadata = $this->get_feed_metadata( $feed['id'] );
+			try {
+				$metadata = $this->get_feed_metadata( $feed['id'] );
+			} catch ( Exception $e ) {
+				$message = sprintf( 'There was an error trying to get feed metadata: %s', $e->getMessage() );
+				WC_Facebookcommerce_Utils::log( $message );
+				continue;
+			}
 
 			if ( $feed['id'] === $integration_feed_id ) {
-				$active_feed_metadata = $metadata;
+				$active_feed_metadata = clone $metadata;
 				break;
 			}
 
-			if ( ! $metadata || ! array_key_exists( 'latest_upload', $metadata ) || ! array_key_exists( 'start_time', $metadata['latest_upload'] ) ) {
+			if (
+				! isset( $metadata['latest_upload'] ) ||
+				! is_array( $metadata['latest_upload'] ) ||
+				! array_key_exists( 'start_time', $metadata['latest_upload'] )
+			) {
 				continue;
 			}
+
 			$metadata['latest_upload_time'] = strtotime( $metadata['latest_upload']['start_time'] );
-			if ( ! $active_feed_metadata ||
-				( $metadata['latest_upload_time'] > $active_feed_metadata['latest_upload_time'] ) ) {
-				$active_feed_metadata = $metadata;
+			if (
+				! $active_feed_metadata ||
+				$metadata['latest_upload_time'] > $active_feed_metadata['latest_upload_time']
+			) {
+				$active_feed_metadata = clone $metadata;
 			}
 		}
 
@@ -104,11 +120,11 @@ class FeedConfigurationDetection {
 		}
 
 		$active_feed = array();
-		if ( array_key_exists( 'created_time', $active_feed_metadata ) ) {
+		if ( isset( $active_feed_metadata['created_time'] ) ) {
 			$active_feed['created-time'] = gmdate( 'Y-m-d H:i:s', strtotime( $active_feed_metadata['created_time'] ) );
 		}
 
-		if ( array_key_exists( 'product_count', $active_feed_metadata ) ) {
+		if ( isset( $active_feed_metadata['product_count'] ) ) {
 			$active_feed['product-count'] = $active_feed_metadata['product_count'];
 		}
 
@@ -119,18 +135,18 @@ class FeedConfigurationDetection {
 		 * These may both be configured; we will track settings for each individually (i.e. both).
 		 * https://developers.facebook.com/docs/marketing-api/reference/product-feed/
 		 */
-		if ( array_key_exists( 'schedule', $active_feed_metadata ) ) {
+		if ( isset( $active_feed_metadata['schedule'] ) ) {
 			$active_feed['schedule']['interval']       = $active_feed_metadata['schedule']['interval'];
 			$active_feed['schedule']['interval-count'] = $active_feed_metadata['schedule']['interval_count'];
 		}
-		if ( array_key_exists( 'update_schedule', $active_feed_metadata ) ) {
+		if ( isset( $active_feed_metadata['update_schedule'] ) ) {
 			$active_feed['update-schedule']['interval']       = $active_feed_metadata['update_schedule']['interval'];
 			$active_feed['update-schedule']['interval-count'] = $active_feed_metadata['update_schedule']['interval_count'];
 		}
 
 		$info['active-feed'] = $active_feed;
 
-		if ( array_key_exists( 'latest_upload', $active_feed_metadata ) ) {
+		if ( isset( $active_feed_metadata['latest_upload'] ) ) {
 			$latest_upload = $active_feed_metadata['latest_upload'];
 			$upload        = array();
 
@@ -175,9 +191,10 @@ class FeedConfigurationDetection {
 
 	/**
 	 * @param string $product_catalog_id
+	 *
 	 * @return array Facebook Product Feeds.
-	 * @throws \WooCommerce\Facebook\API\Exceptions\Request_Limit_Reached
-	 * @throws \WooCommerce\Facebook\Framework\Api\Exception
+	 * @throws Request_Limit_Reached
+	 * @throws ApiException
 	 */
 	private function get_feed_nodes_for_catalog( string $product_catalog_id ) {
 		try {
@@ -194,27 +211,22 @@ class FeedConfigurationDetection {
 	 * Given feed id fetch this feed configuration metadata.
 	 *
 	 * @param string $feed_id Facebook Product Feed ID.
-	 * @return \WooCommerce\Facebook\API\Response|bool
-	 * @throws \WooCommerce\Facebook\API\Exceptions\Request_Limit_Reached
-	 * @throws \WooCommerce\Facebook\Framework\Api\Exception
+	 *
+	 * @return Response
+	 * @throws Request_Limit_Reached
+	 * @throws ApiException
 	 */
 	private function get_feed_metadata( string $feed_id ) {
-		try {
-			$response = facebook_for_woocommerce()->get_api()->read_feed($feed_id);
-		} catch ( \Exception $e ) {
-			$message = sprintf( 'There was an error trying to get feed metadata: %s', $e->getMessage() );
-			facebook_for_woocommerce()->log( $message );
-			return false;
-		}
-		return $response;
+		return facebook_for_woocommerce()->get_api()->read_feed( $feed_id );
 	}
 
 	/**
 	 * Given upload id fetch this upload execution metadata.
 	 *
+	 * @param string $upload_id Facebook Feed upload ID.
+	 *
+	 * @return Response
 	 * @throws Error Upload metadata fetch was not successful.
-	 * @param String                        $upload_id Facebook Feed upload ID.
-	 * @return \WooCommerce\Facebook\API\Response|bool
 	 */
 	private function get_feed_upload_metadata( $upload_id ) {
 		try {

--- a/includes/Feed/FeedConfigurationDetection.php
+++ b/includes/Feed/FeedConfigurationDetection.php
@@ -6,6 +6,8 @@ namespace WooCommerce\Facebook\Feed;
 defined( 'ABSPATH' ) || exit;
 
 use Error;
+use WooCommerce\Facebook\API\Exceptions\Request_Limit_Reached;
+use WooCommerce\Facebook\Framework\Api\Exception;
 use WooCommerce\Facebook\Products\Feed;
 use WooCommerce\Facebook\Utilities\Heartbeat;
 
@@ -172,7 +174,13 @@ class FeedConfigurationDetection {
 	 * @throws \WooCommerce\Facebook\Framework\Api\Exception
 	 */
 	private function get_feed_nodes_for_catalog( string $product_catalog_id ) {
-		$response = facebook_for_woocommerce()->get_api()->read_feeds( $product_catalog_id );
+		try {
+			$response = facebook_for_woocommerce()->get_api()->read_feeds($product_catalog_id);
+		} catch ( \Exception $e ) {
+			$message = sprintf( 'There was an error trying to update product item: %s', $e->getMessage() );
+			facebook_for_woocommerce()->log( $message );
+			return array();
+		}
 		return $response->data;
 	}
 
@@ -180,12 +188,18 @@ class FeedConfigurationDetection {
 	 * Given feed id fetch this feed configuration metadata.
 	 *
 	 * @param string $feed_id Facebook Product Feed ID.
-	 * @return \WooCommerce\Facebook\API\Response
+	 * @return \WooCommerce\Facebook\API\Response|bool
 	 * @throws \WooCommerce\Facebook\API\Exceptions\Request_Limit_Reached
 	 * @throws \WooCommerce\Facebook\Framework\Api\Exception
 	 */
 	private function get_feed_metadata( string $feed_id ) {
-		$response = facebook_for_woocommerce()->get_api()->read_feed( $feed_id );
+		try {
+			$response = facebook_for_woocommerce()->get_api()->read_feed($feed_id);
+		} catch ( \Exception $e ) {
+			$message = sprintf( 'There was an error trying to update product item: %s', $e->getMessage() );
+			facebook_for_woocommerce()->log( $message );
+			return false;
+		}
 		return $response;
 	}
 
@@ -194,10 +208,16 @@ class FeedConfigurationDetection {
 	 *
 	 * @throws Error Upload metadata fetch was not successful.
 	 * @param String                        $upload_id Facebook Feed upload ID.
-	 * @return array Array of feed configurations.
+	 * @return \WooCommerce\Facebook\API\Response|bool
 	 */
 	private function get_feed_upload_metadata( $upload_id ) {
-		$response = facebook_for_woocommerce()->get_api()->read_upload( $upload_id );
+		try {
+			$response = facebook_for_woocommerce()->get_api()->read_upload($upload_id);
+		} catch ( \Exception $e ) {
+			$message = sprintf( 'There was an error trying to update product item: %s', $e->getMessage() );
+			facebook_for_woocommerce()->log( $message );
+			return false;
+		}
 		return $response;
 	}
 

--- a/includes/Framework/Api/JSONResponse.php
+++ b/includes/Framework/Api/JSONResponse.php
@@ -20,7 +20,7 @@ abstract class JSONResponse implements Response, ArrayAccess {
 	protected $raw_response_json;
 
 	/** @var array decoded response data */
-	protected $response_data;
+	public $response_data;
 
 	/**
 	 * Build the data object from the raw JSON.

--- a/includes/Framework/Api/JSONResponse.php
+++ b/includes/Framework/Api/JSONResponse.php
@@ -74,7 +74,7 @@ abstract class JSONResponse implements Response, ArrayAccess {
 	/**
 	 * Determine whether the given offset exists.
 	 *
-	 * @since x.x.x
+	 * @since 3.0.2
 	 *
 	 * @param int|string $offset The offset key.
 	 *
@@ -87,7 +87,7 @@ abstract class JSONResponse implements Response, ArrayAccess {
 	/**
 	 * Get the given offset.
 	 *
-	 * @since x.x.x
+	 * @since 3.0.2
 	 *
 	 * @param int|string $offset The offset key.
 	 *
@@ -100,7 +100,7 @@ abstract class JSONResponse implements Response, ArrayAccess {
 	/**
 	 * Set the offset to the given value.
 	 *
-	 * @since x.x.x
+	 * @since 3.0.2
 	 *
 	 * @param int|string $offset The offset key.
 	 * @param mixed      $value  The offset value.
@@ -114,7 +114,7 @@ abstract class JSONResponse implements Response, ArrayAccess {
 	/**
 	 * Unset the given offset.
 	 *
-	 * @since x.x.x
+	 * @since 3.0.2
 	 *
 	 * @param int|string $offset The offset key.
 	 *

--- a/includes/Framework/Api/JSONResponse.php
+++ b/includes/Framework/Api/JSONResponse.php
@@ -1,32 +1,32 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Facebook for WooCommerce.
  */
 
 namespace WooCommerce\Facebook\Framework\Api;
 
-defined( 'ABSPATH' ) or exit;
+use ArrayAccess;
+
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Base JSON API response class.
  *
  * @since 4.3.0
  */
-abstract class JSONResponse implements Response {
-
+abstract class JSONResponse implements Response, ArrayAccess {
 
 	/** @var string string representation of this response */
 	protected $raw_response_json;
 
-	/** @var mixed decoded response data */
-	public $response_data;
-
+	/** @var array decoded response data */
+	protected $response_data;
 
 	/**
 	 * Build the data object from the raw JSON.
 	 *
 	 * @since 4.3.0
+	 *
 	 * @param string $raw_response_json The raw JSON
 	 */
 	public function __construct( string $raw_response_json ) {
@@ -34,12 +34,13 @@ abstract class JSONResponse implements Response {
 		$this->response_data     = json_decode( $raw_response_json, true );
 	}
 
-
 	/**
 	 * Magic accessor for response data attributes
 	 *
 	 * @since 4.3.0
+	 *
 	 * @param string $name The attribute name to get.
+	 *
 	 * @return mixed The attribute value
 	 */
 	public function __get( string $name ) {
@@ -47,28 +48,79 @@ abstract class JSONResponse implements Response {
 		return $this->response_data[ $name ] ?? null;
 	}
 
-
 	/**
 	 * Get the string representation of this response.
 	 *
 	 * @since 4.3.0
-	 * @see SV_Response::to_string()
 	 * @return string
+	 * @see   SV_Response::to_string()
 	 */
 	public function to_string() {
 		return $this->raw_response_json;
 	}
-
 
 	/**
 	 * Get the string representation of this response with any and all sensitive elements masked
 	 * or removed.
 	 *
 	 * @since 4.3.0
-	 * @see Response::to_string_safe()
 	 * @return string
+	 * @see   Response::to_string_safe()
 	 */
 	public function to_string_safe() {
 		return $this->to_string();
+	}
+
+	/**
+	 * Determine whether the given offset exists.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int|string $offset The offset key.
+	 *
+	 * @return bool Whether the offset exists.
+	 */
+	public function offsetExists( $offset ) {
+		return array_key_exists( $offset, $this->response_data );
+	}
+
+	/**
+	 * Get the given offset.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int|string $offset The offset key.
+	 *
+	 * @return mixed The offset value.
+	 */
+	public function offsetGet( $offset ) {
+		return $this->response_data[ $offset ];
+	}
+
+	/**
+	 * Set the offset to the given value.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int|string $offset The offset key.
+	 * @param mixed      $value  The offset value.
+	 *
+	 * @return void
+	 */
+	public function offsetSet( $offset, $value ) {
+		$this->response_data[ $offset ] = $value;
+	}
+
+	/**
+	 * Unset the given offset.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param int|string $offset The offset key.
+	 *
+	 * @return void
+	 */
+	public function offsetUnset( $offset ) {
+		unset( $this->response_data[ $offset ] );
 	}
 }

--- a/includes/fbinfobanner.php
+++ b/includes/fbinfobanner.php
@@ -11,6 +11,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
+
 require_once __DIR__ . '/fbutils.php';
 
 /**
@@ -131,8 +133,14 @@ class WC_Facebookcommerce_Info_Banner {
 			// tip pass time cap.
 			$tip_info = WC_Facebookcommerce_Utils::get_cached_best_tip();
 		} else {
-			$tip_info = facebook_for_woocommerce()->get_api()->get_tip_info( $this->external_merchant_settings_id );
-			update_option( 'fb_info_banner_last_query_time', current_time( 'mysql' ) );
+
+			try {
+				$tip_info = facebook_for_woocommerce()->get_api()->get_tip_info( $this->external_merchant_settings_id );
+				update_option( 'fb_info_banner_last_query_time', current_time( 'mysql' ) );
+			} catch ( ApiException $exception ) {
+				// always log this error, regardless of debug setting
+				facebook_for_woocommerce()->log( 'Could not retrieve tip. ' . $exception->getMessage() );
+			}
 		}
 
 		// Not render if no cached best tip, or no best tip returned from FB.

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -605,7 +605,13 @@ class WC_Facebook_Product_Feed {
 	public function is_upload_complete( &$settings ) {
 
 		$upload_id = facebook_for_woocommerce()->get_integration()->get_upload_id();
-		$result    = facebook_for_woocommerce()->get_api()->read_upload( $upload_id );
+		try {
+			$result = facebook_for_woocommerce()->get_api()->read_upload($upload_id);
+		} catch ( \Exception $e ) {
+			// if the upload ID is invalid, the feed is not complete
+			$this->log_feed_progress( $e->getMessage() );
+			return 'error';
+		}
 
 		if ( is_wp_error( $result ) || ! isset( $result['body'] ) ) {
 			 $this->log_feed_progress( json_encode( $result ) );

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -13,6 +13,7 @@ defined( 'ABSPATH' ) || exit;
 
 use WooCommerce\Facebook\Events\AAMSettings;
 use WooCommerce\Facebook\Events\Normalizer;
+use WooCommerce\Facebook\Framework\Api\Exception as ApiException;
 
 /**
  * FB Graph API helper functions
@@ -296,7 +297,12 @@ class WC_Facebookcommerce_Utils {
 		);
 		$ems     = $ems ?: self::$ems;
 		if ( $ems ) {
-			facebook_for_woocommerce()->get_api()->log( $ems, $message, $error );
+			try {
+				facebook_for_woocommerce()->get_api()->log($ems, $message, $error);
+			} catch ( ApiException $e ) {
+				$message = sprintf( 'There was an error trying to update product item: %s', $e->getMessage() );
+				facebook_for_woocommerce()->log( $message );
+			}
 		} else {
 			error_log(
 				'external merchant setting is null, something wrong here: ' .
@@ -311,7 +317,12 @@ class WC_Facebookcommerce_Utils {
 	public static function tip_events_log( $tip_id, $channel_id, $event, $ems = '' ) {
 		$ems = $ems ?: self::$ems;
 		if ( $ems ) {
-			facebook_for_woocommerce()->get_api()->log_tip_event( $tip_id, $channel_id, $event );
+			try {
+				facebook_for_woocommerce()->get_api()->log_tip_event($tip_id, $channel_id, $event);
+			} catch ( ApiException $e ) {
+				$message = sprintf( 'There was an error trying to update product item: %s', $e->getMessage() );
+				facebook_for_woocommerce()->log( $message );
+			}
 		} else {
 			error_log( 'external merchant setting is null' );
 		}

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -300,7 +300,7 @@ class WC_Facebookcommerce_Utils {
 			try {
 				facebook_for_woocommerce()->get_api()->log($ems, $message, $error);
 			} catch ( ApiException $e ) {
-				$message = sprintf( 'There was an error trying to update product item: %s', $e->getMessage() );
+				$message = sprintf( 'There was an error trying to log: %s', $e->getMessage() );
 				facebook_for_woocommerce()->log( $message );
 			}
 		} else {
@@ -320,7 +320,7 @@ class WC_Facebookcommerce_Utils {
 			try {
 				facebook_for_woocommerce()->get_api()->log_tip_event($tip_id, $channel_id, $event);
 			} catch ( ApiException $e ) {
-				$message = sprintf( 'There was an error trying to update product item: %s', $e->getMessage() );
+				$message = sprintf( 'There was an error while logging tip events: %s', $e->getMessage() );
 				facebook_for_woocommerce()->log( $message );
 			}
 		} else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 6.1
-Stable tag: 3.0.1
+Stable tag: 3.0.2
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later
@@ -39,7 +39,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= 3.0.2 - 2022-xx-xx =
+= 3.0.2 - 2022-11-18 =
 * Fix - Properly handle API exceptions
 * Fix - Set correct PHP version in plugin header
 * Dev - Add ArrayAccess implementation to JSONResponse class

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,11 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
+= 3.0.2 - 2022-xx-xx =
+* Fix - Properly handle API exceptions
+* Fix - Set correct PHP version in plugin header
+* Dev - Add ArrayAccess implementation to JSONResponse class
+
 = 3.0.1 - 2022-11-17 =
 * Fix - Wrong path to the fbutils.php file.
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Commits:

- Handle `get_api()` exception.
- Ensure only product id is passed to `get_product_fbid`.
- Adds try-catch block around `get_api` calls
- Handle `ApiException`.
- Adds try catch block around `get_api` calls in product feed class.
- Refactors try catch in Orders
- Ensure `ApiException` is handled across the extension.
- Update exception log message
- Handle empty responses.
- Set php version in plugin header and composer
- Update composer.lock after updating composer.json
- Remove unused imports
- Add `ArrayAccess` methods and implementation to `JSONResponse`
- Rework feed metadata retrieval with correct typing
- Use consistent method for logging: `WC_Facebookcommerce_Utils::log()`


Checks:

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changelog entry

> Fix - Properly handle API exceptions
> Fix - Set correct PHP version in plugin header
> Dev - Add ArrayAccess implementation to JSONResponse class
