### PR TITLE
Merge hotfix/3.0.3 into develop

### DIFF
--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Run PHPCS on all files
         run: vendor/bin/phpcs -q -n --report=checkstyle | cs2pr
+
+      - name: PHP Syntax checker
+        uses: StephaneBour/actions-php-lint@7.2

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 *** Facebook for WooCommerce Changelog ***
 
-= 3.0.3 - 2022-xx-xx =
+= 3.0.3 - 2022-11-18 =
 * Fix - Remove flexible heredoc syntax that is incompatible with PHP 7.2
 
 = 3.0.2 - 2022-11-18 =

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 3.0.3 - 2022-xx-xx =
+* Fix - Remove flexible heredoc syntax that is incompatible with PHP 7.2
+
 = 3.0.2 - 2022-11-18 =
 * Fix - Properly handle API exceptions
 * Fix - Set correct PHP version in plugin header

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -2668,11 +2668,13 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	private function get_message_html( string $message, string $type = 'error' ): string {
 		ob_start();
-		$type = esc_attr( $type );
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo <<<MESSAGE
-		<div class="notice is-dismissible notice-{$type}"><p>{$message}</p></div>
-		MESSAGE;
+		printf(
+			'<div class="notice is-dismissible notice-%s"><p>%s</p></div>',
+			esc_attr( $type ),
+			$message
+		);
+
 		return ob_get_clean();
 	}
 
@@ -2724,14 +2726,15 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	public function admin_options() {
 		$this->facebook_for_woocommerce->get_message_handler()->show_messages();
 
-		$display  = ! $this->is_configured() ? 'style="display: none"' : '';
-		$settings = $this->generate_settings_html( $this->get_form_fields() );
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo <<<HTML
-		<div id="integration-settings" {$display}>
-			<table class="form-table">{$settings}</table>
-		</div>
-		HTML;
+		printf(
+			'<div id="integration-settings" %s>%s</div>',
+			! $this->is_configured() ? 'style="display: none"' : '',
+			sprintf(
+				'<table class="form-table">%s</table>',
+				$this->generate_settings_html( $this->get_form_fields() )
+			)
+		);
 	}
 
 	/**

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -47,7 +47,7 @@ class WC_Facebook_Loader {
 	const PLUGIN_VERSION = '3.0.2'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
-	const MINIMUM_PHP_VERSION = '7.0.0';
+	const MINIMUM_PHP_VERSION = '7.2.0';
 
 	// Minimum WordPress version required by this plugin.
 	const MINIMUM_WP_VERSION = '4.4';

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,7 +11,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.0.2
+ * Version: 3.0.3
  * Text Domain: facebook-for-woocommerce
  * Tested up to: 6.1
  * WC requires at least: 5.3
@@ -44,7 +44,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '3.0.2'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '3.0.3'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.2.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 6.1
-Stable tag: 3.0.2
+Stable tag: 3.0.3
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later
@@ -39,7 +39,7 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
-= 3.0.3 - 2022-xx-xx =
+= 3.0.3 - 2022-11-18 =
 * Fix - Remove flexible heredoc syntax that is incompatible with PHP 7.2
 
 = 3.0.2 - 2022-11-18 =

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,9 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
+= 3.0.3 - 2022-xx-xx =
+* Fix - Remove flexible heredoc syntax that is incompatible with PHP 7.2
+
 = 3.0.2 - 2022-11-18 =
 * Fix - Properly handle API exceptions
 * Fix - Set correct PHP version in plugin header

--- a/tests/Unit/ApiTest.php
+++ b/tests/Unit/ApiTest.php
@@ -15,14 +15,14 @@ class ApiTest extends WP_UnitTestCase {
 	 *
 	 * @var string
 	 */
-	private string $endpoint = Api::GRAPH_API_URL;
+	private $endpoint = Api::GRAPH_API_URL;
 
 	/**
 	 * Facebook Graph API version.
 	 *
 	 * @var string
 	 */
-	private string $version = Api::API_VERSION;
+	private $version = Api::API_VERSION;
 
 	/**
 	 * @var Api

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -223,7 +223,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 			10,
 			has_action(
 				'wp_ajax_ajax_fb_background_check_queue',
-				[ $this->integration, 'ajax_fb_background_check_queue' ],
+				[ $this->integration, 'ajax_fb_background_check_queue' ]
 			)
 		);
 	}
@@ -1057,7 +1057,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 			->method( 'create_product_item' )
 			->with(
 				'facebook-simple-product-group-item-id',
-				$facebook_product->prepare_product( WC_Facebookcommerce_Utils::get_fb_retailer_id( $facebook_product ) ),
+				$facebook_product->prepare_product( WC_Facebookcommerce_Utils::get_fb_retailer_id( $facebook_product ) )
 			)
 			->willReturn( new API\ProductCatalog\Products\Create\Response( '{"id":"facebook-simple-product-group-item-id"}' ) );
 

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -3,7 +3,6 @@ declare( strict_types=1 );
 
 require_once __DIR__ . '/../../facebook-commerce.php';
 
-use Automattic\WooCommerce\GoogleListingsAndAds\Product\ProductHelper;
 use WooCommerce\Facebook\Admin;
 use WooCommerce\Facebook\Admin\Products as AdminProducts;
 use WooCommerce\Facebook\Admin\Enhanced_Catalog_Attribute_Fields;
@@ -22,29 +21,29 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	/**
 	 * @var WC_Facebookcommerce
 	 */
-	private WC_Facebookcommerce $facebook_for_woocommerce;
+	private $facebook_for_woocommerce;
 
 	/**
 	 * @var Connection
 	 */
-	private Connection $connection_handler;
+	private $connection_handler;
 
 	/**
 	 * @var Api
 	 */
-	private Api $api;
+	private $api;
 
 	/**
 	 * @var WC_Facebookcommerce_Integration
 	 */
-	private WC_Facebookcommerce_Integration $integration;
+	private $integration;
 
 	/**
 	 * Default plugin options.
 	 *
 	 * @var array
 	 */
-	private static array $default_options = [
+	private static $default_options = [
 		WC_Facebookcommerce_Pixel::PIXEL_ID_KEY     => '0',
 		WC_Facebookcommerce_Pixel::USE_PII_KEY      => true,
 		WC_Facebookcommerce_Pixel::USE_S2S_KEY      => false,

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -3153,11 +3153,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 		$output = ob_get_clean();
 
 		$this->assertEquals(
-			<<<HTML
-			<div id="integration-settings" style="display: none">
-				<table class="form-table"></table>
-			</div>
-			HTML,
+			'<div id="integration-settings" style="display: none"><table class="form-table"></table></div>',
 			$output
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes the instances of the [flexible heredoc syntax](https://www.php.net/manual/en/migration73.new-features.php#migration73.new-features.core.heredoc) that are incompatible with PHP 7.2.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changelog entry

>

