### PR TITLE
Prevent disconnection errors when the user ID is missing.

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -334,15 +334,23 @@ class Connection {
 		}
 		try {
 			$response = facebook_for_woocommerce()->get_api()->get_user();
-			$response = facebook_for_woocommerce()->get_api()->delete_user_permission( $response->get_id(), 'manage_business_extension' );
-			$this->disconnect();
-			facebook_for_woocommerce()->get_message_handler()->add_message( __( 'Disconnection successful.', 'facebook-for-woocommerce' ) );
+			$id = $response->get_id();
+			if ( null !== $id ) {
+				$response = facebook_for_woocommerce()->get_api()->delete_user_permission( (string) $id , 'manage_business_extension' );
+				facebook_for_woocommerce()->get_message_handler()->add_message( __( 'Disconnection successful.', 'facebook-for-woocommerce' ) );
+			} else {
+				facebook_for_woocommerce()->log( 'User id not found for the disconnection procedure, connection will be reset.' );
+			}
 		} catch ( ApiException $exception ) {
-			facebook_for_woocommerce()->log( sprintf( 'An error occurred during disconnection: %s. Your Facebook connection settings have been reset.', $exception->getMessage() ) );
+			facebook_for_woocommerce()->log( sprintf( 'An error occurred during disconnection: %s.', $exception->getMessage() ) );
+		} catch ( \Exception $exception ) {
+			facebook_for_woocommerce()->log( sprintf( 'Internal error occurred during disconnection: %s.', $exception->getMessage() ) );
+		} finally {
 			$this->disconnect();
+			facebook_for_woocommerce()->log( sprintf( 'Your Facebook connection settings have been reset.' ) );
+			wp_safe_redirect( facebook_for_woocommerce()->get_settings_url() );
+			exit;
 		}
-		wp_safe_redirect( facebook_for_woocommerce()->get_settings_url() );
-		exit;
 	}
 
 

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -334,7 +334,7 @@ class Connection {
 		}
 		try {
 			$response = facebook_for_woocommerce()->get_api()->get_user();
-			$id = $response->get_id();
+			$id       = $response->get_id();
 			if ( null !== $id ) {
 				$response = facebook_for_woocommerce()->get_api()->delete_user_permission( (string) $id , 'manage_business_extension' );
 				facebook_for_woocommerce()->get_message_handler()->add_message( __( 'Disconnection successful.', 'facebook-for-woocommerce' ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Check when there is no user id. Don't perform the disconnection procedure, just reset the internal structure to allow reconnection. Add a catch clause for any other internal issues.

- [ ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Check that the disconnection procedure works.
2. Tamper with the code to force the missing ID and verify that the internal connection information is reset.
3. Check that connecting again is possible.
3. Tamper with the code to trigger a general error and verify that the handler still correctly removes internal data.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

-->
### Changelog entry

> Fix - Prevent errors in the disconnection procedure when the user id is missing.
