### PR TITLE
Add .nvmrc file (using `lts/gallium`)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/gallium

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "facebook-for-woocommerce",
-      "version": "2.6.24",
+      "version": "3.0.4",
       "license": "GPL-2.0",
       "devDependencies": {
         "@wordpress/scripts": "^14.0.0"
@@ -13886,6 +13886,22 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prettier-linter-helpers": {
@@ -30870,6 +30886,13 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
+    },
+    "prettier": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.0.tgz",
+      "integrity": "sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==",
+      "dev": true,
+      "peer": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add the `.nvmrc` file to ensure the correct version of Node.js (and npm) for working with the project.

I settled on `lts/gallum` (Node 16, npm 8) since the current `package-lock.json` file has `"lockfileVersion": 2`, which indicates npm ≥ v7. The previous LTS, `lts/fermium`, still has npm v6, and shows this warning:
```
npm WARN read-shrinkwrap This version of npm is compatible with lockfileVersion@1, but package-lock.json was generated for lockfileVersion@2. I'll try to do my best with it!
```


### Detailed test instructions:

1. Removed `node_modules`
2. Run `nvm use` to change to Node 16 and npm 8
3. Run `npm install` and check that it works (there are some deprecated warnings).



### Changelog entry

> Dev - Add .nvmrc file
