### PR TITLE
Fix/2370 fb sync status is incorrect for catalog visibility hidden

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -16,6 +16,8 @@ use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Framework\Plugin\Exception as PluginException;
 use WooCommerce\Facebook\Products;
 use WooCommerce\Facebook\Products\Feed;
+use WooCommerce\Facebook\ProductSync\ProductExcludedException;
+use WooCommerce\Facebook\ProductSync\ProductInvalidException;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -769,6 +771,18 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		$sync_mode = isset( $_POST['wc_facebook_sync_mode'] )
 			? sanitize_text_field( wp_unslash( $_POST['wc_facebook_sync_mode'] ) )
 			: Admin::SYNC_MODE_SYNC_DISABLED;
+
+		// Restore sync mode if product is marked as visible and meet all the other criteria for sync.
+		$catalog_visibility = isset( $_POST['_visibility'] ) ? wc_clean( wp_unslash( $_POST['_visibility'] ) ) : null;
+		if ( $catalog_visibility && 'hidden' !== $catalog_visibility && $product->is_visible() ) {
+			try {
+				facebook_for_woocommerce()->get_product_sync_validator( $product )->validate_but_skip_sync_field();
+				$sync_mode = Admin::SYNC_MODE_SYNC_AND_SHOW;
+			} catch ( ProductExcludedException | ProductInvalidException $e ) {
+				// do nothing.
+			}
+		}
+
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 		$sync_enabled = Admin::SYNC_MODE_SYNC_DISABLED !== $sync_mode;
 
@@ -776,6 +790,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			// force to Sync and hide
 			$sync_mode = Admin::SYNC_MODE_SYNC_AND_HIDE;
 		}
+
 		$products_to_delete_from_facebook = $this->get_removed_from_sync_products_to_delete();
 		if ( $product->is_type( 'variable' ) ) {
 			// check variations for deletion

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -16,8 +16,6 @@ use WooCommerce\Facebook\Framework\Helper;
 use WooCommerce\Facebook\Framework\Plugin\Exception as PluginException;
 use WooCommerce\Facebook\Products;
 use WooCommerce\Facebook\Products\Feed;
-use WooCommerce\Facebook\ProductSync\ProductExcludedException;
-use WooCommerce\Facebook\ProductSync\ProductInvalidException;
 
 defined( 'ABSPATH' ) || exit;
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -775,12 +775,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		// Restore sync mode if product is marked as visible and meet all the other criteria for sync.
 		$catalog_visibility = isset( $_POST['_visibility'] ) ? wc_clean( wp_unslash( $_POST['_visibility'] ) ) : null;
 		if ( $catalog_visibility && 'hidden' !== $catalog_visibility && $product->is_visible() && $sync_mode !== Admin::SYNC_MODE_SYNC_AND_HIDE ) {
-			try {
-				facebook_for_woocommerce()->get_product_sync_validator( $product )->validate_but_skip_sync_field();
-				$sync_mode = Admin::SYNC_MODE_SYNC_AND_SHOW;
-			} catch ( ProductExcludedException | ProductInvalidException $e ) {
-				// do nothing.
-			}
+			$sync_mode = facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_all_checks_except_sync_field()
+				? Admin::SYNC_MODE_SYNC_AND_SHOW : $sync_mode;
 		}
 
 		// phpcs:enable WordPress.Security.NonceVerification.Missing

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -774,7 +774,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		// Restore sync mode if product is marked as visible and meet all the other criteria for sync.
 		$catalog_visibility = isset( $_POST['_visibility'] ) ? wc_clean( wp_unslash( $_POST['_visibility'] ) ) : null;
-		if ( $catalog_visibility && 'hidden' !== $catalog_visibility && $product->is_visible() ) {
+		if ( $catalog_visibility && 'hidden' !== $catalog_visibility && $product->is_visible() && $sync_mode !== Admin::SYNC_MODE_SYNC_AND_HIDE ) {
 			try {
 				facebook_for_woocommerce()->get_product_sync_validator( $product )->validate_but_skip_sync_field();
 				$sync_mode = Admin::SYNC_MODE_SYNC_AND_SHOW;

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1142,9 +1142,15 @@ class Admin {
 	public function add_product_settings_tab_content() {
 		global $post;
 
+
 		// all products have sync enabled unless explicitly disabled
 		$sync_enabled = 'no' !== get_post_meta( $post->ID, Products::SYNC_ENABLED_META_KEY, true );
 		$is_visible   = ( $visibility = get_post_meta( $post->ID, Products::VISIBILITY_META_KEY, true ) ) ? wc_string_to_bool( $visibility ) : true;
+
+		$product = wc_get_product( $post );
+		if ( $product && !Products::product_should_be_synced( $product ) ) {
+			$sync_enabled = false;
+		}
 
 		$description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, true );
 		$price        = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_PRICE, true );

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1246,7 +1246,6 @@ class Admin {
 				?>
 			</div>
 			<?php
-			$product          = wc_get_product( $post );
 			$commerce_handler = facebook_for_woocommerce()->get_commerce_handler();
 			?>
 			<?php if ( $commerce_handler->is_connected() && $commerce_handler->is_available() ) : ?>

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1148,7 +1148,7 @@ class Admin {
 		$is_visible   = ( $visibility = get_post_meta( $post->ID, Products::VISIBILITY_META_KEY, true ) ) ? wc_string_to_bool( $visibility ) : true;
 
 		$product = wc_get_product( $post );
-		if ( $product && !Products::product_should_be_synced( $product ) ) {
+		if ( $product && !facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_all_checks() ) {
 			$sync_enabled = false;
 		}
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1148,7 +1148,7 @@ class Admin {
 		$is_visible   = ( $visibility = get_post_meta( $post->ID, Products::VISIBILITY_META_KEY, true ) ) ? wc_string_to_bool( $visibility ) : true;
 
 		$product = wc_get_product( $post );
-		if ( $product && !facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_all_checks() ) {
+		if ( $product && ! facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_all_checks() ) {
 			$sync_enabled = false;
 		}
 

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -203,6 +203,23 @@ class ProductValidator {
 	}
 
 	/**
+	 * Validate whether the product should be synced to Facebook, but skip the sync field validation.
+	 *
+	 * @return bool
+	 */
+	public function passes_all_checks_except_sync_field(): bool {
+		try {
+			$this->validate_but_skip_sync_field();
+		} catch ( ProductExcludedException $e ) {
+			return false;
+		} catch ( ProductInvalidException $e ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Check whether product sync is globally disabled.
 	 *
 	 * @throws ProductExcludedException If product should not be synced.

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -136,6 +136,22 @@ class ProductValidator {
 	}
 
 	/**
+	 * Validate whether the product should be synced to Facebook but skip the sync field check.
+	 *
+	 * @since x.x.x
+	 * @throws ProductExcludedException|ProductInvalidException If product should not be synced.
+	 */
+	public function validate_but_skip_sync_field() {
+		$this->validate_sync_enabled_globally();
+		$this->validate_product_stock_status();
+		$this->validate_product_price();
+		$this->validate_product_visibility();
+		$this->validate_product_terms();
+		$this->validate_product_description();
+		$this->validate_product_title();
+	}
+
+	/**
 	 * Validate whether the product should be synced to Facebook.
 	 *
 	 * @return bool


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When a product's catalog visibility is set to hidden, the Facebook Sync status is incorrect in the Products list admin and edit. The product is not synced in Facebook. This is because the sync_enabled variable would not take into account product_should_sync status in order to determined the dropdown value.

Making this change also meant adding provision for catalog visibility being restored. I added a helper method in the ProductValidator class to check whether is product is valid without checking the sync field, as this would still contain old meta data. 

Closes #2370.

_Replace this with a good description of your changes & reasoning._

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Create a product with catalog visibility hidden.
2. Check the status of Facebook Sync in Products in the admin panel. It shows "Do not sync."
3. Check the status of Facebook Sync in the Products Edit screen. It shows "Do not sync."
4. Set this catalog visibility back to show and check that the Facebook Sync is restored to "Sync and Show."

### Changelog entry

> Fix - Facebook Sync status is incorrect when a product has catalog visibility hidden
