### PR TITLE
Fix deprecated notices coming from ported skyverge code.

### DIFF
--- a/includes/Framework/Utilities/BackgroundJobHandler.php
+++ b/includes/Framework/Utilities/BackgroundJobHandler.php
@@ -175,7 +175,7 @@ abstract class BackgroundJobHandler extends AsyncRequest {
 			)
 		);
 
-		return ! ( $count > 0 );
+		return intval( $count ) === 0;
 	}
 
 

--- a/includes/Framework/Utilities/BackgroundJobHandler.php
+++ b/includes/Framework/Utilities/BackgroundJobHandler.php
@@ -127,20 +127,35 @@ abstract class BackgroundJobHandler extends AsyncRequest {
 			wp_die();
 		}
 
-		// WC core does 2 things here that can interfere with our nonce check:
-		// 1. WooCommerce starts a session due to our GET request to dispatch a job
-		//  However, this happens *after* we've generated a nonce without a session (in CRON context)
-		// 2. it then filters nonces for logged-out users indiscriminately without checking the nonce action; if
-		//  there is a session created (and now the server does have one), it tries to filter every.single.nonce
-		//  for logged-out users to use the customer session ID instead of 0 for user ID. We *want* to check
-		//  against a UID of 0 (since that's how the nonce was created), so we temporarily pause the
-		//  logged-out nonce hijacking before standing aside.
-		remove_filter( 'nonce_user_logged_out', array( WC()->session, 'nonce_user_logged_out' ) );
+		/**
+		 * WC core does 2 things here that can interfere with our nonce check:
+		 *
+		 * 1. WooCommerce starts a session due to our GET request to dispatch a job
+		 *  However, this happens *after* we've generated a nonce without a session (in CRON context)
+		 * 2. it then filters nonces for logged-out users indiscriminately without checking the nonce action; if
+		 *  there is a session created (and now the server does have one), it tries to filter every.single.nonce
+		 *  for logged-out users to use the customer session ID instead of 0 for user ID. We *want* to check
+		 *  against a UID of 0 (since that's how the nonce was created), so we temporarily pause the
+		 *  logged-out nonce hijacking before standing aside.
+		 *
+		 * @see \WC_Session_Handler::init() when the action is hooked
+		 * @see \WC_Session_Handler::nonce_user_logged_out() WC < 5.3 callback
+		 * @see \WC_Session_Handler::maybe_update_nonce_user_logged_out() WC >= 5.3 callback
+		 */
+		if ( Compatibility::is_wc_version_gte('5.3') ) {
+			$callback = [ WC()->session, 'maybe_update_nonce_user_logged_out' ];
+			$arguments = 2;
+		} else {
+			$callback = [ WC()->session, 'nonce_user_logged_out' ];
+			$arguments = 1;
+		}
+
+		remove_filter( 'nonce_user_logged_out', $callback );
 
 		check_ajax_referer( $this->identifier, 'nonce' );
 
 		// sorry, later nonce users! please play again
-		add_filter( 'nonce_user_logged_out', array( WC()->session, 'nonce_user_logged_out' ) );
+		add_filter( 'nonce_user_logged_out', $callback, 10, $arguments );
 
 		$this->handle();
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Integrating a deprecated notice fix from Sky Verge repository https://github.com/godaddy-wordpress/wc-plugin-framework/pull/547 into our codebase.

Closes #1966 .

### Detailed test instructions:

1. While syncing products to Facebook note that there's some deprecated notices from WC_Session_Handler::nonce_user_logged_out coming from SkyVerge's plugin framework.

### Changelog entry

> Fix - Deprecated notice fix.
