### PR TITLE
Made Advertise tab be the default when connected

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -199,7 +199,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 
 			// load admin handlers, before admin_init
 			if ( is_admin() ) {
-				$this->admin_settings = new WooCommerce\Facebook\Admin\Settings();
+				$this->admin_settings = new WooCommerce\Facebook\Admin\Settings( $this->connection_handler->is_connected() );
 			}
 		}
 	}
@@ -830,4 +830,3 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 function facebook_for_woocommerce() {
 	return \WC_Facebookcommerce::instance();
 }
-

--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -104,7 +104,9 @@ abstract class Abstract_Settings_Screen {
 			return false;
 		}
 		// assume we are on the Connection tab by default because the link under Marketing doesn't include the tab query arg
-		$tab = Helper::get_requested_value( 'tab', 'connection' );
+		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
+		$default_tab = $connection_handler->is_connected() ? 'advertise' : 'connection';
+		$tab = Helper::get_requested_value( 'tab', $default_tab );
 		return ! empty( $tab ) && $tab === $this->get_id();
 	}
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -53,17 +53,34 @@ class Settings {
 	 *
 	 * @since 2.0.0
 	 */
-	public function __construct() {
-		$this->screens = array(
-			Settings_Screens\Connection::ID   => new Settings_Screens\Connection(),
-			Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
-			Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
-			Settings_Screens\Messenger::ID    => new Settings_Screens\Messenger(),
-			Settings_Screens\Advertise::ID    => new Settings_Screens\Advertise(),
-		);
+	public function __construct( bool $is_connected ) {
+
+		$this->screens = $this->build_menu_item_array( $is_connected );
+
 		add_action( 'admin_menu', array( $this, 'add_menu_item' ) );
 		add_action( 'wp_loaded', array( $this, 'save' ) );
 		add_filter( 'parent_file', array( $this, 'set_parent_and_submenu_file' ) );
+	}
+
+	/**
+	 * Arranges the tabs. If the plugin is connected to FB, Advertise tab will be first, otherwise the Connection tab will be the first tab.
+	 *
+	 * @since 3.0.5
+	 */
+	private function build_menu_item_array( bool $is_connected ): array{
+		$advertise = [Settings_Screens\Advertise::ID    => new Settings_Screens\Advertise(),];
+		$connection = [Settings_Screens\Connection::ID   => new Settings_Screens\Connection(),];
+
+		$first = ( $is_connected ) ? $advertise : $connection ;
+		$last = ( $is_connected ) ? $connection : $advertise ;
+
+		$screens = array(
+			Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
+			Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
+			Settings_Screens\Messenger::ID    => new Settings_Screens\Messenger(),
+		);
+
+		return array(...$first, ...$screens, ...$last);
 	}
 
 	/**

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -80,7 +80,7 @@ class Settings {
 			Settings_Screens\Messenger::ID    => new Settings_Screens\Messenger(),
 		);
 
-		return array( ...$first, ...$screens, ...$last );
+		return array_merge( array_merge( $first, $screens ), $last );
 	}
 
 	/**

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -80,7 +80,7 @@ class Settings {
 			Settings_Screens\Messenger::ID    => new Settings_Screens\Messenger(),
 		);
 
-		return array(...$first, ...$screens, ...$last);
+		return array( ...$first, ...$screens, ...$last );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:
The Connection and Advertise tabs in Settings change place depending on whether the user is connected to their FB Ads Account or not. 

