### PR TITLE
Made Advertise tab be the default when connected

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -199,7 +199,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 
 			// load admin handlers, before admin_init
 			if ( is_admin() ) {
-				$this->admin_settings = new WooCommerce\Facebook\Admin\Settings();
+				$this->admin_settings = new WooCommerce\Facebook\Admin\Settings( $this->connection_handler->is_connected() );
 			}
 		}
 	}
@@ -830,4 +830,3 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 function facebook_for_woocommerce() {
 	return \WC_Facebookcommerce::instance();
 }
-

--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -105,8 +105,8 @@ abstract class Abstract_Settings_Screen {
 		}
 		// assume we are on the Connection tab by default because the link under Marketing doesn't include the tab query arg
 		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
-		$default_tab = $connection_handler->is_connected() ? 'advertise' : 'connection';
-		$tab = Helper::get_requested_value( 'tab', $default_tab );
+		$default_tab        = $connection_handler->is_connected() ? 'advertise' : 'connection';
+		$tab                = Helper::get_requested_value( 'tab', $default_tab );
 		return ! empty( $tab ) && $tab === $this->get_id();
 	}
 

--- a/includes/Admin/Abstract_Settings_Screen.php
+++ b/includes/Admin/Abstract_Settings_Screen.php
@@ -104,7 +104,9 @@ abstract class Abstract_Settings_Screen {
 			return false;
 		}
 		// assume we are on the Connection tab by default because the link under Marketing doesn't include the tab query arg
-		$tab = Helper::get_requested_value( 'tab', 'connection' );
+		$connection_handler = facebook_for_woocommerce()->get_connection_handler();
+		$default_tab = $connection_handler->is_connected() ? 'advertise' : 'connection';
+		$tab = Helper::get_requested_value( 'tab', $default_tab );
 		return ! empty( $tab ) && $tab === $this->get_id();
 	}
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -65,6 +65,7 @@ class Settings {
 	/**
 	 * Arranges the tabs. If the plugin is connected to FB, Advertise tab will be first, otherwise the Connection tab will be the first tab.
 	 *
+	 * @param bool $is_connected is Facebook connected
 	 * @since x.x.x
 	 */
 	private function build_menu_item_array( bool $is_connected ): array {

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -68,11 +68,11 @@ class Settings {
 	 * @since x.x.x
 	 */
 	private function build_menu_item_array( bool $is_connected ): array{
-		$advertise = [Settings_Screens\Advertise::ID    => new Settings_Screens\Advertise(),];
-		$connection = [Settings_Screens\Connection::ID   => new Settings_Screens\Connection(),];
+		$advertise  = [ Settings_Screens\Advertise::ID => new Settings_Screens\Advertise() ];
+		$connection = [ Settings_Screens\Connection::ID => new Settings_Screens\Connection() ];
 
-		$first = ( $is_connected ) ? $advertise : $connection ;
-		$last = ( $is_connected ) ? $connection : $advertise ;
+		$first = ( $is_connected ) ? $advertise : $connection;
+		$last  = ( $is_connected ) ? $connection : $advertise;
 
 		$screens = array(
 			Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -67,7 +67,7 @@ class Settings {
 	 *
 	 * @since x.x.x
 	 */
-	private function build_menu_item_array( bool $is_connected ): array{
+	private function build_menu_item_array( bool $is_connected ): array {
 		$advertise  = [ Settings_Screens\Advertise::ID => new Settings_Screens\Advertise() ];
 		$connection = [ Settings_Screens\Connection::ID => new Settings_Screens\Connection() ];
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -53,17 +53,34 @@ class Settings {
 	 *
 	 * @since 2.0.0
 	 */
-	public function __construct() {
-		$this->screens = array(
-			Settings_Screens\Connection::ID   => new Settings_Screens\Connection(),
-			Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
-			Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
-			Settings_Screens\Messenger::ID    => new Settings_Screens\Messenger(),
-			Settings_Screens\Advertise::ID    => new Settings_Screens\Advertise(),
-		);
+	public function __construct( bool $is_connected ) {
+
+		$this->screens = $this->build_menu_item_array( $is_connected );
+
 		add_action( 'admin_menu', array( $this, 'add_menu_item' ) );
 		add_action( 'wp_loaded', array( $this, 'save' ) );
 		add_filter( 'parent_file', array( $this, 'set_parent_and_submenu_file' ) );
+	}
+
+	/**
+	 * Arranges the tabs. If the plugin is connected to FB, Advertise tab will be first, otherwise the Connection tab will be the first tab.
+	 *
+	 * @since 3.0.5
+	 */
+	private function build_menu_item_array( bool $is_connected ): array{
+		$advertise = [Settings_Screens\Advertise::ID    => new Settings_Screens\Advertise(),];
+		$connection = [Settings_Screens\Connection::ID   => new Settings_Screens\Connection(),];
+
+		$first = ( $is_connected ) ? $advertise : $connection ;
+		$last = ( $is_connected ) ? $connection : $advertise ;
+
+		$screens = array(
+			Settings_Screens\Product_Sync::ID => new Settings_Screens\Product_Sync(),
+			Settings_Screens\Product_Sets::ID => new Settings_Screens\Product_Sets(),
+			Settings_Screens\Messenger::ID    => new Settings_Screens\Messenger(),
+		);
+
+		return array_merge( array_merge( $first, $screens ), $last );
 	}
 
 	/**

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -51,6 +51,7 @@ class Settings {
 	/**
 	 * Settings constructor.
 	 *
+	 * @param bool $is_connected is the state of the plugin connection to the Facebook Marketing API
 	 * @since 2.0.0
 	 */
 	public function __construct( bool $is_connected ) {

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -65,7 +65,7 @@ class Settings {
 	/**
 	 * Arranges the tabs. If the plugin is connected to FB, Advertise tab will be first, otherwise the Connection tab will be the first tab.
 	 *
-	 * @since 3.0.5
+	 * @since x.x.x
 	 */
 	private function build_menu_item_array( bool $is_connected ): array{
 		$advertise = [Settings_Screens\Advertise::ID    => new Settings_Screens\Advertise(),];


### PR DESCRIPTION
The https://github.com/woocommerce/facebook-for-woocommerce/pull/2421 was merged without a review. It was reverted.
This PR re-adds the code for review before the merge.

@vahidkay-meta Please fill in the required information in the PR description. I am assigning our team to the review process.
Please don't merge without a review!
If the review will find anything that requires adjusting you will be able to fix it and push on the branch created for this review.