### PR TITLE
Update meta server with new plugin version information.

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -103,6 +103,8 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	/** @var WooCommerce\Facebook\Utilities\Heartbeat */
 	public $heartbeat;
 
+	/** @var WooCommerce\Facebook\ExternalVersionUpdate */
+	private $external_version_update
 	/**
 	 * The Debug tools instance.
 	 *
@@ -168,6 +170,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 			$this->product_sets_sync_handler = new WooCommerce\Facebook\ProductSets\Sync();
 			$this->commerce_handler          = new WooCommerce\Facebook\Commerce();
 			$this->fb_categories             = new WooCommerce\Facebook\Products\FBCategories();
+			$this->external_version_update   = new WooCommerce\Facebook\ExternalVersionUpdate\Update();
 
 			if ( wp_doing_ajax() ) {
 				$this->ajax = new WooCommerce\Facebook\AJAX();

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -105,6 +105,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 
 	/** @var WooCommerce\Facebook\ExternalVersionUpdate */
 	private $external_version_update;
+
 	/**
 	 * The Debug tools instance.
 	 *

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -104,7 +104,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	public $heartbeat;
 
 	/** @var WooCommerce\Facebook\ExternalVersionUpdate */
-	private $external_version_update
+	private $external_version_update;
 	/**
 	 * The Debug tools instance.
 	 *

--- a/includes/API.php
+++ b/includes/API.php
@@ -295,6 +295,21 @@ class API extends Base {
 		return $this->perform_request( $request );
 	}
 
+	/**
+	 * Updates the messenger configuration.
+	 *
+	 * @param string $external_business_id external business ID
+	 * @param string $plugin_version messenger configuration
+	 * @return API\Response|API\FBE\Configuration\Update\Response
+	 * @throws ApiException
+	 */
+	public function update_plugin_version_configuration( string $external_business_id, string $plugin_version ): API\FBE\Configuration\Update\Response {
+		$request = new API\FBE\Configuration\Update\Request( $external_business_id );
+		$request->set_plugin_version( $plugin_version );
+		$this->set_response_handler( API\FBE\Configuration\Update\Response::class );
+		return $this->perform_request( $request );
+	}
+
 
 	/**
 	 * Uses the Catalog Batch API to update or remove items from catalog.

--- a/includes/API.php
+++ b/includes/API.php
@@ -296,7 +296,7 @@ class API extends Base {
 	}
 
 	/**
-	 * Updates the messenger configuration.
+	 * Updates the plugin version configuration.
 	 *
 	 * @param string $external_business_id external business ID
 	 * @param string $plugin_version messenger configuration

--- a/includes/API.php
+++ b/includes/API.php
@@ -301,7 +301,7 @@ class API extends Base {
 	 * @param string $external_business_id external business ID
 	 * @param string $plugin_version The plugin version.
 	 * @return API\Response|API\FBE\Configuration\Update\Response
-	 * @throws ApiException
+	 * @throws WooCommerce\Facebook\Framework\Api\Exception
 	 */
 	public function update_plugin_version_configuration( string $external_business_id, string $plugin_version ): API\FBE\Configuration\Update\Response {
 		$request = new API\FBE\Configuration\Update\Request( $external_business_id );

--- a/includes/API.php
+++ b/includes/API.php
@@ -299,7 +299,7 @@ class API extends Base {
 	 * Updates the plugin version configuration.
 	 *
 	 * @param string $external_business_id external business ID
-	 * @param string $plugin_version messenger configuration
+	 * @param string $plugin_version The plugin version.
 	 * @return API\Response|API\FBE\Configuration\Update\Response
 	 * @throws ApiException
 	 */

--- a/includes/API/FBE/Configuration/Update/Request.php
+++ b/includes/API/FBE/Configuration/Update/Request.php
@@ -53,5 +53,19 @@ class Request extends Configuration\Request {
 		);
 	}
 
+	/**
+	 * Sets the plugin version for configuration update request.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param string $plugin_version current plugin version.
+	 */
+	public function set_plugin_version( string $plugin_version ) {
+
+		$this->data['business_config'] = array(
+			'external_client_version_id' => "\"$plugin_version\"",
+		);
+	}
+
 
 }

--- a/includes/API/FBE/Configuration/Update/Request.php
+++ b/includes/API/FBE/Configuration/Update/Request.php
@@ -63,7 +63,10 @@ class Request extends Configuration\Request {
 	public function set_plugin_version( string $plugin_version ) {
 
 		$this->data['business_config'] = array(
-			'external_client_version_id' => "$plugin_version",
+			'external_client' =>
+				array(
+					'version_id' => "$plugin_version",
+				),
 		);
 	}
 

--- a/includes/API/FBE/Configuration/Update/Request.php
+++ b/includes/API/FBE/Configuration/Update/Request.php
@@ -63,7 +63,7 @@ class Request extends Configuration\Request {
 	public function set_plugin_version( string $plugin_version ) {
 
 		$this->data['business_config'] = array(
-			'external_client_version_id' => "\"$plugin_version\"",
+			'external_client_version_id' => "$plugin_version",
 		);
 	}
 

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -60,9 +60,15 @@ class Update {
 	 * @since x.x.x
 	 */
 	public function send_new_version_to_facebook_server() {
+		$plugin = facebook_for_woocommerce();
+
+		if ( ! $plugin->get_connection_handler()->is_connected() ) {
+			// If the plugin is not connected, we don't need to send the version to the Meta server.
+			return;
+		}
+
 		// Send the request to the Meta server with the latest plugin version.
 		try {
-			$plugin               = facebook_for_woocommerce();
 			$external_business_id = $plugin->get_connection_handler()->get_external_business_id();
 			$plugin->get_api()->update_plugin_version_configuration( $external_business_id, WC_Facebookcommerce_Utils::PLUGIN_VERSION );
 			update_option( self::LATEST_VERSION_SENT, WC_Facebookcommerce_Utils::PLUGIN_VERSION );

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -27,7 +27,7 @@ use WooCommerce\Facebook\Utilities\Heartbeat;
 class Update {
 
 	/** @var string Name of the option that stores the latest version that was sent to the Meta server. */
-	const LATEST_VERSION_SENT = 'wc_facebook_latest_version_sent_to_server';
+	const LATEST_VERSION_SENT = 'facebook_for_woocommerce_latest_version_sent_to_server';
 
 	/**
 	 * Update class constructor.

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -74,7 +74,7 @@ class Update {
 		try {
 			$external_business_id = $plugin->get_connection_handler()->get_external_business_id();
 			$response             = $plugin->get_api()->update_plugin_version_configuration( $external_business_id, WC_Facebookcommerce_Utils::PLUGIN_VERSION );
-			if ( ! $response->has_api_error() ) {
+			if ( $response->has_api_error() ) {
 				// If the request fails, we should retry it in the next heartbeat.
 				return;
 			}

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -44,7 +44,7 @@ class Update {
 	 * @since x.x.x
 	 */
 	public function maybe_update_external_plugin_version() {
-		$latest_version_sent = '';//get_option( self::LATEST_VERSION_SENT, '0.0.0' );
+		$latest_version_sent = get_option( self::LATEST_VERSION_SENT, '0.0.0' );
 
 		if ( WC_Facebookcommerce_Utils::PLUGIN_VERSION === $latest_version_sent ) {
 			// Up to date. Nothing to do.

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -45,6 +45,20 @@ class Update {
 	 * @return bool
 	 */
 	public function maybe_update_external_plugin_version() {
+		if ( ! $this->should_update_version() ) {
+			return false;
+		}
+
+		return $this->send_new_version_to_facebook_server();
+	}
+
+	/**
+	 * Checks if the plugin version needs to be updated.
+	 *
+	 * @since x.x.x
+	 * @return bool
+	 */
+	public function should_update_version() {
 		$latest_version_sent = get_option( self::LATEST_VERSION_SENT, '0.0.0' );
 
 		if ( WC_Facebookcommerce_Utils::PLUGIN_VERSION === $latest_version_sent ) {
@@ -58,8 +72,6 @@ class Update {
 			// If the plugin is not connected, we don't need to send the version to the Meta server.
 			return false;
 		}
-
-		return $this->send_new_version_to_facebook_server();
 	}
 
 	/**

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -44,7 +44,7 @@ class Update {
 	 * @since x.x.x
 	 */
 	public function maybe_update_external_plugin_version() {
-		$latest_version_sent = get_option( self::LATEST_VERSION_SENT, '0.0.0' );
+		$latest_version_sent = '';//get_option( self::LATEST_VERSION_SENT, '0.0.0' );
 
 		if ( WC_Facebookcommerce_Utils::PLUGIN_VERSION === $latest_version_sent ) {
 			// Up to date. Nothing to do.
@@ -73,7 +73,11 @@ class Update {
 		// Send the request to the Meta server with the latest plugin version.
 		try {
 			$external_business_id = $plugin->get_connection_handler()->get_external_business_id();
-			$plugin->get_api()->update_plugin_version_configuration( $external_business_id, WC_Facebookcommerce_Utils::PLUGIN_VERSION );
+			$response             = $plugin->get_api()->update_plugin_version_configuration( $external_business_id, WC_Facebookcommerce_Utils::PLUGIN_VERSION );
+			if ( ! $response->has_api_error() ) {
+				// If the request fails, we should retry it in the next heartbeat.
+				return;
+			}
 			update_option( self::LATEST_VERSION_SENT, WC_Facebookcommerce_Utils::PLUGIN_VERSION );
 		} catch ( Exception $e ) {
 			WC_Facebookcommerce_Utils::log( $e->getMessage() );

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -72,6 +72,8 @@ class Update {
 			// If the plugin is not connected, we don't need to send the version to the Meta server.
 			return false;
 		}
+
+		return true;
 	}
 
 	/**

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -65,6 +65,7 @@ class Update {
 	 * Sends the latest plugin version to the Meta server.
 	 *
 	 * @since x.x.x
+	 * @return bool
 	 */
 	public function send_new_version_to_facebook_server() {
 
@@ -76,13 +77,13 @@ class Update {
 			$response             = $plugin->get_api()->update_plugin_version_configuration( $external_business_id, WC_Facebookcommerce_Utils::PLUGIN_VERSION );
 			if ( $response->has_api_error() ) {
 				// If the request fails, we should retry it in the next heartbeat.
-				return;
+				return false;
 			}
-			update_option( self::LATEST_VERSION_SENT, WC_Facebookcommerce_Utils::PLUGIN_VERSION );
+			return update_option( self::LATEST_VERSION_SENT, WC_Facebookcommerce_Utils::PLUGIN_VERSION );
 		} catch ( Exception $e ) {
 			WC_Facebookcommerce_Utils::log( $e->getMessage() );
 			// If the request fails, we should retry it in the next heartbeat.
-			return;
+			return false;
 		}
 	}
 

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -51,6 +51,13 @@ class Update {
 			return;
 		}
 
+		$plugin = facebook_for_woocommerce();
+
+		if ( ! $plugin->get_connection_handler()->is_connected() ) {
+			// If the plugin is not connected, we don't need to send the version to the Meta server.
+			return;
+		}
+
 		$this->send_new_version_to_facebook_server();
 	}
 
@@ -60,12 +67,8 @@ class Update {
 	 * @since x.x.x
 	 */
 	public function send_new_version_to_facebook_server() {
-		$plugin = facebook_for_woocommerce();
 
-		if ( ! $plugin->get_connection_handler()->is_connected() ) {
-			// If the plugin is not connected, we don't need to send the version to the Meta server.
-			return;
-		}
+		$plugin = facebook_for_woocommerce();
 
 		// Send the request to the Meta server with the latest plugin version.
 		try {

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -42,23 +42,24 @@ class Update {
 	 * Check if we need to inform the Meta server of a new version.
 	 *
 	 * @since x.x.x
+	 * @return bool
 	 */
 	public function maybe_update_external_plugin_version() {
 		$latest_version_sent = get_option( self::LATEST_VERSION_SENT, '0.0.0' );
 
 		if ( WC_Facebookcommerce_Utils::PLUGIN_VERSION === $latest_version_sent ) {
 			// Up to date. Nothing to do.
-			return;
+			return false;
 		}
 
 		$plugin = facebook_for_woocommerce();
 
 		if ( ! $plugin->get_connection_handler()->is_connected() ) {
 			// If the plugin is not connected, we don't need to send the version to the Meta server.
-			return;
+			return false;
 		}
 
-		$this->send_new_version_to_facebook_server();
+		return $this->send_new_version_to_facebook_server();
 	}
 
 	/**

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
+ *
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @package FacebookCommerce
+ */
+
+namespace WooCommerce\Facebook\ExternalVersionUpdate;
+
+defined( 'ABSPATH' ) || exit;
+
+use Exception;
+use WC_Facebookcommerce_Utils;
+use WooCommerce\Facebook\Utilities\Heartbeat;
+
+/**
+ * Facebook for WooCommerce External Plugin Version Update.
+ *
+ * Whenever this plugin gets updated, we need to inform the Meta server of the new version.
+ * This is done by sending a request to the Meta server with the new version number.
+ *
+ * @since x.x.x
+ */
+class Update {
+
+	/** @var string Name of the option that stores the latest version that was sent to the Meta server. */
+	const LATEST_VERSION_SENT = 'wc_facebook_latest_version_sent_to_server';
+
+	/**
+	 * Update class constructor.
+	 *
+	 * @since x.x.x
+	 */
+	public function __construct() {
+		add_action( Heartbeat::HOURLY, array( $this, 'maybe_update_external_plugin_version' ) );
+	}
+
+	/**
+	 * Check if we need to inform the Meta server of a new version.
+	 *
+	 * @since x.x.x
+	 */
+	public function maybe_update_external_plugin_version() {
+		$latest_version_sent = get_option( self::LATEST_VERSION_SENT, '0.0.0' );
+
+		if ( WC_Facebookcommerce_Utils::PLUGIN_VERSION === $latest_version_sent ) {
+			// Up to date. Nothing to do.
+			return;
+		}
+
+		$this->send_new_version_to_facebook_server();
+	}
+
+	/**
+	 * Sends the latest plugin version to the Meta server.
+	 *
+	 * @since x.x.x
+	 */
+	public function send_new_version_to_facebook_server() {
+		// Send the request to the Meta server with the latest plugin version.
+		try {
+			$plugin               = facebook_for_woocommerce();
+			$external_business_id = $plugin->get_connection_handler()->get_external_business_id();
+			$plugin->get_api()->update_plugin_version_configuration( $external_business_id, WC_Facebookcommerce_Utils::PLUGIN_VERSION );
+			update_option( self::LATEST_VERSION_SENT, WC_Facebookcommerce_Utils::PLUGIN_VERSION );
+		} catch ( Exception $e ) {
+			WC_Facebookcommerce_Utils::log( $e->getMessage() );
+			// If the request fails, we should retry it in the next heartbeat.
+			return;
+		}
+	}
+
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As requested by Meta:

> Allow Meta to understand what version of the ‘Facebook for WooCommerce’ plugin is used by a connected WooCommerce instance

> This will allow Meta to promote new features supported by the plugin, and streamline the adoption flow for WooCommerce users.

To enable this, make the following request to send the plugin version to Meta:

```bash
CURL -X POST \   
  -F 'fbe_external_business_id=<fbe_external_business_id>' \
  -F 'business_config={...,  "external_client": {"version_id":[version string]}'\
  -F 'access_token=<access_token>'
“https://graph.facebook.com/<API_VERSION>/fbe_business/”
```

### Implementation

This PR implements the functionality requested. A new Update class subscribes to an `Hourly` heartbeat. In that heartbeat, it compares the last version that was sent to Meta to the current plugin version. In case they don't match a call to `https://graph.facebook.com/<API_VERSION>/fbe_business/` with the latest version is performed.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Set debugger at `maybe_update_external_plugin_version`.
2. Trigger the hourly action `facebook_for_woocommerce_hourly_heartbeat`.
3. Step through the code and confirm that everything works as expected. 

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer-facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

Add - Ping Meta server with the currently installed plugin version.
