### PR TITLE
Use transient flag to keep track of order placed.

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -890,19 +890,19 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			}
 
 			// use a session flag to ensure an order is tracked with any payment method, also when the order is placed through AJAX
-			$order_placed_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_order_placed_' . $order_id;
+			$order_placed_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_order_placed_' . $order_id;
 
 			// use a session flag to ensure a Purchase event is not tracked multiple times
-			$purchase_tracked_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_purchase_tracked_' . $order_id;
+			$purchase_tracked_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_purchase_tracked_' . $order_id;
 
 			// when saving the order meta data: add a flag to mark the order tracked
 			if ( 'woocommerce_checkout_update_order_meta' === current_action() ) {
-				WC()->session->set( $order_placed_session_flag, 'yes' );
+				set_transient( $order_placed_flag, 'yes', 15 * MINUTE_IN_SECONDS );
 				return;
 			}
 
 			// bail if by the time we are on the thank you page the meta has not been set or we already tracked a Purchase event
-			if ( 'yes' !== WC()->session->get( $order_placed_session_flag, 'no' ) || 'yes' === WC()->session->get( $purchase_tracked_session_flag, 'no' ) ) {
+			if ( 'yes' !== get_transient( $order_placed_flag ) || 'yes' === get_transient( $purchase_tracked_flag ) ) {
 				return;
 			}
 
@@ -957,7 +957,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$this->inject_subscribe_event( $order_id );
 
 			// mark the order as tracked
-			WC()->session->set( $purchase_tracked_session_flag, 'yes' );
+			set_transient( $purchase_tracked_flag, 'yes', 15 * MINUTE_IN_SECONDS );
+
 		}
 
 		/**
@@ -987,8 +988,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
-			$order_placed_session_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_order_placed_' . $order->get_id();
-			WC()->session->set( $order_placed_session_flag, 'yes' );
+			$order_placed_flag = '_wc_' . facebook_for_woocommerce()->get_id() . '_order_placed_' . $order->get_id();
+			set_transient( $order_placed_flag, 'yes', 15 * MINUTE_IN_SECONDS );
 
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Addresses part of #2447.

When the user clicks a FB ad on FB or Instagram on iOS (not tested on Android), they're sent to a payment app. The session object is wiped when they're returned to the shop in certain cases. This means the purchase isn't tracked. This PR saves the flag we rely on to avoid duplicate trackings as transient option instead of session variable.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1. Complete a purchase.
2. Observe the Pixel purchase event is tracked.
3. Refresh the thank you page. The inject_purchase_event method should exit, and no additional purchase events tracked.


### Additional details:

The user also raised an issue with _fbcid not being sent to FB. Because of blocked tracking, the information isn't saved in the cookies. Currently investigation alternative approach to send this information.

### Changelog entry

> Fix - CAPI purchase event not firing with orders from FB/Instagram app on iOS
