### PR TITLE
Fix - Setting a product's Facebook sync status to "Do not sync" not working.

### DIFF
--- a/assets/js/admin/products-admin.js
+++ b/assets/js/admin/products-admin.js
@@ -574,7 +574,6 @@ jQuery( document ).ready( function( $ ) {
 				if ( simpleProductSyncModeSelect.val() === 'sync_disabled' ) {
 					simpleProductSyncModeSelect.val( 'sync_and_show' ).trigger( 'change' );;
 				}
-				toggleSyncAndShowOption( true, simpleProductSyncModeSelect );
 			}
 		})
 

--- a/assets/js/admin/products-admin.js
+++ b/assets/js/admin/products-admin.js
@@ -567,6 +567,17 @@ jQuery( document ).ready( function( $ ) {
 			toggleSyncAndShowOption( ! $( this ).prop( 'checked' ), simpleProductSyncModeSelect );
 		} ).trigger( 'change' );
 
+		// Update the sync when catalog visibility changes.
+		$( 'input[name=_visibility]' ).on ( 'change', function(){
+			if ( $( this ).val() !== 'hidden' && $( this ).val() !== 'search' ) {
+
+				if ( simpleProductSyncModeSelect.val() === 'sync_disabled' ) {
+					simpleProductSyncModeSelect.val( 'sync_and_show' ).trigger( 'change' );;
+				}
+				toggleSyncAndShowOption( true, simpleProductSyncModeSelect );
+			}
+		})
+
 		const $productData = $( '#woocommerce-product-data' );
 
 		// check whether the product meets the requirements for Commerce

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -770,13 +770,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			? sanitize_text_field( wp_unslash( $_POST['wc_facebook_sync_mode'] ) )
 			: Admin::SYNC_MODE_SYNC_DISABLED;
 
-		// Restore sync mode if product is marked as visible and meet all the other criteria for sync.
-		$catalog_visibility = isset( $_POST['_visibility'] ) ? wc_clean( wp_unslash( $_POST['_visibility'] ) ) : null;
-		if ( $catalog_visibility && 'hidden' !== $catalog_visibility && $product->is_visible() && $sync_mode !== Admin::SYNC_MODE_SYNC_AND_HIDE && $sync_mode !== Admin::SYNC_MODE_SYNC_DISABLED ) {
-			$sync_mode = facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_all_checks_except_sync_field()
-				? Admin::SYNC_MODE_SYNC_AND_SHOW : $sync_mode;
-		}
-
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 		$sync_enabled = Admin::SYNC_MODE_SYNC_DISABLED !== $sync_mode;
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -772,7 +772,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		// Restore sync mode if product is marked as visible and meet all the other criteria for sync.
 		$catalog_visibility = isset( $_POST['_visibility'] ) ? wc_clean( wp_unslash( $_POST['_visibility'] ) ) : null;
-		if ( $catalog_visibility && 'hidden' !== $catalog_visibility && $product->is_visible() && $sync_mode !== Admin::SYNC_MODE_SYNC_AND_HIDE ) {
+		if ( $catalog_visibility && 'hidden' !== $catalog_visibility && $product->is_visible() && $sync_mode !== Admin::SYNC_MODE_SYNC_AND_HIDE && $sync_mode !== Admin::SYNC_MODE_SYNC_DISABLED ) {
 			$sync_mode = facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_all_checks_except_sync_field()
 				? Admin::SYNC_MODE_SYNC_AND_SHOW : $sync_mode;
 		}

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -554,6 +554,33 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	 *
 	 * @return void
 	 */
+	public function test_on_product_save_existing_simple_product_sync_disabled_updates_the_product() {
+		$product_to_update = WC_Helper_Product::create_simple_product();
+		$product_to_delete = WC_Helper_Product::create_simple_product();
+
+		$_POST['wc_facebook_sync_mode'] = Admin::SYNC_MODE_SYNC_DISABLED;
+
+		$_POST[ WC_Facebook_Product::FB_REMOVE_FROM_SYNC ] = $product_to_delete->get_id();
+
+		$product_to_update->set_stock_status( 'instock' );
+
+		add_post_meta( $product_to_update->get_id(), WC_Facebookcommerce_Integration::FB_PRODUCT_ITEM_ID, 'facebook-product-item-id' );
+		add_post_meta( $product_to_update->get_id(), Products::VISIBILITY_META_KEY, 'no' );
+
+		$this->integration->on_product_save( $product_to_update->get_id() );
+
+		$this->assertEquals( null, get_post_meta( $product_to_delete->get_id(), WC_Facebookcommerce_Integration::FB_PRODUCT_ITEM_ID, true ) );
+		$this->assertEquals( null, get_post_meta( $product_to_delete->get_id(), WC_Facebookcommerce_Integration::FB_PRODUCT_GROUP_ID, true ) );
+		$this->assertEquals( 'no', get_post_meta( $product_to_update->get_id(), Products::SYNC_ENABLED_META_KEY, true ) );
+		$this->assertEquals( 'no', get_post_meta( $product_to_update->get_id(), Products::VISIBILITY_META_KEY, true ) );
+
+	}
+
+	/**
+	 * Sunny day test with all the conditions evaluated to true and maximum conditions triggered.
+	 *
+	 * @return void
+	 */
 	public function test_on_product_save_existing_variable_product_sync_enabled_updates_the_product() {
 		$parent           = WC_Helper_Product::create_variation_product();
 		$fb_product       = new WC_Facebook_Product( $parent->get_id() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #2403, we added some code to restore visibility when a product catalog visibility is restored. This logic did not check the SYNC_DISABLED status, hence forcing the visibility back to SYNC_AND_SHOW -- preventing users from disabling sync on products. 

Closes #2441.

_Replace this with a good description of your changes & reasoning._

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:


1. Follow the steps outlined in #2441
2. Confirm that the product is removed from the catalog when "Remove from sync and delete" is chosen
3. Confirm "Do not sync" status is persisted.


### Changelog entry

> Fix - Setting a product's Facebook sync status to "Do not sync" not working.
