### PR TITLE
PHP 8.1 deprecated warnings

### DIFF
--- a/includes/Admin/Product_Sets.php
+++ b/includes/Admin/Product_Sets.php
@@ -76,8 +76,8 @@ class Product_Sets {
 	public function category_field_on_new() {
 		?>
 		<div class="form-field">
-			<?php echo wp_kses( $this->get_field_label(), $this->allowed_html ); ?>
-			<?php echo wp_kses( $this->get_field(), $this->allowed_html ); ?>
+			<?php $this->get_field_label(); ?>
+			<?php $this->get_field(); ?>
 		</div>
 		<?php
 	}
@@ -97,8 +97,8 @@ class Product_Sets {
 		<table class="form-table" role="presentation">
 			<tbody>
 				<tr class="form-field product-categories-wrap">
-					<th scope="row"><?php echo wp_kses( $this->get_field_label(), $this->allowed_html ); ?></th>
-					<td><?php echo wp_kses( $this->get_field( $term_id ), $this->allowed_html ); ?></td>
+					<th scope="row"><?php $this->get_field_label(); ?></th>
+					<td><?php $this->get_field(); ?></td>
 				</tr>
 			</tbody>
 		</table>

--- a/includes/Framework/Api/JSONResponse.php
+++ b/includes/Framework/Api/JSONResponse.php
@@ -80,7 +80,7 @@ abstract class JSONResponse implements Response, ArrayAccess {
 	 *
 	 * @return bool Whether the offset exists.
 	 */
-	public function offsetExists( $offset ) {
+	public function offsetExists( $offset ): bool {
 		return array_key_exists( $offset, $this->response_data );
 	}
 
@@ -93,7 +93,7 @@ abstract class JSONResponse implements Response, ArrayAccess {
 	 *
 	 * @return mixed The offset value.
 	 */
-	public function offsetGet( $offset ) {
+	public function offsetGet( $offset ): mixed {
 		return $this->response_data[ $offset ];
 	}
 
@@ -107,7 +107,7 @@ abstract class JSONResponse implements Response, ArrayAccess {
 	 *
 	 * @return void
 	 */
-	public function offsetSet( $offset, $value ) {
+	public function offsetSet( $offset, $value ): void {
 		$this->response_data[ $offset ] = $value;
 	}
 
@@ -120,7 +120,7 @@ abstract class JSONResponse implements Response, ArrayAccess {
 	 *
 	 * @return void
 	 */
-	public function offsetUnset( $offset ) {
+	public function offsetUnset( $offset ): void {
 		unset( $this->response_data[ $offset ] );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This fixes two sets of deprecated warnings in PHP 8.1:

1. Caused by missing method return type declarations in [`includes/Framework/Api/JSONResponse.php`](https://github.com/woocommerce/facebook-for-woocommerce/blob/develop/includes/Framework/Api/JSONResponse.php):
    ![image](https://user-images.githubusercontent.com/228780/216377858-3cac2a33-59ae-4f21-afda-5669bb7567df.png)

    👉🏻  Adding the return types resolves this issue.



2. Caused by [passing the return value of a method that doesn't return anything to `wp_kses`](https://github.com/woocommerce/facebook-for-woocommerce/blob/6ceea0a49599c7d38a7095426de6d288fbbc43c3/includes/Admin/Product_Sets.php#L76-L83):
    ![image](https://user-images.githubusercontent.com/228780/216378091-0703676e-12a9-4a25-a994-ca319fc74488.png)
    ![image](https://user-images.githubusercontent.com/228780/216378107-e2dea9b6-e2b0-467c-b41c-010498b6de79.png)

    👉🏻  Since the void methods display the HTML for the label and field directly, there's no need to sanitize or `echo` their return values.


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. With PHP 8.1 and the `develop` branch, connect a store to Facebook and visit the `Marketing > Facebook > Connection` tab (`/wp-admin/admin.php?page=wc-facebook&tab=connection`).
2. Confirm the presence of the deprecated warnings for `JSONResponse.php`.
3. Visit `Marketing > Facebook Product Sets` (`/wp-admin/edit-tags.php?taxonomy=fb_product_set&post_type=product`) and confirm the deprecated warnings near the bottom of the `Add new Facebook Product Set` form.
4. Create a Product Set, then click its Edit link.
5. Confirm the deprecated warnings in the last form label and field.
6. Switch to this PR branch, and confirm that all the deprecated warnings have been resolved.



