### PR TITLE
Remove `mixed` return type, unsupported in PHP 7.2

### DIFF
--- a/includes/Framework/Api/JSONResponse.php
+++ b/includes/Framework/Api/JSONResponse.php
@@ -93,7 +93,8 @@ abstract class JSONResponse implements Response, ArrayAccess {
 	 *
 	 * @return mixed The offset value.
 	 */
-	public function offsetGet( $offset ): mixed {
+	#[\ReturnTypeWillChange]
+	public function offsetGet( $offset ) {
 		return $this->response_data[ $offset ];
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Removes the `mixed` return type introduced in #2467, in favor of `#[\ReturnTypeWillChange]` 
Hat tip @mikkamp for catching this one

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:
You will likely need to connect a Facebook account to a WooCommerce store to test this.

1. Check that PHP 7.2 gives a fatal error on the connection tab with the `develop` branch.
   `/wp-admin/admin.php?page=wc-facebook&tab=connection`
2. Confirm that PHP 7.2 doesn't give a fatal error on that page with this PR branch.
4. Confirm that PHP 8.1 doesn't show any errors or deprecation notices with this PR branch.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

>
