### PR TITLE
Fix - New product gets "Do not sync" by default

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1146,11 +1146,7 @@ class Admin {
 		// all products have sync enabled unless explicitly disabled
 		$sync_enabled = 'no' !== get_post_meta( $post->ID, Products::SYNC_ENABLED_META_KEY, true );
 		$is_visible   = ( $visibility = get_post_meta( $post->ID, Products::VISIBILITY_META_KEY, true ) ) ? wc_string_to_bool( $visibility ) : true;
-
-		$product = wc_get_product( $post );
-		if ( $product && ! facebook_for_woocommerce()->get_product_sync_validator( $product )->passes_all_checks() ) {
-			$sync_enabled = false;
-		}
+		$product 	  = wc_get_product( $post );
 
 		$description  = get_post_meta( $post->ID, \WC_Facebookcommerce_Integration::FB_PRODUCT_DESCRIPTION, true );
 		$price        = get_post_meta( $post->ID, \WC_Facebook_Product::FB_PRODUCT_PRICE, true );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #2403, I added a default $sync_mode assignment based on sync validator checks. This is unnecessary, as we update sync mode when catalog visibility is updated (#2403).  This forces $sync_mode to default to `false` for new products. This PR reverses the changes made by #2403 and fixes

PS: This is not really testable via unit tests, as we need an e2e test to check if the select box renders with the expected correct default value for new product.

Closes #2470.

_Replace this with a good description of your changes & reasoning._

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1. Checkout this branch
2. Create a new product and click the Facebook tab. Observe that the Facebook sync mode does not default to "Do not sync"


### Changelog entry

> Fix - Default sync mode on new product