### PR TITLE
Replace is_ajax calls with wp_doing_ajax()

### DIFF
--- a/includes/Framework/Helper.php
+++ b/includes/Framework/Helper.php
@@ -406,7 +406,7 @@ class Helper {
 	 */
 	public static function trigger_error( $message, $type = E_USER_NOTICE ) {
 
-		if ( is_callable( 'is_ajax' ) && is_ajax() ) {
+		if ( is_callable( 'wp_doing_ajax' ) && wp_doing_ajax() ) {
 
 			switch ( $type ) {
 

--- a/includes/Framework/Helper.php
+++ b/includes/Framework/Helper.php
@@ -394,41 +394,4 @@ class Helper {
 		return (bool) apply_filters( 'woocommerce_is_rest_api_request', $is_rest_api_request );
 	}
 
-
-	/**
-	 * Triggers a PHP error.
-	 *
-	 * This wrapper method ensures AJAX isn't broken in the process.
-	 *
-	 * @since 4.6.0
-	 * @param string $message the error message
-	 * @param int $type Optional. The error type. Defaults to E_USER_NOTICE
-	 */
-	public static function trigger_error( $message, $type = E_USER_NOTICE ) {
-
-		if ( is_callable( 'wp_doing_ajax' ) && wp_doing_ajax() ) {
-
-			switch ( $type ) {
-
-				case E_USER_NOTICE:
-					$prefix = 'Notice: ';
-				break;
-
-				case E_USER_WARNING:
-					$prefix = 'Warning: ';
-				break;
-
-				default:
-					$prefix = '';
-			}
-
-			error_log( $prefix . $message );
-
-		} else {
-
-			trigger_error( $message, $type );
-		}
-	}
-
-
 }

--- a/includes/Framework/Lifecycle.php
+++ b/includes/Framework/Lifecycle.php
@@ -47,7 +47,7 @@ class Lifecycle {
 		add_action( 'admin_init', array( $this, 'handle_activation' ) );
 		// handle deactivation
 		add_action( 'deactivate_' . $this->get_plugin()->get_plugin_file(), array( $this, 'handle_deactivation' ) );
-		if ( is_admin() && ! is_ajax() ) {
+		if ( is_admin() && ! wp_doing_ajax() ) {
 			// initialize the plugin lifecycle
 			add_action( 'wp_loaded', array( $this, 'init' ) );
 			// add the admin notices

--- a/includes/Utilities/DebugTools.php
+++ b/includes/Utilities/DebugTools.php
@@ -15,7 +15,7 @@ class DebugTools {
 	 * @since 3.0.5
 	 */
 	public function __construct() {
-		if ( is_admin() && ! is_ajax() ) {
+		if ( is_admin() && ! wp_doing_ajax() ) {
 			add_filter( 'woocommerce_debug_tools', [ $this, 'add_debug_tool' ] );
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

is_ajax() has been deprecated since version 6.1.0.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install facebook-for-woocommerce on WP 6.1.1 install and observe that no warning notices are displayed in the backend

### Changelog entry

> Fix - Replace is_ajax calls with wp_doing_ajax()
