### PR TITLE
Fix out of stock products not deleted in FB.

### DIFF
--- a/includes/Products/Stock.php
+++ b/includes/Products/Stock.php
@@ -97,7 +97,7 @@ class Stock {
 	 */
 	private function maybe_sync_product_stock_status( \WC_Product $product ) {
 		if ( Products::product_should_be_deleted( $product ) ) {
-			facebook_for_woocommerce()->get_products_sync_handler()->delete_products( array( \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product ) ) );
+			facebook_for_woocommerce()->get_integration()->delete_fb_product( $product );
 			return;
 		}
 		facebook_for_woocommerce()->get_products_sync_handler()->create_or_update_products( array( $product->get_id() ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`facebook_for_woocommerce()->get_products_sync_handler()->delete_products()` is more suited for deleting multiple variations using background sync. This PR fixes the stock update sync by using `facebook_for_woocommerce()->get_integration()->delete_fb_product( $product )` which handles different cases.

Closes #2478.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:

1. Navigate to WooCommerce > Settings > Products > Inventory (tab) and enable "Hide out of stock items from the catalog".
2. Create a product with a stock quantity (e.g 5)
3. Purchase the available product quantity
4. Deleted the product from the store
5. Check the Facebook catalog/shop; the product should be deleted too.
6. The test can be replicated with variable products.


### Changelog entry

> Fix - out-of-stock products not deleted in Facebook catalog.
