### PR TITLE
Fix custom attribute name with special characters breaks sync.

### DIFF
--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -283,7 +283,7 @@ class Background extends BackgroundJobHandler {
 					$val
 				);
 				/** Force replacing , and : characters if those were not cleaned up by filters */
-				$attributes[] = $key . ':' . str_replace( [ ',', ':' ], ' ', $attribute_value );
+				$attributes[] = str_replace( [ ',', ':' ], ' ', $key ) . ':' . str_replace( [ ',', ':' ], ' ', $attribute_value );
 			}
 
 			$data['additional_variant_attribute'] = implode( ',', $attributes );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2063. Related to #2195.

If a disallowed character such as `:` is sent in the `additional_variant_attribute properties`, the associated variation will fail to sync, and an error will be thrown:

`The additional_variant_attribute information under  is invalid.`

This was fixed for invalid characters in the attribute _values_ in #2195, but was [then reported to also cause issues in the attribute _names_](https://github.com/woocommerce/facebook-for-woocommerce/issues/2063#issuecomment-1286020498).

This PR simply includes the attribute names in the final check for invalid characters that break the sync (`:` and `,`) .

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:
__Example before change with errors__
![image](https://user-images.githubusercontent.com/228780/220161263-18bf66cf-f452-4a28-a986-02ccd176e292.png)

__Example after change without errors__
![image](https://user-images.githubusercontent.com/228780/220161274-ad704f0d-6731-4eef-bd48-df7693697456.png)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. __Enable debug mode__ in Facebook > Connection.
2. With a Variable product, add or change an attribute name to include a colon `:` or a comma `,`.
3. Try to update the product, and then check the Facebook log WooCommerce > Status > Logs and see that warning is returned.
4. (Confirm warning / sync error with `develop` branch).


