### PR TITLE
Add a check to ensure WC()->session is not null.

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -744,8 +744,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function set_last_product_added_to_cart_upon_redirect( $redirect, $product = null ) {
 
-			// Bail if the session variable has been set.
-			if ( isset( WC()->session ) && WC()->session->get( 'facebook_for_woocommerce_last_product_added_to_cart', 0 ) > 0 ) {
+			// Bail if the session variable has been set or WC()->session is null.
+			if ( ! isset( WC()->session ) || WC()->session->get( 'facebook_for_woocommerce_last_product_added_to_cart', 0 ) > 0 ) {
 				return $redirect;
 			}
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -745,7 +745,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		public function set_last_product_added_to_cart_upon_redirect( $redirect, $product = null ) {
 
 			// Bail if the session variable has been set.
-			if ( WC()->session->get( 'facebook_for_woocommerce_last_product_added_to_cart', 0 ) > 0 ) {
+			if ( isset( WC()->session ) && WC()->session->get( 'facebook_for_woocommerce_last_product_added_to_cart', 0 ) > 0 ) {
 				return $redirect;
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As described by @ibndawood:

> The plugin Woo_Variation_Swatches_Product_Page uses the woocommerce_add_to_cart_redirect filter while enqueuing its scripts.
> 
> Facebook for WooCommerce plugin hooks the method set_last_product_added_to_cart_upon_redirect of the WC_Facebookcommerce_EventsTracker the same filter woocommerce_add_to_cart_redirect. The set_last_product_added_to_cart_upon_redirect uses WC()->session.
> 
> The SiteGround Optimizer plugin uses REST API to generate the optimized assets. WC()->session is not available when accessed via REST. So we'll have to check for the WC()->session availability before proceeding with using the object

This PR adds the aforementioned check.

Closes #2456.


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. You will need the [Siteground Optimizer](https://wordpress.org/plugins/sg-cachepress/) and the [Variation Swatches for WooCommerce
](https://wordpress.org/plugins/woo-variation-swatches/) to reproduce as explained here: https://github.com/woocommerce/facebook-for-woocommerce/issues/2456#issuecomment-1401478601
2. Checkout this branch, and you should no longer see a fatal crash when navigating to the shop.


### Changelog entry

> Fix -2456: WC()->session causing fatal error when the `woocommerce_add_to_cart_redirect` filter is called via REST API
