### PR TITLE
Fix - View Content events triggering PHP server notices on elementor sites

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -182,8 +182,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			$products = array_values(
 				array_map(
-					function( $item ) {
-						return wc_get_product( $item->ID );
+					function( $post ) {
+						return wc_get_product( $post );
 					},
 					$wp_query->posts
 				)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Elementor Pro's product-archive template seems to modify the $wp_query global variable. We expect the `posts` property to be an array of WP_Post objects, but this instead returned as an array of post ids causing the `View Content events triggering PHP server notices` on elementor sites.

This PR fixes the issue by passing the index value to `wc_get_product` which can handle both post ids and objects internally.


Closes #2190.


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

 

1. Make sure you have elementor core &  pro
2. Create a new template of the type product archive ( The preview is enough to reproduce).
![Screenshot 2023-03-17 at 15 49 01](https://user-images.githubusercontent.com/4209011/225924469-d9ef30cf-a4b6-4203-b08c-6420da8fc707.jpg)

3. Click on the preview link and then settings, and configure to only display a given term;
![Screenshot 2023-03-17 at 15 53 55](https://user-images.githubusercontent.com/4209011/225924903-4ff30d96-fe28-4672-b734-81cce1204068.jpg)

4. Apply and preview, then preview. You should see no php warning notices


### Additional details:


### Changelog entry

> Fix - viewContent events triggering PHP server notices on elementor sites
