### PR TITLE
Display Facebook tab and sync settings for external products.

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1125,7 +1125,7 @@ class Admin {
 		$tabs['fb_commerce_tab'] = array(
 			'label'  => __( 'Facebook', 'facebook-for-woocommerce' ),
 			'target' => 'facebook_options',
-			'class'  => array( 'show_if_simple', 'show_if_variable' ),
+			'class'  => array( 'show_if_simple', 'show_if_variable', 'show_if_external' ),
 		);
 
 		return $tabs;
@@ -1162,7 +1162,7 @@ class Admin {
 		// 'id' attribute needs to match the 'target' parameter set above
 		?>
 		<div id='facebook_options' class='panel woocommerce_options_panel'>
-			<div class='options_group show_if_simple'>
+			<div class='options_group hide_if_variable'>
 				<?php
 
 				woocommerce_wp_select(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

External/Affiliate products are syncing to Facebook. However, the Facebook product data tab isn't available on this product type, making it confusing if external/affiliate products are supported.

After discussions, we agreed that this tab should be displayed for external products since they're synced. This PR enables the Facebook tab and sync settings for external products.

Closes #2352.


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:

1. Create an External/Affiliate product
2. Notice it's synced to Facebook like other products
3. Check product tabs, and you should see the "Facebook" tab for controlling Facebook data.


### Additional details:

This PR only covers external products. 

### Changelog entry

> Fix - Display the Facebook tab and sync settings for external products.
