### PR TITLE
Fix selected categories not showing on Product Sets edit page.

### DIFF
--- a/includes/Admin/Product_Sets.php
+++ b/includes/Admin/Product_Sets.php
@@ -98,7 +98,7 @@ class Product_Sets {
 			<tbody>
 				<tr class="form-field product-categories-wrap">
 					<th scope="row"><?php $this->get_field_label(); ?></th>
-					<td><?php $this->get_field(); ?></td>
+					<td><?php $this->get_field( $term_id ); ?></td>
 				</tr>
 			</tbody>
 		</table>
@@ -164,7 +164,7 @@ class Product_Sets {
 			<?php $selected = ( is_array( $saved_items ) && in_array( $product_cat->term_id, $saved_items, true ) ) ? ' selected="selected"' : ''; ?>
 			<option value="<?php echo esc_attr( $product_cat->term_id ); ?>" <?php echo esc_attr( $selected ); ?>><?php echo esc_attr( $product_cat->name ); ?></option>
 		<?php endforeach; ?>
-		<select>
+		</select>
 		<p class="description"><?php echo esc_html__( 'Map Facebook Product Set to WC Product Categories', 'facebook-for-woocommerce' ); ?>.</p>
 		<?php
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

get_field() needs to pass the term id on the edit screen. This was mistakenly removed in a previous refactor.

Closes #2513.

_Replace this with a good description of your changes & reasoning._

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:


1. The steps stated in #2513 should results in the selected categories showing as expected


### Changelog entry

> Fix - Selected categories not showing on Product Sets edit page.
