### PR TITLE
Fix - Fatal error when facebook_config option is empty.

### DIFF
--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -657,14 +657,11 @@ class WC_Facebookcommerce_Pixel {
 		 * Get PixelID related settings.
 		 */
 		public static function get_options() {
-			return get_option(
-				self::SETTINGS_KEY,
-				array(
-					self::PIXEL_ID_KEY     => '0',
-					self::USE_PII_KEY      => 0,
-					self::USE_S2S_KEY      => false,
-					self::ACCESS_TOKEN_KEY => '',
-				)
+			return get_option( self::SETTINGS_KEY ) ?: array(
+				self::PIXEL_ID_KEY     => '0',
+				self::USE_PII_KEY      => 0,
+				self::USE_S2S_KEY      => false,
+				self::ACCESS_TOKEN_KEY => '',
 			);
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We received a report of a fatal error in the Pixel Event class. After investigation, I noticed that if the `facebook_config` option is an empty string, the value returned by get_options would be an empty string, causing the exception: `error message: Uncaught TypeError: Cannot access offset of type string on string`. 

This assumes that `facebook_config` will always contain a serialized object, and the error is, in fact, caused by the `facebook_config` option being empty. 

Closes #2516.


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.




### Detailed test instructions:

1. log in as an admin, and navigate to wp-admin/options.php then delete the content of facebook_config.
2. navigate to any admin page, and you should receive the fatal error.
3. Switch to this branch, and the fatal should be gone.

### Changelog entry

> Fix - Fatal error when facebook_config option is empty.
