### PR TITLE
Bump Marketing API version from v16.0

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -33,7 +33,7 @@ class API extends Base {
 
 	public const GRAPH_API_URL = 'https://graph.facebook.com/';
 
-	public const API_VERSION = 'v14.0';
+	public const API_VERSION = 'v16.0';
 
 	/** @var string URI used for the request */
 	protected $request_uri = self::GRAPH_API_URL . self::API_VERSION;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update Facebook Marketing API to v16.0

There should be no changes in the endpoints that we use, so the application should behave as it used to without any additional changes.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.



### Detailed test instructions:
1. Use https://github.com/woocommerce/facebook-for-woocommerce/wiki/Smoke-tests for testing instructions
Make sure that logging is enabled in the plugin. After the tests, inspect the logs for errors.
The use of v16 API will be clearly visible in the endpoint URL:

![Screenshot 2023-04-12 at 10 18 40](https://user-images.githubusercontent.com/4209011/231396627-5f3281d3-165a-4c35-83d6-75c3eae467c1.jpg)


### Additional information:

I created a related PR to update the connect.woocommerce.com bridge. This will need to be reviewed to ensure that the connection flow also works:

https://github.com/Automattic/connect.woocommerce.com/pull/164#issue-1664053564

### Changelog entry

> Tweak - Bump Marketing API version from v16.0
