### PR TITLE
Register delete action hook outside of is_admin check.

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -303,11 +303,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 					[ $this, 'on_quick_and_bulk_edit_save' ]
 				);
 
-				add_action( 'before_delete_post', [ $this, 'on_product_delete' ] );
-
-				// Ensure product is deleted from FB when moved to trash.
-				add_action( 'wp_trash_post', [ $this, 'on_product_delete' ] );
-
 				add_action( 'add_meta_boxes', 'WooCommerce\Facebook\Admin\Product_Sync_Meta_Box::register', 10, 1 );
 
 				add_action(
@@ -365,6 +360,11 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			10,
 			3
 		);
+
+		add_action( 'before_delete_post', [ $this, 'on_product_delete' ] );
+
+		// Ensure product is deleted from FB when moved to trash.
+		add_action( 'wp_trash_post', [ $this, 'on_product_delete' ] );
 
 		add_action( 'untrashed_post', [ $this, 'fb_restore_untrashed_variable_product' ] );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When deleting a WooCommerce product via the rest API it remains in Facebook's catalogue.  This is because the delete hook was only registered in the admin context. This PR moves these hooks outside the is_admin check.


Closes #2526 .

_Replace this with a good description of your changes & reasoning._

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1. Delete any product using any API framework with DELETE /wp-json/wc/v3/products/<id>
2. The product should be deleted in the FB catalog as well.

### Changelog entry

> Fix - Delete product in the Facebook catalog when products are deleted via WC Rest API.
