### PR TITLE
Remove the prefix from the retailer ID for variation deletion

### DIFF
--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -312,10 +312,11 @@ class Background extends BackgroundJobHandler {
 	/**
 	 * Processes a DELETE sync request for the given product.
 	 *
-	 * @param string $retailer_id Product retailer ID.
+	 * @param string $prefixed_retailer_id Product retailer ID.
 	 */
-	private function process_item_delete( $retailer_id ) {
-		$request = [
+	private function process_item_delete( $prefixed_retailer_id ) {
+		$retailer_id = str_replace( Sync::PRODUCT_INDEX_PREFIX, '', $prefixed_retailer_id );
+		$request     = [
 			'data'   => [ 'id' => $retailer_id ],
 			'method' => Sync::ACTION_DELETE,
 		];
@@ -326,9 +327,9 @@ class Background extends BackgroundJobHandler {
 		 * @since 2.0.0
 		 *
 		 * @param array $request request data
-		 * @param string $retailer product retailer ID
+		 * @param string $retailer prefixed product retailer ID
 		 */
-		return apply_filters( 'wc_facebook_sync_background_item_delete_request', $request, $retailer_id );
+		return apply_filters( 'wc_facebook_sync_background_item_delete_request', $request, $prefixed_retailer_id );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2549 and #2550.

This PR adds functionality to remove the ID prefix `p-` in the `process_item_delete` method to match the same removal already present in the [`process_item_update` method](https://github.com/woocommerce/facebook-for-woocommerce/blob/2711806c7719d34e0b65c868ac979d2ff9a86213/includes/Products/Sync/Background.php#L177-L178). (Ref p1685890999903499-slack-CK365S85V) This ensures that product variation are correctly deleted when necessary (deleted, set to not sync, out of stock, etc).

The original, prefixed `$retailer_id` is still passed to the subsequent `wc_facebook_sync_background_item_delete_request` filter.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:
(Note: enable "Debug mode" for the Facebook for WooCommerce extension to review the logs of the requests, and ensure that variation "DELETE" requests are no longer sent with a prefixed ID (i.e., they don't being with `p-`).

(From #2550):
1. Create a variable product (2 variants are okay) and ensure it's synced to Facebook
1. Edit one of the variations and change the Facebook Sync Status from "Sync and show in catalog" to "Do not Sync"
1. On the ensuing prompt, click "Remove from sync and delete" and update the variable product
1. Confirm the Facebook sync widget says Sync disabled in product field
1. Check the Facebook catalog and confirm the product variant has been deleted.

(From #2549):
1. Enabled Hide out of stock items from the catalog in WooCommerce > Settings > Products > Inventory (tab)
1. Create a variable product (2 variants are okay)
1. Assign stock quantity to the variants (or to 1 variant)  and ensure they're synced to Facebook
2. Buy the whole quantity of a variant.
3. Confirm that the "Facebook product sync" widget returns Product must be in stock.
4. Check the Facebook catalog and confirm that the product is deleted.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Product variants weren't deleted correctly from the Facebook catalog in some instances.