### PR TITLE
Remove wc-enhanced-select to avoid conflict with woo core behaviour.

### DIFF
--- a/assets/js/admin/google-product-category-fields.js
+++ b/assets/js/admin/google-product-category-fields.js
@@ -218,7 +218,7 @@ jQuery( document ).ready( ( $ ) => {
 
 			var $container = $( '#wc-facebook-google-product-category-fields' );
 			var $otherSelects = $container.find( '.wc-facebook-google-product-category-select' );
-			var $select = $( '<select class="wc-enhanced-select wc-facebook-google-product-category-select"></select>' );
+			var $select = $( '<select class="wc-facebook-google-product-category-select"></select>' );
 
 			$otherSelects.addClass( 'locked' );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

After assigning a Google product category taxonomy to a product on the individual product level, there's no way to remove the taxonomy when a site has no attribute. This is because select2 isn't initialised with allowClear by Woo core. 

In this PR, we remove the wc-enhanced-select class to keep out select field from inheriting WC core behaviour.


Closes #2554.

_Replace this with a good description of your changes & reasoning._

- [ x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1.  Using WC 7.7.2, delete all your attributes
2. Edit/Add products
3. Click the Facebook tab and assign a Google Category. e.g. Apparel & Accessories > Clothing Accessories > Hats
Saves changes by updating the product.
4. Return to the Facebook tab and notice you can't remove the Google category. The "x" option for removing the category isn't there.
5. Checkout this branch and build your javascript assets `npm run build:assets`
6. Notice that The "x" option for removing the category is present and works as expected.


### Changelog entry

> Fix - Remove assigned Google product category at individual product level.
