### PR TITLE
Fix for PHP Warning caused by array_filter() call.

### DIFF
--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -196,7 +196,7 @@ class AJAX {
 						$has_excluded_terms = ! empty( $product_cats ) && array_intersect( $product_cats, $integration->get_excluded_product_category_ids() );
 
 						// the form post can send an array with empty items, so filter them out
-						$product_tags = array_filter( $product_tags, null ); // $callback = null is the default. If no callback is supplied, all empty entries of array will be removed. 
+						$product_tags = array_filter( $product_tags ); // $callback = null is the default. If no callback is supplied, all empty entries of array will be removed.
 
 						// try next with tags, but WordPress only gives us tag names
 						if ( ! $has_excluded_terms && ! empty( $product_tags ) ) {

--- a/includes/AJAX.php
+++ b/includes/AJAX.php
@@ -196,7 +196,7 @@ class AJAX {
 						$has_excluded_terms = ! empty( $product_cats ) && array_intersect( $product_cats, $integration->get_excluded_product_category_ids() );
 
 						// the form post can send an array with empty items, so filter them out
-						$product_tags = array_filter( $product_tags ); // $callback = null is the default. If no callback is supplied, all empty entries of array will be removed.
+						$product_tags = array_filter( $product_tags, 'strlen' ); // $callback = null is the default. If no callback is supplied, all empty entries of array will be removed.
 
 						// try next with tags, but WordPress only gives us tag names
 						if ( ! $has_excluded_terms && ! empty( $product_tags ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Explicitly passing `null` as the array_filter param turns the value assigned $product_tags to `null` when no tags is sent. This also results in the PHP warning notice:

`PHP Warning array_filter() expects parameter 2 to be a valid callback, no array or string given in /public_html/wp-content/plugins/facebook-for-woocommerce/includes/AJAX.php on line 199`

The goal is to remove empty values from `$product_tags` array, and this can be achieved with `array_filter( $product_tags )` alone or passing `strlen` as callback. Also, doing this does not change the  `$product_tags` value data type.

fixes #2546 .


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

1. Using PHP 7.4, WC 7.7.2, and WP 6.2.2. Enable WP DEBUG and create and/or save a product with no tags added. Notice the PHP Warning above in your logs.
2. Check out this branch, and there should be no PHP Warning notices.


### Additional details:
In the case reported by the user, the PHP warning error prevents them from saving or creating new products. I didn't observe this. Although I could reproduce the PHP warning, I could save the product successfully. I will suggest to the user this fix to see if this fixes their issue.

### Changelog entry

> Fix - PHP Warning caused by array_filter() call.
