### PR TITLE
Check if $response_body is empty.

### DIFF
--- a/includes/Events/AAMSettings.php
+++ b/includes/Events/AAMSettings.php
@@ -69,15 +69,20 @@ class AAMSettings {
 	public static function build_from_pixel_id( $pixel_id ) {
 		$url      = self::get_url( $pixel_id );
 		$response = wp_remote_get( $url );
+
 		if ( is_wp_error( $response ) ) {
 			return null;
-		} else {
-			$response_body = json_decode( wp_remote_retrieve_body( $response ), true );
-			if ( ! array_key_exists( 'errorMessage', $response_body ) ) {
-				$response_body['matchingConfig']['pixelId'] = $pixel_id;
-				return new AAMSettings( $response_body['matchingConfig'] );
-			}
 		}
+
+		$response_body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( ! is_array( $response_body ) || array_key_exists( 'errorMessage', $response_body ) || ! isset( $response_body['matchingConfig'] ) ) {
+			return null;
+		}
+
+		$response_body['matchingConfig']['pixelId'] = $pixel_id;
+		return new AAMSettings( $response_body['matchingConfig'] );
+
 		return null;
 	}
 

--- a/includes/Events/AAMSettings.php
+++ b/includes/Events/AAMSettings.php
@@ -82,8 +82,6 @@ class AAMSettings {
 
 		$response_body['matchingConfig']['pixelId'] = $pixel_id;
 		return new AAMSettings( $response_body['matchingConfig'] );
-
-		return null;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We received 2 reports for fatal errors this morning:

https://wordpress.org/support/topic/plugin-fatal-error-site-inaccessible/
https://wordpress.org/support/topic/fatal-error-4468/

As explained by @evscoding on the forum post:
https://wordpress.org/support/topic/plugin-fatal-error-site-inaccessible/#post-16814771

> it seems that this function in /facebook-for-woocommerce/includes/Events/AAMSettings.php:69 does not take into account that $response might not be a is_wp_error() but can be still empty. So “array_key_exists()” check fails cause there is no array there in the first place.

This PR adds in more defensive checks to avoid fatal error.


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changelog entry

> Fix - Fatal error when Facebook.net returns an empty response.
