### PR TITLE
Adds priority to enhanced catalog attributes and display them as per their priority

### DIFF
--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -90,10 +90,10 @@ class Enhanced_Catalog_Attribute_Fields {
 		 */
 		$priorities = array(
 			'product_length' => 140,
-			'product_width' => 130,
+			'product_width'  => 130,
 			'product_height' => 120,
-			'product_depth' => 110,
-			'default' => 100,
+			'product_depth'  => 110,
+			'default'        => 100,
 		);
 
 		foreach ( $recommended_attributes as $key => &$attribute ) {

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -88,9 +88,9 @@ class Enhanced_Catalog_Attribute_Fields {
 		/**
 		 * Attributes should be ordered by priority in this order: Length, Width, Height, Depth, Other measurement attributes, others.
 		 */
-		foreach( $recommended_attributes as $key => $attribute ) {
+		foreach ( $recommended_attributes as $key => $attribute ) {
 			if ( 'measurement' === $attribute['type'] ) {
-				switch( $attribute['key'] ) {
+				switch ( $attribute['key'] ) {
 					case 'product_length':
 						$attr_priority = 140;
 						break;
@@ -106,12 +106,12 @@ class Enhanced_Catalog_Attribute_Fields {
 					default:
 						$attr_priority = 100;
 				}
-				$recommended_attributes[ $key ][ 'priority' ] = $attr_priority;
+				$recommended_attributes[ $key ]['priority'] = $attr_priority;
 			} else {
-				$recommended_attributes[ $key ][ 'priority' ] = 5;
+				$recommended_attributes[ $key ]['priority'] = 5;
 			}
-			
-			$priority[ $key ] = $recommended_attributes[ $key ][ 'priority' ];
+
+			$priority[ $key ] = $recommended_attributes[ $key ]['priority'];
 		}
 
 		array_multisort( $priority, SORT_DESC, $recommended_attributes );

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -96,15 +96,16 @@ class Enhanced_Catalog_Attribute_Fields {
 			'default'        => 100,
 		);
 
-		foreach ( $recommended_attributes as $key => &$attribute ) {
-			$attribute['priority'] = 5; // Assign 5 initially to each attribute
+		foreach ( $recommended_attributes as $key => $attribute ) {
+			$recommended_attributes[ $key ]['priority'] = 5; // Assign 5 initially to each attribute
 			if ( 'measurement' === $attribute['type'] ) {
-				$attribute['priority'] = isset( $priorities[ $attribute['key'] ] ) ? $priorities[ $attribute['key'] ] : $priorities['default'];
+				$recommended_attributes[ $key ]['priority'] = isset( $priorities[ $attribute['key'] ] ) ? $priorities[ $attribute['key'] ] : $priorities['default'];
 			}
-			$priority[ $key ] = $attribute['priority'];
+			$priority[ $key ] = $recommended_attributes[ $key ]['priority'];
 		}
 
 		array_multisort( $priority, SORT_DESC, $recommended_attributes );
+
 		foreach ( $recommended_attributes as $attribute ) {
 			$this->render_attribute( $attribute );
 		}

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -85,6 +85,9 @@ class Enhanced_Catalog_Attribute_Fields {
 			);
 		}
 
+		/**
+		 * Attributes should be ordered by priority in this order: Length, Width, Height, Depth, Other measurement attributes, others.
+		 */
 		foreach( $recommended_attributes as $key => $attribute ) {
 			if ( 'measurement' === $attribute['type'] ) {
 				switch( $attribute['key'] ) {

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -85,6 +85,14 @@ class Enhanced_Catalog_Attribute_Fields {
 			);
 		}
 
+		foreach( $recommended_attributes as $key => $attribute ) {
+			if ( 'measurement' === $attribute['type'] ) {
+				$recommended_attributes[ $key ][ 'priority' ] = 10;
+			} else {
+				$recommended_attributes[ $key ][ 'priority' ] = 5;
+			}
+		}
+
 		foreach ( $recommended_attributes as $attribute ) {
 			$this->render_attribute( $attribute );
 		}

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -87,7 +87,23 @@ class Enhanced_Catalog_Attribute_Fields {
 
 		foreach( $recommended_attributes as $key => $attribute ) {
 			if ( 'measurement' === $attribute['type'] ) {
-				$recommended_attributes[ $key ][ 'priority' ] = 10;
+				switch( $attribute['key'] ) {
+					case 'product_length':
+						$attr_priority = 140;
+						break;
+					case 'product_width':
+						$attr_priority = 130;
+						break;
+					case 'product_height':
+						$attr_priority = 120;
+						break;
+					case 'product_depth':
+						$attr_priority = 110;
+						break;
+					default:
+						$attr_priority = 100;
+				}
+				$recommended_attributes[ $key ][ 'priority' ] = $attr_priority;
 			} else {
 				$recommended_attributes[ $key ][ 'priority' ] = 5;
 			}

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -91,7 +91,11 @@ class Enhanced_Catalog_Attribute_Fields {
 			} else {
 				$recommended_attributes[ $key ][ 'priority' ] = 5;
 			}
+			
+			$priority[ $key ] = $recommended_attributes[ $key ][ 'priority' ];
 		}
+
+		array_multisort( $priority, SORT_DESC, $recommended_attributes );
 
 		foreach ( $recommended_attributes as $attribute ) {
 			$this->render_attribute( $attribute );

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -88,34 +88,23 @@ class Enhanced_Catalog_Attribute_Fields {
 		/**
 		 * Attributes should be ordered by priority in this order: Length, Width, Height, Depth, Other measurement attributes, others.
 		 */
-		foreach ( $recommended_attributes as $key => $attribute ) {
-			if ( 'measurement' === $attribute['type'] ) {
-				switch ( $attribute['key'] ) {
-					case 'product_length':
-						$attr_priority = 140;
-						break;
-					case 'product_width':
-						$attr_priority = 130;
-						break;
-					case 'product_height':
-						$attr_priority = 120;
-						break;
-					case 'product_depth':
-						$attr_priority = 110;
-						break;
-					default:
-						$attr_priority = 100;
-				}
-				$recommended_attributes[ $key ]['priority'] = $attr_priority;
-			} else {
-				$recommended_attributes[ $key ]['priority'] = 5;
-			}
+		$priorities = array(
+			'product_length' => 140,
+			'product_width' => 130,
+			'product_height' => 120,
+			'product_depth' => 110,
+			'default' => 100,
+		);
 
-			$priority[ $key ] = $recommended_attributes[ $key ]['priority'];
+		foreach ( $recommended_attributes as $key => &$attribute ) {
+			$attribute['priority'] = 5; // Assign 5 initially to each attribute
+			if ( 'measurement' === $attribute['type'] ) {
+				$attribute['priority'] = isset( $priorities[ $attribute['key'] ] ) ? $priorities[ $attribute['key'] ] : $priorities['default'];
+			}
+			$priority[ $key ] = $attribute['priority'];
 		}
 
 		array_multisort( $priority, SORT_DESC, $recommended_attributes );
-
 		foreach ( $recommended_attributes as $attribute ) {
 			$this->render_attribute( $attribute );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

The enhanced attributes in the product edit are not assigned a priority. This results in related attributes appearing randomly instead of together, as shown in the screenshot below.

![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/179533/da87da95-a692-4a0b-8f5c-70d5cc57f327)

It is expected that the product dimensions such as length, width, height, and depth should appear together. This PR loops through recommended attributes and assigns a `priority` index. We'll then sort the recommended attributes based on the `priority`.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

After this PR:

![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/179533/d0dc13c5-0c01-43c0-bc72-b836a5f9209b)



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install, activate, and connect Facebook for WooCommerce.
2. Navigate to `Products > All Products` and click on `Edit` to open the product editor.
3. In the `Product data` metabox, choose the `Facebook` tab.
4. For `Google Product Category` field, choose a category that has measurements as attributes. A list of all  category and their respective attributes can be found here: https://github.com/woocommerce/facebook-for-woocommerce/blob/develop/bin/fb_google_category_to_attribute_mapping.json
5. Verify that the category specific fields are in order: Length, Width, Height, Depth, other measurement attributes and others. Please note that not all measure fields are available for all attributes. The order should be for whatever attributes are available.

### Additional details:

Related forum issue: https://wordpress.org/support/topic/ui-issues-2/

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Priority to enhanced catalog attributes and display as per priority.
