### PR TITLE
Deletes the product from facebook once it is switched to draft.

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -368,13 +368,8 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		add_action( 'untrashed_post', [ $this, 'fb_restore_untrashed_variable_product' ] );
 
-		// Ensure product is deleted from FB when moved to draft.
-		add_action(
-			'transition_post_status',
-			array( $this, 'delete_draft_product' ),
-			10,
-			3
-		);
+		// Ensure product is deleted from FB when status is changed to draft.
+		add_action( 'publish_to_draft', [ $this, 'on_product_delete' ] );
 
 		// Product Set hooks.
 		add_action( 'fb_wc_product_set_sync', [ $this, 'create_or_update_product_set_item' ], 99, 2 );
@@ -933,25 +928,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		// clear out both item and group IDs
 		delete_post_meta( $product_id, self::FB_PRODUCT_ITEM_ID );
 		delete_post_meta( $product_id, self::FB_PRODUCT_GROUP_ID );
-	}
-
-	/**
-	 * Deletes a product from Facebook when status is changed to draft.
-	 *
-	 * @param string   $new_status
-	 * @param string   $old_status
-	 * @param \WP_post $post
-	 */
-	public function delete_draft_product( $new_status, $old_status, $post ) {
-
-		if ( ! $post ) {
-			return;
-		}
-
-		if ( $old_status === 'publish' && $new_status === 'draft' ) {
-			$this->on_product_delete ( $post->ID );
-		}
-
 	}
 
 	/**

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -368,6 +368,14 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		add_action( 'untrashed_post', [ $this, 'fb_restore_untrashed_variable_product' ] );
 
+		// Ensure product is deleted from FB when moved to draft.
+		add_action(
+			'transition_post_status',
+			array( $this, 'delete_draft_product' ),
+			10,
+			3
+		);
+
 		// Product Set hooks.
 		add_action( 'fb_wc_product_set_sync', [ $this, 'create_or_update_product_set_item' ], 99, 2 );
 		add_action( 'fb_wc_product_set_delete', [ $this, 'delete_product_set_item' ], 99 );
@@ -925,6 +933,24 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		// clear out both item and group IDs
 		delete_post_meta( $product_id, self::FB_PRODUCT_ITEM_ID );
 		delete_post_meta( $product_id, self::FB_PRODUCT_GROUP_ID );
+	}
+
+	/**
+	 * Deletes a product from Facebook when status is changed to draft.
+	 *
+	 * @param int $product_id product ID
+	 */
+	public function delete_draft_product( $new_status, $old_status, $post ) {
+
+		if ( ! $post ) {
+			return;
+		}
+
+		if ( $old_status === 'publish' && $new_status === 'draft' ) {
+			$product_id = $post->ID;
+			$this->on_product_delete ( $product_id );
+		}
+
 	}
 
 	/**

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -949,8 +949,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		}
 
 		if ( $old_status === 'publish' && $new_status === 'draft' ) {
-			$product_id = $post->ID;
-			$this->on_product_delete ( $product_id );
+			$this->on_product_delete ( $post->ID );
 		}
 
 	}

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -938,7 +938,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/**
 	 * Deletes a product from Facebook when status is changed to draft.
 	 *
-	 * @param int $product_id product ID
+	 * @param string   $new_status
+	 * @param string   $old_status
+	 * @param \WP_post $post
 	 */
 	public function delete_draft_product( $new_status, $old_status, $post ) {
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Products are visible on Facebook even after switching to draft.  This PR deletes the product from Meta Commerce Manager once the product status is switched to draft. 

Closes #2547.

- [ ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install and activate the Facebook for WooCommerce plugin
2. Go to Meta Commerce Manager
3. Look for a specific product and note the ID
4. Go to WP-Admin > Products and edit the same product
5. Change the product status to draft and update
6. Look for the same product under Meta Commerce Manager
7. Verify the product isn't visible - compare product ID

