### PR TITLE
Deletes the product from facebook once it is switched to draft.

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -368,6 +368,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 		add_action( 'untrashed_post', [ $this, 'fb_restore_untrashed_variable_product' ] );
 
+		// Ensure product is deleted from FB when status is changed to draft.
+		add_action( 'publish_to_draft', [ $this, 'delete_draft_product' ] );
+
 		// Product Set hooks.
 		add_action( 'fb_wc_product_set_sync', [ $this, 'create_or_update_product_set_item' ], 99, 2 );
 		add_action( 'fb_wc_product_set_delete', [ $this, 'delete_product_set_item' ], 99 );

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1023,6 +1023,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/**
 	 * Deletes a product from Facebook when status is changed to draft.
 	 *
+	 * @since x.x.x
 	 * @param \WP_post $post
 	 */
 	public function delete_draft_product( $post ) {

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -369,7 +369,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		add_action( 'untrashed_post', [ $this, 'fb_restore_untrashed_variable_product' ] );
 
 		// Ensure product is deleted from FB when status is changed to draft.
-		add_action( 'publish_to_draft', [ $this, 'on_product_delete' ] );
+		add_action( 'publish_to_draft', [ $this, 'delete_draft_product' ] );
 
 		// Product Set hooks.
 		add_action( 'fb_wc_product_set_sync', [ $this, 'create_or_update_product_set_item' ], 99, 2 );
@@ -1019,6 +1019,22 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	private function should_update_visibility_for_product_status_change( $new_status, $old_status ) {
 		return ( $old_status === 'publish' && $new_status !== 'publish' ) || ( $old_status === 'trash' && $new_status === 'publish' ) || ( $old_status === 'future' && $new_status === 'publish' );
 	}
+
+	/**
+	 * Deletes a product from Facebook when status is changed to draft.
+	 *
+	 * @param \WP_post $post
+	 */
+	public function delete_draft_product( $post ) {
+
+		if ( ! $post ) {
+			return;
+		}
+
+		$this->on_product_delete ( $post->ID );
+
+	}
+
 
 	/**
 	 * Generic function for use with any product publishing.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Products are visible on Facebook even after switching to draft. This PR deletes the product from Meta Commerce Manager once the product status is switched to draft.

Closes #2547.

_Replace this with a good description of your changes & reasoning._

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install and activate the Facebook for WooCommerce plugin
2. Go to Meta Commerce Manager
3. Look for a specific product and note the ID
4. Go to WP-Admin > Products and edit the same product
5. Change the product status to draft and update
6. Look for the same product under Meta Commerce Manager
7. Verify the product isn't visible - compare product ID

### Additional details:

The issue was previously fixed in [PR 2569](https://github.com/woocommerce/facebook-for-woocommerce/pull/2569). I noticed an issue so submitted the correct code in this PR.

### Changelog entry

> Fix - Products are deleted from facebook once changed to draft.
