### PR TITLE
Fixes Woo categories synced as Google Product category

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -564,7 +564,8 @@ class WC_Facebook_Product {
 				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 			);
-			$product_data = $this->add_sale_price( $product_data, true );
+			$product_data   = $this->add_sale_price( $product_data, true );
+			$gpc_field_name = 'google_product_category';
 		} else {
 			$product_data = array(
 				'name'                  => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
@@ -580,12 +581,13 @@ class WC_Facebook_Product {
 				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 			);
-			$product_data = $this->add_sale_price( $product_data );
+			$product_data   = $this->add_sale_price( $product_data );
+			$gpc_field_name = 'category';
 		}//end if
 
 		$google_product_category = Products::get_google_product_category_id( $this->woo_product );
 		if ( $google_product_category ) {
-			$product_data['google_product_category'] = $google_product_category;
+			$product_data[ $gpc_field_name ] = $google_product_category;
 		}
 
 		// Currently only items batch and feed support enhanced catalog fields

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -553,9 +553,7 @@ class WC_Facebook_Product {
 
 		if ( self::PRODUCT_PREP_TYPE_ITEMS_BATCH === $type_to_prepare_for ) {
 			$product_data = array(
-				'title'                 => WC_Facebookcommerce_Utils::clean_string(
-					$this->get_title()
-				),
+				'title'                 => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
 				'description'           => $this->get_fb_description(),
 				'image_link'            => $image_urls[0],
 				'additional_image_link' => $this->get_additional_image_urls( $image_urls ),
@@ -569,9 +567,7 @@ class WC_Facebook_Product {
 			$product_data = $this->add_sale_price( $product_data, true );
 		} else {
 			$product_data = array(
-				'name'                  => WC_Facebookcommerce_Utils::clean_string(
-					$this->get_title()
-				),
+				'name'                  => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
 				'description'           => $this->get_fb_description(),
 				'image_url'             => $image_urls[0],
 				'additional_image_urls' => $this->get_additional_image_urls( $image_urls ),

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -584,10 +584,13 @@ class WC_Facebook_Product {
 		}//end if
 
 		$google_product_category = Products::get_google_product_category_id( $this->woo_product );
+		if ( $google_product_category ) {
+			$product_data['google_product_category'] = $google_product_category;
+		}
+
 		// Currently only items batch and feed support enhanced catalog fields
 		if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && $google_product_category ) {
-			$product_data['google_product_category'] = $google_product_category;
-			$product_data                            = $this->apply_enhanced_catalog_fields_from_attributes( $product_data, $google_product_category );
+			$product_data = $this->apply_enhanced_catalog_fields_from_attributes( $product_data, $google_product_category );
 		}
 
 		// add the Commerce values (only stock quantity for the moment)

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -576,7 +576,7 @@ class WC_Facebook_Product {
 				'image_url'             => $image_urls[0],
 				'additional_image_urls' => $this->get_additional_image_urls( $image_urls ),
 				'url'                   => $product_url,
-				'category'              => $categories['categories'],
+				'product_type'          => $categories['categories'],
 				'brand'                 => Helper::str_truncate( $brand, 100 ),
 				'retailer_id'           => $retailer_id,
 				'price'                 => $this->get_fb_price(),

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -593,7 +593,7 @@ class WC_Facebook_Product {
 
 		// Currently only items batch and feed support enhanced catalog fields
 		if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && $google_product_category ) {
-			$product_data = $this->apply_enhanced_catalog_fields_from_attributes( $product_data, $google_product_category );
+			$product_data = $this->apply_enhanced_catalog_fields_from_attributes( $product_data, $google_product_category, $gpc_field_name );
 		}
 
 		// add the Commerce values (only stock quantity for the moment)
@@ -650,11 +650,13 @@ class WC_Facebook_Product {
 	 * the main function to make it easier to develop and debug, potentially
 	 * worth refactoring into main prepare_product function when complete.
 	 *
-	 * @param array $product_data map
+	 * @param array  $product_data       The preparted product data map.
+	 * @param string $google_category_id The Google product category id string.
+	 * @param string $gpc_field_name     Google product category field name.
 	 * @return array
 	 */
-	private function apply_enhanced_catalog_fields_from_attributes( $product_data, $google_category_id ) {
-		$google_category_id = $product_data['google_product_category'];
+	private function apply_enhanced_catalog_fields_from_attributes( $product_data, $google_category_id, $gpc_field_name = 'google_product_category' ) {
+		$google_category_id = $product_data[ $gpc_field_name ];
 		$category_handler   = facebook_for_woocommerce()->get_facebook_category_handler();
 		if ( empty( $google_category_id ) || ! $category_handler->is_category( $google_category_id ) ) {
 			return $product_data;

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -558,6 +558,7 @@ class WC_Facebook_Product {
 				'image_link'            => $image_urls[0],
 				'additional_image_link' => $this->get_additional_image_urls( $image_urls ),
 				'link'                  => $product_url,
+				'product_type'          => $categories['categories'],
 				'brand'                 => Helper::str_truncate( $brand, 100 ),
 				'retailer_id'           => $retailer_id,
 				'price'                 => $this->get_fb_price( true ),

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -593,7 +593,7 @@ class WC_Facebook_Product {
 
 		// Currently only items batch and feed support enhanced catalog fields
 		if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && $google_product_category ) {
-			$product_data = $this->apply_enhanced_catalog_fields_from_attributes( $product_data, $google_product_category, $gpc_field_name );
+			$product_data = $this->apply_enhanced_catalog_fields_from_attributes( $product_data, $google_product_category );
 		}
 
 		// add the Commerce values (only stock quantity for the moment)
@@ -652,11 +652,9 @@ class WC_Facebook_Product {
 	 *
 	 * @param array  $product_data       The preparted product data map.
 	 * @param string $google_category_id The Google product category id string.
-	 * @param string $gpc_field_name     Google product category field name.
 	 * @return array
 	 */
-	private function apply_enhanced_catalog_fields_from_attributes( $product_data, $google_category_id, $gpc_field_name = 'google_product_category' ) {
-		$google_category_id = $product_data[ $gpc_field_name ];
+	private function apply_enhanced_catalog_fields_from_attributes( $product_data, $google_category_id ) {
 		$category_handler   = facebook_for_woocommerce()->get_facebook_category_handler();
 		if ( empty( $google_category_id ) || ! $category_handler->is_category( $google_category_id ) ) {
 			return $product_data;

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -521,6 +521,7 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 		/* Data coming from _POST data. */
 		$facebook_product_data['description'] = 'Facebook product description.';
 		$facebook_product_data['price']       = 19900;
+		$facebook_product_data['category']    = 1718;
 
 		$this->api->expects( $this->once() )
 			->method( 'update_product_item' )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2564.

This PR:

* Maps the Woo category to the `product_type` field name, which is the recommended field for retailer categories.
* Sets the Google product category name field which is `google_product_category` for batch requests and `category` for individual requests.
* Removes the condition that sets the Google Product category only for batch requests.
* Fixes some indentation issues.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install and activate WooCommerce and Facebook for WooCommerce plugins.
2. Connect the Woo store to Facebook and sync products. 
3. Create a simple product on the site and assign it a WooCommerce product category
4. Go to the Facebook tab and specify a Google product category
5. Publish the product and view the attributes field on Facebook.
6. Verify the Google Product category is set to the value chosen in the editor.
7. Verify the Product Type field is set to the value of the category in the Product editor.
8. Repeat the steps from 3-7 for a variable product.

### Screenshots

#### Woo Category and Google Product category in Product editor

![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/179533/4496a103-541a-419c-9821-5928f750b8bd)

#### Google Product category & Woo Category synced to Facebook Catalog

![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/179533/8bf90ae4-7fb3-49e7-b2d8-cdaa12006e86)

![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/179533/d65e0bb6-4ad9-46f4-91a2-a0a25582569a)


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Woo category synced as Google Product category.
