### PR TITLE
Changes backlink label to 'Go to Facebook Product Sets' on Edit Facebook Product Sets page.

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -377,6 +377,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 				'separate_items_with_commas' => sprintf( esc_html__( 'Separate %s with commas', 'facebook-for-woocommerce' ), $plural ),
 				// translators: Text label
 				'choose_from_most_used'      => sprintf( esc_html__( 'Choose from the most used %s', 'facebook-for-woocommerce' ), $plural ),
+				'back_to_items'              => sprintf( esc_html__( 'Go to %s', 'facebook-for-woocommerce' ), $plural ),
 			),
 			'hierarchical'      => true,
 			'public'            => true,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

On the Edit Facebook Product Sets page, the backlink label that appears after updating the brand says "Go to Categories". This PR changes the backlink label to "Go to Facebook Product Sets".

Closes #2580.

_Replace this with a good description of your changes & reasoning._

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

<img width="340" alt="Screenshot 2023-07-13 at 6 58 45 PM" src="https://github.com/woocommerce/facebook-for-woocommerce/assets/33723519/2ede6bc5-f0b6-4ff4-9c84-f823a98cfa1a">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install and activate Facebook for WooCommerce plugin
2. Go to Marketing > Facebook Product Sets
3. Edit existing Product set (if you have none then add a new and then edit it)
4. Make changes and click Save
5. Verify the backlink label in the success notice says "← Go to Facebook Product Sets"

### Changelog entry

> Fix - Corrects backlink to 'Go to Facebook Product Sets' in success notice on Edit Facebook Product Sets page
