### PR TITLE
Syncs product with name in ALL CAPS and displays warning

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -374,6 +374,25 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		// Product Set hooks.
 		add_action( 'fb_wc_product_set_sync', [ $this, 'create_or_update_product_set_item' ], 99, 2 );
 		add_action( 'fb_wc_product_set_delete', [ $this, 'delete_product_set_item' ], 99 );
+
+		// Show notice if a product with ALL CAPS name is published or updated.
+		add_action( 'woocommerce_new_product', [ $this, 'show_all_caps_notice' ], 10, 2 );
+		add_action( 'woocommerce_update_product', [ $this, 'show_all_caps_notice' ], 10, 2 );
+	}
+
+	/**
+	 * Validate if product name contains ALL CAPS.
+	 * Show notice if true.
+	 *
+	 * @param int $product_id
+	 * @param object $product
+	 */
+	public function show_all_caps_notice( $product_id, $product ) {
+
+		// Checks if product title contains ALL CAPS.
+		if ( \WC_Facebookcommerce_Utils::is_all_caps( $product->get_name() ) ) {
+			//TODO: pop up modal window to show notice
+		}
 	}
 
 	/**

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -374,25 +374,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		// Product Set hooks.
 		add_action( 'fb_wc_product_set_sync', [ $this, 'create_or_update_product_set_item' ], 99, 2 );
 		add_action( 'fb_wc_product_set_delete', [ $this, 'delete_product_set_item' ], 99 );
-
-		// Show notice if a product with ALL CAPS name is published or updated.
-		add_action( 'woocommerce_new_product', [ $this, 'show_all_caps_notice' ], 10, 2 );
-		add_action( 'woocommerce_update_product', [ $this, 'show_all_caps_notice' ], 10, 2 );
-	}
-
-	/**
-	 * Validate if product name contains ALL CAPS.
-	 * Show notice if true.
-	 *
-	 * @param int $product_id
-	 * @param object $product
-	 */
-	public function show_all_caps_notice( $product_id, $product ) {
-
-		// Checks if product title contains ALL CAPS.
-		if ( \WC_Facebookcommerce_Utils::is_all_caps( $product->get_name() ) ) {
-			//TODO: pop up modal window to show notice
-		}
 	}
 
 	/**

--- a/includes/Admin/Product_Sync_Meta_Box.php
+++ b/includes/Admin/Product_Sync_Meta_Box.php
@@ -119,7 +119,7 @@ class Product_Sync_Meta_Box {
 
 			<?php endif; ?>
 
-			<?php if ( \WC_Facebookcommerce_Utils::is_all_caps( $fb_product->get_title() ) ): ?>
+			<?php if ( \WC_Facebookcommerce_Utils::is_all_caps( $fb_product->get_title() ) ) : ?>
 				<p><b><?php echo esc_html__( 'Product title in all capital letters can lead to the server rejecting the product. To ensure successful product synchronization, please convert the product title to a sentence case.', 'facebook-for-woocommerce' ); ?></b></p>
 
 			<?php endif; ?>

--- a/includes/Admin/Product_Sync_Meta_Box.php
+++ b/includes/Admin/Product_Sync_Meta_Box.php
@@ -83,6 +83,11 @@ class Product_Sync_Meta_Box {
 			<?php echo esc_html__( 'Facebook ID:', 'facebook-for-woocommerce' ); ?>
 			<a href="https://facebook.com/<?php echo esc_attr( $fb_product_id ); ?>" target="_blank"><?php echo esc_html( $fb_product_id ); ?></a>
 
+			<?php if ( \WC_Facebookcommerce_Utils::is_all_caps( $fb_product->get_title() ) ) {
+				echo esc_html__( 'may have issue with synchronisation as product title is all capital letters. Please change the title to sentence case to ensure product is synchronized.', 'facebook-for-woocommerce' ); ?><br/>
+				<?php
+			} ?>
+
 			<?php if ( \WC_Facebookcommerce_Utils::is_variable_type( $fb_product->get_type() ) ) : ?>
 
 				<?php

--- a/includes/Admin/Product_Sync_Meta_Box.php
+++ b/includes/Admin/Product_Sync_Meta_Box.php
@@ -83,17 +83,6 @@ class Product_Sync_Meta_Box {
 			<?php echo esc_html__( 'Facebook ID:', 'facebook-for-woocommerce' ); ?>
 			<a href="https://facebook.com/<?php echo esc_attr( $fb_product_id ); ?>" target="_blank"><?php echo esc_html( $fb_product_id ); ?></a>
 
-			<?php
-
-			if ( \WC_Facebookcommerce_Utils::is_all_caps( $fb_product->get_title() ) ) {
-				echo esc_html__( 'may have issue with synchronisation as product title is all capital letters. Please change the title to sentence case to ensure product is synchronized.', 'facebook-for-woocommerce' );
-				?>
-				<br/>
-
-				<?php
-			}
-			?>
-
 			<?php if ( \WC_Facebookcommerce_Utils::is_variable_type( $fb_product->get_type() ) ) : ?>
 
 				<?php
@@ -127,6 +116,11 @@ class Product_Sync_Meta_Box {
 					</p>
 
 				<?php endif; ?>
+
+			<?php endif; ?>
+
+			<?php if ( \WC_Facebookcommerce_Utils::is_all_caps( $fb_product->get_title() ) ): ?>
+				<p><b><?php echo esc_html__( 'Product title in all capital letters can lead to the server rejecting the product. To ensure successful product synchronization, please convert the product title to a sentence case.', 'facebook-for-woocommerce' ); ?></b></p>
 
 			<?php endif; ?>
 

--- a/includes/Admin/Product_Sync_Meta_Box.php
+++ b/includes/Admin/Product_Sync_Meta_Box.php
@@ -83,10 +83,16 @@ class Product_Sync_Meta_Box {
 			<?php echo esc_html__( 'Facebook ID:', 'facebook-for-woocommerce' ); ?>
 			<a href="https://facebook.com/<?php echo esc_attr( $fb_product_id ); ?>" target="_blank"><?php echo esc_html( $fb_product_id ); ?></a>
 
-			<?php if ( \WC_Facebookcommerce_Utils::is_all_caps( $fb_product->get_title() ) ) {
-				echo esc_html__( 'may have issue with synchronisation as product title is all capital letters. Please change the title to sentence case to ensure product is synchronized.', 'facebook-for-woocommerce' ); ?><br/>
+			<?php
+
+			if ( \WC_Facebookcommerce_Utils::is_all_caps( $fb_product->get_title() ) ) {
+				echo esc_html__( 'may have issue with synchronisation as product title is all capital letters. Please change the title to sentence case to ensure product is synchronized.', 'facebook-for-woocommerce' );
+				?>
+				<br/>
+
 				<?php
-			} ?>
+			}
+			?>
 
 			<?php if ( \WC_Facebookcommerce_Utils::is_variable_type( $fb_product->get_type() ) ) : ?>
 

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -388,12 +388,8 @@ class ProductValidator {
 
 		/*
 		 * Requirements:
-		 * - No all caps title.
 		 * - Max length 150.
 		 */
-		if ( \WC_Facebookcommerce_Utils::is_all_caps( $title ) ) {
-			throw new ProductInvalidException( __( 'Product title is all capital letters. Please change the title to sentence case in order to allow synchronization of your product.', 'facebook-for-woocommerce' ) );
-		}
 		if ( mb_strlen( $title, 'UTF-8' ) > self::MAX_TITLE_LENGTH ) {
 			throw new ProductInvalidException( __( 'Product title is too long. Maximum allowed length is 150 characters.', 'facebook-for-woocommerce' ) );
 		}

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -388,8 +388,12 @@ class ProductValidator {
 
 		/*
 		 * Requirements:
+		 * - No all caps title.
 		 * - Max length 150.
 		 */
+		if ( \WC_Facebookcommerce_Utils::is_all_caps( $title ) ) {
+			throw new ProductInvalidException( __( 'Product title is all capital letters. Please change the title to sentence case in order to allow synchronization of your product.', 'facebook-for-woocommerce' ) );
+		}
 		if ( mb_strlen( $title, 'UTF-8' ) > self::MAX_TITLE_LENGTH ) {
 			throw new ProductInvalidException( __( 'Product title is too long. Maximum allowed length is 150 characters.', 'facebook-for-woocommerce' ) );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR enables syncing to Facebook for products with All Caps title. It adds a warning in the Facebook meta box on edit product page mentioning a potential synchronization issue and suggests changing it to sentence case.

Closes #2582.

_Replace this with a good description of your changes & reasoning._

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

<img width="300" alt="Screenshot 2023-07-24 at 8 28 26 PM" src="https://github.com/woocommerce/facebook-for-woocommerce/assets/33723519/3c61e6a7-e2b8-473f-b4ce-2d6c8168f920">

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Clone the repo and checkout this branch
2. Add new product or edit existing product 
3. Enter product name in All Caps 
4. Enter dummy description
5. Click Update or Publish
6. You'll see "This product is not yet synced to Facebook." under  Facebook meta box
7. Refresh the page
8. Verify Facebook meta box shows notice "Facebook ID: xxxxx may have issue with synchronisation as product title is all capital letters. Please change the title to sentence case to ensure product is synchronized."

### Additional information:

If you leave the description blank, it will throw an exception showing a different notice. This will be addressed in separate report.

### Changelog entry

> Fix - Syncs products with All Caps title to Facebook and displays a warning in Facebook meta box.
