### PR TITLE
Fix PHP 8.1 deprecation notices of dynamic property access

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -82,6 +82,9 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	/** @var WooCommerce\Facebook\Products\Sync\Background background sync handler */
 	private $sync_background_handler;
 
+	/** @var WooCommerce\Facebook\Feed\FeedConfigurationDetection feed configuration detection handler */
+	private $configuration_detection;
+
 	/** @var WooCommerce\Facebook\ProductSets\Sync product sets sync handler */
 	private $product_sets_sync_handler;
 
@@ -93,6 +96,9 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 
 	/** @var WooCommerce\Facebook\Commerce commerce handler */
 	private $commerce_handler;
+
+	/** @var WooCommerce\Facebook\Products\FBCategories categories handler */
+	private $fb_categories;
 
 	/** @var WooCommerce\Facebook\Utilities\Tracker */
 	private $tracker;

--- a/facebook-commerce-messenger-chat.php
+++ b/facebook-commerce-messenger-chat.php
@@ -23,6 +23,20 @@ if ( ! class_exists( 'WC_Facebookcommerce_MessengerChat' ) ) :
 	class WC_Facebookcommerce_MessengerChat {
 
 		/**
+		 * Page ID
+		 *
+		 * @var string
+		 */
+		private $page_id;
+
+		/**
+		 * JS SDK version
+		 *
+		 * @var string
+		 */
+		private $jssdk_version;
+
+		/**
 		 * Class constructor.
 		 *
 		 * @param array $settings FB page settings array.

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -178,8 +178,17 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	 */
 	private $test_mode = false;
 
+	/** @var WC_Facebookcommerce_EventsTracker */
+	private $events_tracker;
+
+	/** @var WC_Facebookcommerce_MessengerChat*/
+	private $messenger_chat;
+
 	/** @var WC_Facebookcommerce */
 	private $facebook_for_woocommerce;
+
+	/** @var WC_Facebookcommerce_Background_Process */
+	private $background_processor;
 
 	/**
 	 * Init and hook in the integration.

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -36,6 +36,9 @@ class Admin {
 	/** @var Product_Categories the product category admin handler */
 	protected $product_categories;
 
+	/** @var Product_Sets the product sets admin handler */
+	protected $product_sets;
+
 	/** @var array screens ids where to include scripts */
 	protected $screen_ids = [];
 

--- a/includes/fbbackground.php
+++ b/includes/fbbackground.php
@@ -17,6 +17,8 @@ if ( ! class_exists( 'WP_Background_Process', false ) ) {
 }
 
 class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
+		/** @var WC_Facebookcommerce_Integration */
+		protected $commerce;
 
 		public function __construct( $commerce ) {
 			$this->commerce = $commerce; // Full WC_Facebookcommerce_Integration obj


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fix PHP 8.1 deprecation of dynamic property access by explicitly defining them.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Additional details:

Fix - Define object properties to fix deprecated dynamic property access
