### PR TITLE
Add GH workflows for release PR w/ checklist & auto merge trunk to develop

### DIFF
--- a/.github/workflows/post-release-automerge.yml
+++ b/.github/workflows/post-release-automerge.yml
@@ -1,0 +1,19 @@
+name: 'Merge the release to develop'
+run-name:  Merge the released `${{ github.head_ref }}` from `trunk` to `develop`
+
+# **What it does**: Merges trunk to develop after `release/*` is merged to `trunk`.
+# **Why we have it**: To automate the release process and follow git-flow.
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - trunk
+
+jobs:
+  automerge_trunk:
+    name: Automerge released trunk
+    runs-on: ubuntu-latest
+    steps:
+      - uses: woocommerce/grow/automerge-released-trunk@actions-v1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -43,7 +43,7 @@ jobs:
                - [ ] Publish any new required docs
                - [ ] Update triggers/rules/actions listing pages
             1. [ ] Mark related ideas complete on ideas board
-            1. [ ] Confirm the release deployed correctly to [GitHub](https://github.com/woocommerce/facebook-for-woocommerce/releases) and [WPORG](https://wordpress.org/plugins/facebook-for-woocommerce/).
+            1. [ ] Confirm the release deployed correctly to [WPORG](https://wordpress.org/plugins/facebook-for-woocommerce/).
                - [ ] Ensure you can download and install the latest release from WPORG and WCCOM.
                - [ ] We've had an issue where the release tag (e.g. 2.6.1) wasn't present in the svn `tags/` folder.
                - [ ] Troubleshooting processes when the release version doesn't exist in the svn `tags/` folder:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,56 @@
+name: 'Prepare New Release'
+run-name:  Prepare New Release `${{ github.event.inputs.type }}/${{ github.event.inputs.version }}` from by @${{ github.actor }}
+
+# **What it does**: Does release preparation: creates the release branch and the PR with a checklist.
+# **Why we have it**: To support devs automating a few manual steps and to leave a nice reference for consumers.
+
+on:
+  workflow_dispatch:
+    inputs:
+      ## In the future we could infer that version from the changelog, or bump it via major|minor|patch.
+      version:
+        description: 'Version number to be released'
+        required: true
+      type:
+        description: 'Type of the release (release|hotfix)'
+        required: true
+        default: 'release'
+      wp-version:
+        description: 'WordPress tested up to'
+      wc-version:
+        description: 'WooCommerce tested up to'
+
+
+jobs:
+  PrepareRelease:
+    name: Prepare Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Create branch & PR
+        uses: woocommerce/grow/prepare-extension-release@actions-v1
+        with:
+          version: ${{ github.event.inputs.version }}
+          type: ${{ github.event.inputs.type }}
+          wp-version: ${{ github.event.inputs.wp-version }}
+          wc-version: ${{ github.event.inputs.wc-version }}
+          main-branch: 'trunk'
+          post-steps: |
+            ### After deploy
+            1. [ ] Update documentation
+               - [ ] Publish any new required docs
+               - [ ] Update triggers/rules/actions listing pages
+            1. [ ] Mark related ideas complete on ideas board
+            1. [ ] Confirm the release deployed correctly to [GitHub](https://github.com/woocommerce/facebook-for-woocommerce/releases) and [WPORG](https://wordpress.org/plugins/facebook-for-woocommerce/).
+               - [ ] Ensure you can download and install the latest release from WPORG and WCCOM.
+               - [ ] We've had an issue where the release tag (e.g. 2.6.1) wasn't present in the svn `tags/` folder.
+               - [ ] Troubleshooting processes when the release version doesn't exist in the svn `tags/` folder:
+                    1. [ ] Check the version by `Stable tag` in [https://plugins.svn.wordpress.org/facebook-for-woocommerce/trunk/readme.txt](https://plugins.svn.wordpress.org/facebook-for-woocommerce/trunk/readme.txt) to see if the new release is committed to `trunk`
+                    1. [ ] If the above version is the same as the one just released, then you can make up the missed version tag by `svn cp https://plugins.svn.wordpress.org/facebook-for-woocommerce/trunk https://plugins.svn.wordpress.org/facebook-for-woocommerce/tags/X.X.X -m "Tagging version X.X.X"`. Please note that the `X.X.X` is used as a placeholder but should be replaced with the *actual* release version (e.g., `1.5.0`).
+                    1. [ ] Wait for a while, and the zip file should be able to download from: [https://downloads.wordpress.org/plugin/facebook-for-woocommerce.x.x.x.zip](https://downloads.wordpress.org/plugin/facebook-for-woocommerce.x.x.x.zip)
+            1. [ ] Close the release milestone.
+            1. [ ] Publish any documentation updates relating to the release:
+               - [ ] [User documentation](https://docs.woocommerce.com/document/facebook-for-woocommerce)
+               - [ ] [Any changes to privacy/tracking](https://woocommerce.com/usage-tracking/)


### PR DESCRIPTION
See https://github.com/woocommerce/pinterest-for-woocommerce/pull/788 for reference.

### Changes proposed in this Pull Request:

- Add a manual [GH workflow](https://github.com/woocommerce/grow/tree/trunk/packages/github-actions/actions/prepare-extension-release) that takes versions, then starts a branch and creates a PR with the checklist.
The aim is to automate and unify the release process across Grow repos.

- [Add automerge-released-trunk workflow](https://github.com/woocommerce/facebook-for-woocommerce/commit/90e53d9c8779d7abccebd0bee61c31beacd024ed) 
   to automate merging trunk to develop after a release

### Screenshots:

![image](https://github.com/woocommerce/woocommerce-google-analytics-integration/assets/17435/685aaa36-0165-4164-8346-cda3a6ba8b69)




### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

Unfortunately, you cannot test a manually triggered workflow, until it's merged to the default branch :( 
But this PR follows,
 https://github.com/woocommerce/automatewoo/pull/1435/ and https://github.com/woocommerce/google-listings-and-ads/pull/1982

#### Manual test
1. Create a test repo with the proposed workflow merged to the main branch.
4. Go to `https://github.com/{org}/{repo}/actions/workflows/prepare-release.yml`, like https://github.com/woocommerce/automatewoo/actions/workflows/prepare-release.yml
5. Click the "Run workflow" dropdown, fill in the details, and click "Run..."
6. Wait for the workflow to finish
7. Check the created PR


### Additional details:

1. There is a difference between this flow and the process described at https://github.com/woocommerce/facebook-for-woocommerce/wiki/Build-%26-Release
   Here, we suggest only generating changelog with `woorelease`'s `--generate_changelog` and do not describe [the manual alternative](https://github.com/woocommerce/facebook-for-woocommerce/wiki/Build-%26-Release#preparing-the-release). IMHO, it simplifies the process. Also, I don't know how often you use the "manual-way", so I'm open for feedback.

1. Once the PR is merged, we can update the wiki, to remove the redundant parts, and just state something like we [did in GLA](https://github.com/woocommerce/google-listings-and-ads/wiki/Release-Process#release-basics):

> 1. Go to [Actions > Prepare New Release](https://github.com/woocommerce/google-listings-and-ads/actions/workflows/prepare-release.yml).
> 2. Open the _"Run workflow"_ dropdown, fill in the details, and click _"Run workflow"_ button.
>    ![image](https://github.com/woocommerce/google-listings-and-ads/assets/17435/782fafa1-eef0-464b-ad43-8caf87d9d00f)
> 
> 
> 3. Wait for the new release PR to be created by the _github-actions[bot]_.
> 4. Follow the steps from the new PR. Some more hints and troubleshooting are provided below.




<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the title of Pull Request will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Add release preparation GH workflow.
