### PR TITLE
Sets default value for the `category` field.

### DIFF
--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -155,7 +155,7 @@ class Product_Categories {
 	 * @return string the explanation text
 	 */
 	public static function get_enhanced_catalog_explanation_text() {
-		return __( 'Facebook catalogs now support category specific fields, to make best use of them you need to select a category. WooCommerce uses the google taxonomy as it is the most widely accepted form of categorisation.', 'facebook-for-woocommerce' );
+		return __( 'Facebook catalogs now support category specific fields, to make best use of them you need to select a category. WooCommerce uses the Google taxonomy as it is the most widely accepted form of categorisation. If no Google product category is chosen, the WooCommerce product category will be used instead.', 'facebook-for-woocommerce' );
 	}
 
 

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -574,6 +574,17 @@ class WC_Facebook_Product {
 				'image_url'             => $image_urls[0],
 				'additional_image_urls' => $this->get_additional_image_urls( $image_urls ),
 				'url'                   => $product_url,
+				/**
+				 * 'category' is a required field for creating a ProductItem object by posting to /{product_catalog_id}/products.
+				 * This field should have the Google product category for the item. Google product category is not a required field
+				 * in the WooCommerce product editor. Hence, we are setting 'category' to Woo product categories by default and overriding
+				 * it when a Google product category is set.
+				 *
+				 * @see https://developers.facebook.com/docs/marketing-api/reference/product-catalog/products/#parameters-2
+				 * @see https://github.com/woocommerce/facebook-for-woocommerce/pull/2575
+				 * @see https://github.com/woocommerce/facebook-for-woocommerce/issues/2593
+				 */
+				'category'              => $categories['categories'],
 				'product_type'          => $categories['categories'],
 				'brand'                 => Helper::str_truncate( $brand, 100 ),
 				'retailer_id'           => $retailer_id,

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -575,7 +575,7 @@ class WC_Facebook_Product {
 				'additional_image_urls' => $this->get_additional_image_urls( $image_urls ),
 				'url'                   => $product_url,
 				/**
-				 * 'category' is a required field for creating a ProductItem object by posting to /{product_catalog_id}/products.
+				 * 'category' is a required field for creating a ProductItem object when posting to /{product_catalog_id}/products.
 				 * This field should have the Google product category for the item. Google product category is not a required field
 				 * in the WooCommerce product editor. Hence, we are setting 'category' to Woo product categories by default and overriding
 				 * it when a Google product category is set.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2593.

In PR: #2575, we've replaced `category` with `product_type` for Woo categories as it is described in the documentation here: https://developers.facebook.com/docs/marketing-api/reference/product-catalog/products/#parameters-2 and reserved `category` field for the Google product category of the item. 

Adding new product posts to [/{product_catalog_id}/products](https://developers.facebook.com/docs/marketing-api/reference/product-catalog/products/) endpoint whereas updates are handled via `items_batch`. When a new product is created without a Google product category item, it returns a bad request response because `category` is not a required field. 

This issue did not happen earlier because `category` was populated with Woo product categories. In this PR, we'll use Woo product categories as the default value for `category` field and override it when a Google product category is set.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Ensure WooCommerce and Facebook for WooCommerce are installed and activated.
2. Ensure a Facebook connection is established.
3. Navigate to Products > Add New.
4. Give the product a title, for example, "New Product without GPC", a product image and a price.
5. In the product tabs, navigate to Facebook and ensure the Facebook sync field is set to "Sync and show in catalog".
6. Click on "Publish" to publish the product.
7. WIthout this PR, the product is not published to the Facebook and no Facebook object ID is generated.
8. With this PR, repeat steps 1 to 6 for another product. On publish, the product is published to Facebook and an object ID is created.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Facebook sync for newly published product without Google product category.
