### PR TITLE
Adds a filter to Business Manager ID

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -678,7 +678,16 @@ class Connection {
 	 * @return string
 	 */
 	public function get_business_manager_id() {
-		return get_option( self::OPTION_BUSINESS_MANAGER_ID, '' );
+		$business_manager_id = get_option( self::OPTION_BUSINESS_MANAGER_ID, '' );
+		/**
+		 * Filters the Business Manager ID.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string     $business_manager_id Business Manager ID.
+		 * @param Connection $connection          The Connection handler instance.
+		 */
+		return (string) apply_filters( 'wc_facebook_business_manager_id', $business_manager_id, $this );
 	}
 
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It would be useful to have a filter that will allow third-party plugins to override the Facebook Business Manager ID. This will be useful when overriding the connection to establish a manual connection,

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Filters Business Manager ID.
