### PR TITLE
Adds ← to Facebook Product Sets backlink for consistency.

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -376,7 +376,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 				'separate_items_with_commas' => sprintf( esc_html__( 'Separate %s with commas', 'facebook-for-woocommerce' ), $plural ),
 				// translators: Text label
 				'choose_from_most_used'      => sprintf( esc_html__( 'Choose from the most used %s', 'facebook-for-woocommerce' ), $plural ),
-				'back_to_items'              => sprintf( esc_html__( 'Go to %s', 'facebook-for-woocommerce' ), $plural ),
+				'back_to_items'              => sprintf( esc_html__( '&larr; Go to %s', 'facebook-for-woocommerce' ), $plural ),
 			),
 			'hierarchical'      => true,
 			'public'            => true,

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -376,6 +376,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 				'separate_items_with_commas' => sprintf( esc_html__( 'Separate %s with commas', 'facebook-for-woocommerce' ), $plural ),
 				// translators: Text label
 				'choose_from_most_used'      => sprintf( esc_html__( 'Choose from the most used %s', 'facebook-for-woocommerce' ), $plural ),
+				// translators: Backlink item label
 				'back_to_items'              => sprintf( esc_html__( '&larr; Go to %s', 'facebook-for-woocommerce' ), $plural ),
 			),
 			'hierarchical'      => true,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I missed adding a backward arrow (←) to the Facebook Product Sets backlink in PR #2581. This PR adds ← to the backlink. Also, I have added a comment for translators explaining what is %s value.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

<img width="297" alt="Screenshot 2023-08-02 at 8 52 21 PM" src="https://github.com/woocommerce/facebook-for-woocommerce/assets/33723519/7746d76b-3466-4e1d-914d-f56038d71039">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install and activate Facebook for WooCommerce plugin
2. Go to Marketing > Facebook Product Sets
3. Edit existing Product set (if you have none then add one and then edit it)
4. Make changes and click Save
5. Verify the backlink label in the success notice says "← Go to Facebook Product Sets"


### Changelog entry

> Tweak - Adds backward arrow to Facebook Product Sets backlink.