### PR TITLE
Return empty config when facebook_config returns a string.

### DIFF
--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -657,8 +657,9 @@ class WC_Facebookcommerce_Pixel {
 		 * Get PixelID related settings.
 		 */
 		public static function get_options() {
-			return is_array( get_option( self::SETTINGS_KEY ) ) && ! empty( get_option( self::SETTINGS_KEY ) )
-				? get_option( self::SETTINGS_KEY )
+			$facebook_config = get_option( self::SETTINGS_KEY );
+			return is_array( $facebook_config ) && ! empty( $facebook_config )
+				? $facebook_config
 				: array(
 					self::PIXEL_ID_KEY     => '0',
 					self::USE_PII_KEY      => 0,
@@ -666,7 +667,6 @@ class WC_Facebookcommerce_Pixel {
 					self::ACCESS_TOKEN_KEY => '',
 				);
 		}
-
 
 		/**
 		 * Gets the logged in user info

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -657,12 +657,14 @@ class WC_Facebookcommerce_Pixel {
 		 * Get PixelID related settings.
 		 */
 		public static function get_options() {
-			return get_option( self::SETTINGS_KEY ) ?: array(
-				self::PIXEL_ID_KEY     => '0',
-				self::USE_PII_KEY      => 0,
-				self::USE_S2S_KEY      => false,
-				self::ACCESS_TOKEN_KEY => '',
-			);
+			return is_array( get_option( self::SETTINGS_KEY ) ) && ! empty( get_option( self::SETTINGS_KEY ) )
+				? get_option( self::SETTINGS_KEY )
+				: array(
+					self::PIXEL_ID_KEY     => '0',
+					self::USE_PII_KEY      => 0,
+					self::USE_S2S_KEY      => false,
+					self::ACCESS_TOKEN_KEY => '',
+				);
 		}
 
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We received a report of a fatal error in the Pixel Event class. After investigation, I noticed that if the `facebook_config` option is an empty string, the value returned by get_options would be an empty string, causing the exception: `error message: Uncaught TypeError: Cannot access offset of type string on string`. 

This assumes that `facebook_config` will always contain a serialized object, and the error is, in fact, caused by the `facebook_config` option being a non serialize object. 

Closes #2516.


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.




### Detailed test instructions:

1. log in as an admin, navigate to wp-admin/options.php, then set the value of the content of facebook_config to a random string. e.g: 10k
2. navigate to any admin page, and you should receive the fatal error.
3. Switch to this branch, and the fatal should be gone.

### Changelog entry

> Fix - Fatal error when facebook_config option is empty.
