### PR TITLE
make get_options a bit more robust.

### DIFF
--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -657,15 +657,27 @@ class WC_Facebookcommerce_Pixel {
 		 * Get PixelID related settings.
 		 */
 		public static function get_options() {
-			$facebook_config = get_option( self::SETTINGS_KEY );
-			return is_array( $facebook_config ) && ! empty( $facebook_config )
-				? $facebook_config
-				: array(
-					self::PIXEL_ID_KEY     => '0',
-					self::USE_PII_KEY      => 0,
-					self::USE_S2S_KEY      => false,
-					self::ACCESS_TOKEN_KEY => '',
-				);
+
+			$default_options = array(
+				self::PIXEL_ID_KEY     => '0',
+				self::USE_PII_KEY      => 0,
+				self::USE_S2S_KEY      => false,
+				self::ACCESS_TOKEN_KEY => '',
+			);
+
+			$fb_options = get_option( self::SETTINGS_KEY );
+
+			if ( ! is_array( $fb_options ) ) {
+				$fb_options = $default_options;
+			} else {
+				foreach ( $default_options as $key => $value ) {
+					if ( ! isset( $fb_options[ $key ] ) ) {
+						$fb_options[ $key ] = $value;
+					}
+				}
+			}
+
+			return $fb_options;
 		}
 
 		/**

--- a/tests/Unit/FacebookCommercePixelEventTest.php
+++ b/tests/Unit/FacebookCommercePixelEventTest.php
@@ -8,54 +8,54 @@ class FacebookCommercePixelTest extends WP_UnitTestCase {
 	 */
 	public function test_get_options_returns_default_options_when_no_options_exist() {
 		$expected_options = array(
-			WC_Facebookcommerce_Pixel::PIXEL_ID_KEY => '0',
-			WC_Facebookcommerce_Pixel::USE_PII_KEY => 0,
-			WC_Facebookcommerce_Pixel::USE_S2S_KEY => false,
+			WC_Facebookcommerce_Pixel::PIXEL_ID_KEY     => '0',
+			WC_Facebookcommerce_Pixel::USE_PII_KEY      => 0,
+			WC_Facebookcommerce_Pixel::USE_S2S_KEY      => false,
 			WC_Facebookcommerce_Pixel::ACCESS_TOKEN_KEY => '',
 		);
 
 		$actual_options = WC_Facebookcommerce_Pixel::get_options();
 
-		$this->assertEquals($expected_options, $actual_options);
+		$this->assertEquals( $expected_options, $actual_options );
 	}
 
 	public function test_get_options_returns_merged_options_when_options_exist() {
 		$default_options = array(
-			WC_Facebookcommerce_Pixel::PIXEL_ID_KEY => '0',
-			WC_Facebookcommerce_Pixel::USE_PII_KEY => 0,
-			WC_Facebookcommerce_Pixel::USE_S2S_KEY => false,
+			WC_Facebookcommerce_Pixel::PIXEL_ID_KEY     => '0',
+			WC_Facebookcommerce_Pixel::USE_PII_KEY      => 0,
+			WC_Facebookcommerce_Pixel::USE_S2S_KEY      => false,
 			WC_Facebookcommerce_Pixel::ACCESS_TOKEN_KEY => '',
 		);
 
 		$existing_options = array(
-			WC_Facebookcommerce_Pixel::PIXEL_ID_KEY => '123456789',
-			WC_Facebookcommerce_Pixel::USE_PII_KEY => 1,
-			WC_Facebookcommerce_Pixel::USE_S2S_KEY => true,
+			WC_Facebookcommerce_Pixel::PIXEL_ID_KEY     => '123456789',
+			WC_Facebookcommerce_Pixel::USE_PII_KEY      => 1,
+			WC_Facebookcommerce_Pixel::USE_S2S_KEY      => true,
 			WC_Facebookcommerce_Pixel::ACCESS_TOKEN_KEY => 'abc123',
 		);
 
-		$expected_options = array_merge($default_options, $existing_options);
+		$expected_options = array_merge( $default_options, $existing_options );
 
-		update_option(WC_Facebookcommerce_Pixel::SETTINGS_KEY, $existing_options);
+		update_option( WC_Facebookcommerce_Pixel::SETTINGS_KEY, $existing_options );
 
 		$actual_options = WC_Facebookcommerce_Pixel::get_options();
 
-		$this->assertEquals($expected_options, $actual_options);
+		$this->assertEquals( $expected_options, $actual_options );
 	}
 
 	public function test_get_options_returns_default_options_when_options_are_not_an_array() {
-		update_option(WC_Facebookcommerce_Pixel::SETTINGS_KEY, 'not an array');
+		update_option( WC_Facebookcommerce_Pixel::SETTINGS_KEY, 'not an array' );
 
 		$expected_options = array(
-			WC_Facebookcommerce_Pixel::PIXEL_ID_KEY => '0',
-			WC_Facebookcommerce_Pixel::USE_PII_KEY => 0,
-			WC_Facebookcommerce_Pixel::USE_S2S_KEY => false,
+			WC_Facebookcommerce_Pixel::PIXEL_ID_KEY     => '0',
+			WC_Facebookcommerce_Pixel::USE_PII_KEY      => 0,
+			WC_Facebookcommerce_Pixel::USE_S2S_KEY      => false,
 			WC_Facebookcommerce_Pixel::ACCESS_TOKEN_KEY => '',
 		);
 
 		$actual_options = WC_Facebookcommerce_Pixel::get_options();
 
-		$this->assertEquals($expected_options, $actual_options);
+		$this->assertEquals( $expected_options, $actual_options );
 	}
 
 }

--- a/tests/Unit/FacebookCommercePixelEventTest.php
+++ b/tests/Unit/FacebookCommercePixelEventTest.php
@@ -1,0 +1,61 @@
+<?php
+declare( strict_types=1 );
+
+class FacebookCommercePixelTest extends WP_UnitTestCase {
+
+	/**
+	 * Unit tests for WC_Facebookcommerce_Pixel class.
+	 */
+	public function test_get_options_returns_default_options_when_no_options_exist() {
+		$expected_options = array(
+			WC_Facebookcommerce_Pixel::PIXEL_ID_KEY => '0',
+			WC_Facebookcommerce_Pixel::USE_PII_KEY => 0,
+			WC_Facebookcommerce_Pixel::USE_S2S_KEY => false,
+			WC_Facebookcommerce_Pixel::ACCESS_TOKEN_KEY => '',
+		);
+
+		$actual_options = WC_Facebookcommerce_Pixel::get_options();
+
+		$this->assertEquals($expected_options, $actual_options);
+	}
+
+	public function test_get_options_returns_merged_options_when_options_exist() {
+		$default_options = array(
+			WC_Facebookcommerce_Pixel::PIXEL_ID_KEY => '0',
+			WC_Facebookcommerce_Pixel::USE_PII_KEY => 0,
+			WC_Facebookcommerce_Pixel::USE_S2S_KEY => false,
+			WC_Facebookcommerce_Pixel::ACCESS_TOKEN_KEY => '',
+		);
+
+		$existing_options = array(
+			WC_Facebookcommerce_Pixel::PIXEL_ID_KEY => '123456789',
+			WC_Facebookcommerce_Pixel::USE_PII_KEY => 1,
+			WC_Facebookcommerce_Pixel::USE_S2S_KEY => true,
+			WC_Facebookcommerce_Pixel::ACCESS_TOKEN_KEY => 'abc123',
+		);
+
+		$expected_options = array_merge($default_options, $existing_options);
+
+		update_option(WC_Facebookcommerce_Pixel::SETTINGS_KEY, $existing_options);
+
+		$actual_options = WC_Facebookcommerce_Pixel::get_options();
+
+		$this->assertEquals($expected_options, $actual_options);
+	}
+
+	public function test_get_options_returns_default_options_when_options_are_not_an_array() {
+		update_option(WC_Facebookcommerce_Pixel::SETTINGS_KEY, 'not an array');
+
+		$expected_options = array(
+			WC_Facebookcommerce_Pixel::PIXEL_ID_KEY => '0',
+			WC_Facebookcommerce_Pixel::USE_PII_KEY => 0,
+			WC_Facebookcommerce_Pixel::USE_S2S_KEY => false,
+			WC_Facebookcommerce_Pixel::ACCESS_TOKEN_KEY => '',
+		);
+
+		$actual_options = WC_Facebookcommerce_Pixel::get_options();
+
+		$this->assertEquals($expected_options, $actual_options);
+	}
+
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We assume that if the serial object is “correct”, meaning an array, then we return it to the caller to check if the index is there. This PR will set an index to the default when such index does not exist in the config

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1. Switch to this branch.
2. log in as an admin, navigate to wp-admin/options.php, then set the value of the content of facebook_config to a random string. e.g: 10k
3. navigate to any admin page. Then check the value of facebook_config and confirm this is a valid serialized object. And repeat this test by setting facebook_config to an empty value.


### Changelog entry

> Fix - WC_Facebookcommerce_Pixel::get_options() throwing a fatal error if facebook_config is invalid
