### PR TITLE
Bump Marketing API version to v17.0

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -33,7 +33,7 @@ class API extends Base {
 
 	public const GRAPH_API_URL = 'https://graph.facebook.com/';
 
-	public const API_VERSION = 'v16.0';
+	public const API_VERSION = 'v17.0';
 
 	/** @var string URI used for the request */
 	protected $request_uri = self::GRAPH_API_URL . self::API_VERSION;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the Facebook Marketing API version to v17.0 

There should be no changes in the endpoints that we use, so the application should behave as it used to without any additional changes.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:
1. Use https://github.com/woocommerce/facebook-for-woocommerce/wiki/Smoke-tests for testing instructions
Make sure that logging is enabled in the plugin. After the tests, inspect the logs for errors.
The use of v17 API will be clearly visible in the endpoint URL:

<img width="755" alt="Screenshot 2023-08-03 at 7 35 01 PM" src="https://github.com/woocommerce/facebook-for-woocommerce/assets/33723519/2561d6c4-177c-44bf-b91f-9b27b2adaf4b">


### Additional information:

Here's the sister PR to update the connect.woocommerce.com bridge - https://github.com/Automattic/connect.woocommerce.com/pull/173

This will need to be reviewed to ensure that the connection flow works properly.

### Changelog entry

> Tweak - Bump Marketing API version to v17.0
