### PR TITLE
Fixes dynamic property creation deprecation warnings with PHP8.2

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -106,6 +106,12 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	/** @var WooCommerce\Facebook\ExternalVersionUpdate */
 	private $external_version_update;
 
+	/** @var WooCommerce\Facebook\Feed\FeedConfigurationDetection instance. */
+	private $configuration_detection;
+
+	/** @var WooCommerce\Facebook\Products\FBCategories instance. */
+	private $fb_categories;
+
 	/**
 	 * The Debug tools instance.
 	 *

--- a/facebook-commerce-messenger-chat.php
+++ b/facebook-commerce-messenger-chat.php
@@ -22,6 +22,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_MessengerChat' ) ) :
 	 */
 	class WC_Facebookcommerce_MessengerChat {
 
+		/** @var Facebook Page ID. */
+		private $page_id;
+
+		/** @var JS SDK Version. */
+		private $jssdk_version;
+
 		/**
 		 * Class constructor.
 		 *

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -181,6 +181,15 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var WC_Facebookcommerce */
 	private $facebook_for_woocommerce;
 
+	/** @var WC_Facebookcommerce_EventsTracker instance. */
+	private $events_tracker;
+
+	/** @var WC_Facebookcommerce_MessengerChat instance. */
+	private $messenger_chat;
+
+	/** @var WC_Facebookcommerce_Background_Process instance. */
+	private $background_processor;
+
 	/**
 	 * Init and hook in the integration.
 	 *

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -39,6 +39,8 @@ class Admin {
 	/** @var array screens ids where to include scripts */
 	protected $screen_ids = [];
 
+	/** @var Product_Sets the product set admin handler. */
+	protected $product_sets;
 
 	/**
 	 * Admin constructor.

--- a/includes/fbbackground.php
+++ b/includes/fbbackground.php
@@ -18,6 +18,11 @@ if ( ! class_exists( 'WP_Background_Process', false ) ) {
 
 class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
 
+		/**
+		 * @var WC_Facebookcommerce_Integration instance.
+		 */
+		private $commerce;
+
 		public function __construct( $commerce ) {
 			$this->commerce = $commerce; // Full WC_Facebookcommerce_Integration obj
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2605.

_Replace this with a good description of your changes & reasoning._

- [ ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:




### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Change your site's PHP version to 8.2
2. Install and activate Facebook for WooCommerce plugin
3. Verify the plugin is activated without any deprecation warnings in the header

### Changelog entry

> Fix - 
