### PR TITLE
Fix WPML product hiding logic

### DIFF
--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -87,6 +87,7 @@ class WC_Facebook_WPML_Injector {
 	}
 
 	public function wpml_ajax_support( $call, $REQUEST ) {
+		/** @var SitePress $sitepress */
 		global $sitepress;
 		if ( isset( $REQUEST['icl_ajx_action'] ) ) {
 			$call = $REQUEST['icl_ajx_action'];
@@ -111,7 +112,7 @@ class WC_Facebook_WPML_Injector {
 	 * The section is shown at the bottom of the WPML > Languages settings page.
 	 */
 	public function wpml_support() {
-		/** @var object $sitepress */
+		/** @var SitePress $sitepress */
 		global $sitepress;
 
 		// there is no nonce to check here and the value of $_GET['page] is being compared against a known and safe string

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -1,5 +1,4 @@
 <?php
-// phpcs:ignoreFile
 /**
  * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
  *
@@ -7,6 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @package FacebookCommerce
+ *
+ * phpcs:disable Squiz.Commenting.ClassComment.Missing
+ * phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+ * phpcs:disable Squiz.Commenting.VariableComment.Missing
+ * phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -82,7 +86,7 @@ class WC_Facebook_WPML_Injector {
 		}
 
 		// Hide products from non-active languages, of if the language status isn't visible.
-		$should_hide = ! isset( self::$settings[ $language_code ] ) || self::$settings[ $language_code ] !== FB_WPML_Language_Status::VISIBLE;
+		$should_hide = ! isset( self::$settings[ $language_code ] ) || FB_WPML_Language_Status::VISIBLE !== self::$settings[ $language_code ];
 
 		return (bool) apply_filters( 'wc_facebook_wpml_should_hide_product', $should_hide, $product_id, $product_lang );
 	}
@@ -93,11 +97,11 @@ class WC_Facebook_WPML_Injector {
 		if ( isset( $REQUEST['icl_ajx_action'] ) ) {
 			$call = $REQUEST['icl_ajx_action'];
 		}
-		if ( $call === 'icl_fb_woo' ) {
+		if ( 'icl_fb_woo' === $call ) {
 			$active_languages = array_keys( $sitepress->get_active_languages() );
 			$settings         = array();
 			foreach ( $active_languages as $lang ) {
-				$settings[ $lang ] = $REQUEST[ $lang ] === 'on' ?
+				$settings[ $lang ] = 'on' === $REQUEST[ $lang ] ?
 				FB_WPML_Language_Status::VISIBLE : FB_WPML_Language_Status::HIDDEN;
 			}
 
@@ -166,7 +170,7 @@ class WC_Facebook_WPML_Injector {
 								<input
 									class="button button-primary"
 									name="save"
-									value="<?php esc_attr_e( 'Save', 'sitepress' ); ?>"
+									value="<?php esc_attr_e( 'Save', 'facebook-for-woocommerce' ); ?>"
 									type="submit"
 								/>
 							</p>

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -42,15 +42,14 @@ class WC_Facebook_WPML_Injector {
 	 *
 	 * @since 1.9.10
 	 *
-	 * @param int $wp_id The product ID.
+	 * @param int $product_id The product ID.
 	 *
 	 * @return bool
 	 */
-	public static function should_hide( $wp_id ) {
-		// Apply WPML filters to the product.
-		$product_lang = apply_filters( 'wpml_post_language_details', null, $wp_id );
-
-		/*
+	public static function should_hide( $product_id ) {
+		/**
+		 * Apply WPML filters to the product ID.
+		 *
 		 * The wpml_post_language_details filter is applied to obtain the language data for the product.
 		 *
 		 * Possible values for $product_lang after the filter is applied:
@@ -59,6 +58,8 @@ class WC_Facebook_WPML_Injector {
 		 * 2. array - WPML returned the language data from wpml_get_language_information().
 		 * 3. WP_Error - WPML didn't recognize the post ID.
 		 */
+		$product_lang = apply_filters( 'wpml_post_language_details', null, $product_id );
+
 		if ( ! is_array( $product_lang ) ) {
 			/**
 			 * Whether to hide the product from Facebook.
@@ -66,10 +67,10 @@ class WC_Facebook_WPML_Injector {
 			 * @since x.x.x
 			 *
 			 * @param bool  $should_hide  Whether to hide the product from Facebook.
-			 * @param int   $wp_id        The product ID.
+			 * @param int   $product_id   The product ID.
 			 * @param mixed $product_lang The result of applying the WPML filters.
 			 */
-			return (bool) apply_filters( 'wc_facebook_wpml_should_hide_product', true, $wp_id, $product_lang );
+			return (bool) apply_filters( 'wc_facebook_wpml_should_hide_product', true, $product_id, $product_lang );
 		}
 
 		// Pull out the language code from the language details.
@@ -77,13 +78,13 @@ class WC_Facebook_WPML_Injector {
 
 		// Option doesn't exist: Backwards Compatibility
 		if ( ! self::$settings ) {
-			return (bool) apply_filters( 'wc_facebook_wpml_should_hide_product', self::$default_lang !== $language_code, $wp_id, $product_lang );
+			return (bool) apply_filters( 'wc_facebook_wpml_should_hide_product', self::$default_lang !== $language_code, $product_id, $product_lang );
 		}
 
 		// Hide products from non-active languages, of if the language status isn't visible.
 		$should_hide = ! isset( self::$settings[ $language_code ] ) || self::$settings[ $language_code ] !== FB_WPML_Language_Status::VISIBLE;
 
-		return (bool) apply_filters( 'wc_facebook_wpml_should_hide_product', $should_hide, $wp_id, $product_lang );
+		return (bool) apply_filters( 'wc_facebook_wpml_should_hide_product', $should_hide, $product_id, $product_lang );
 	}
 
 	public function wpml_ajax_support( $call, $REQUEST ) {

--- a/tests/Unit/WPMLTest.php
+++ b/tests/Unit/WPMLTest.php
@@ -2,6 +2,9 @@
 
 class WPMLTest extends WP_UnitTestCase {
 
+	/** @var int $fake_product_id */
+	private $fake_product_id = 1;
+
 	/**
 	 * Tears down the fixture, for example, close a network connection.
 	 *
@@ -16,7 +19,7 @@ class WPMLTest extends WP_UnitTestCase {
 	}
 
 	public function test_should_hide_product_when_wpml_filter_not_applied() {
-		$this->assertTrue( WC_Facebook_WPML_Injector::should_hide( 1 ) );
+		$this->assertTrue( WC_Facebook_WPML_Injector::should_hide( $this->fake_product_id ) );
 	}
 
 	public function test_product_hidden_when_wpml_filter_returns_wp_error() {
@@ -27,7 +30,7 @@ class WPMLTest extends WP_UnitTestCase {
 			}
 		);
 
-		$this->assertTrue( WC_Facebook_WPML_Injector::should_hide( 1 ) );
+		$this->assertTrue( WC_Facebook_WPML_Injector::should_hide( $this->fake_product_id ) );
 	}
 
 	public function test_product_hidden_no_settings_and_not_default() {
@@ -42,7 +45,7 @@ class WPMLTest extends WP_UnitTestCase {
 			}
 		);
 
-		$this->assertTrue( WC_Facebook_WPML_Injector::should_hide( 1 ) );
+		$this->assertTrue( WC_Facebook_WPML_Injector::should_hide( $this->fake_product_id ) );
 	}
 
 	public function test_product_not_hidden_no_settings_and_default() {
@@ -56,7 +59,7 @@ class WPMLTest extends WP_UnitTestCase {
 			}
 		);
 
-		$this->assertFalse( WC_Facebook_WPML_Injector::should_hide( 1 ) );
+		$this->assertFalse( WC_Facebook_WPML_Injector::should_hide( $this->fake_product_id ) );
 	}
 
 	public function test_product_hidden_language_setting_not_visible() {
@@ -73,7 +76,7 @@ class WPMLTest extends WP_UnitTestCase {
 			}
 		);
 
-		$this->assertTrue( WC_Facebook_WPML_Injector::should_hide( 1 ) );
+		$this->assertTrue( WC_Facebook_WPML_Injector::should_hide( $this->fake_product_id ) );
 	}
 
 	public function test_product_not_hidden_language_setting_visible() {
@@ -90,6 +93,6 @@ class WPMLTest extends WP_UnitTestCase {
 			}
 		);
 
-		$this->assertFalse( WC_Facebook_WPML_Injector::should_hide( 1 ) );
+		$this->assertFalse( WC_Facebook_WPML_Injector::should_hide( $this->fake_product_id ) );
 	}
 }

--- a/tests/Unit/WPMLTest.php
+++ b/tests/Unit/WPMLTest.php
@@ -1,0 +1,95 @@
+<?php
+
+class WPMLTest extends WP_UnitTestCase {
+
+	/**
+	 * Tears down the fixture, for example, close a network connection.
+	 *
+	 * This method is called after each test.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		WC_Facebook_WPML_Injector::$settings     = null;
+		WC_Facebook_WPML_Injector::$default_lang = null;
+		remove_all_filters( 'wpml_post_language_details' );
+	}
+
+	public function test_should_hide_product_when_wpml_filter_not_applied() {
+		$this->assertTrue( WC_Facebook_WPML_Injector::should_hide( 1 ) );
+	}
+
+	public function test_product_hidden_when_wpml_filter_returns_wp_error() {
+		add_filter(
+			'wpml_post_language_details',
+			function() {
+				return new WP_Error();
+			}
+		);
+
+		$this->assertTrue( WC_Facebook_WPML_Injector::should_hide( 1 ) );
+	}
+
+	public function test_product_hidden_no_settings_and_not_default() {
+		WC_Facebook_WPML_Injector::$default_lang = 'en_US';
+
+		add_filter(
+			'wpml_post_language_details',
+			function() {
+				return [
+					'language_code' => 'fr_FR',
+				];
+			}
+		);
+
+		$this->assertTrue( WC_Facebook_WPML_Injector::should_hide( 1 ) );
+	}
+
+	public function test_product_not_hidden_no_settings_and_default() {
+		WC_Facebook_WPML_Injector::$default_lang = 'en_US';
+		add_filter(
+			'wpml_post_language_details',
+			function() {
+				return [
+					'language_code' => 'en_US',
+				];
+			}
+		);
+
+		$this->assertFalse( WC_Facebook_WPML_Injector::should_hide( 1 ) );
+	}
+
+	public function test_product_hidden_language_setting_not_visible() {
+		WC_Facebook_WPML_Injector::$settings = [
+			'fr_FR' => FB_WPML_Language_Status::HIDDEN,
+		];
+
+		add_filter(
+			'wpml_post_language_details',
+			function() {
+				return [
+					'language_code' => 'fr_FR',
+				];
+			}
+		);
+
+		$this->assertTrue( WC_Facebook_WPML_Injector::should_hide( 1 ) );
+	}
+
+	public function test_product_not_hidden_language_setting_visible() {
+		WC_Facebook_WPML_Injector::$settings = [
+			'fr_FR' => FB_WPML_Language_Status::VISIBLE,
+		];
+
+		add_filter(
+			'wpml_post_language_details',
+			function() {
+				return [
+					'language_code' => 'fr_FR',
+				];
+			}
+		);
+
+		$this->assertFalse( WC_Facebook_WPML_Injector::should_hide( 1 ) );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2584.

This updates the logic within the `\WC_Facebook_WPML_Injector::should_hide()` method to more robustly handle various results that could be returned from the applied filter. It also adds unit tests covering this functionality.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Changelog entry

> Fix - Update WPML compatibility to prevent fatal errors on PHP 8+
