### PR TITLE
Changes property access of product id to public.

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -51,7 +51,7 @@ class WC_Facebook_Product {
 	/**
 	 * @var int WC_Product ID.
 	 */
-	private $id;
+	public $id;
 
 	/**
 	 * @var WC_Product


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Private access of $id property done in [PR 2606](https://github.com/woocommerce/facebook-for-woocommerce/pull/2606), breaks the product feed functionality. The Product feed doesn't populate variable products. This is happening because the `id` can't be accessed by fbproductfeed.php file at https://github.com/woocommerce/facebook-for-woocommerce/blob/b152860b22f12adbafb476167ff0573eefae32af/includes/fbproductfeed.php#L475

This PR changes the access from private to public which restores the original product feed functionality. 

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

**Before:**

<img width="405" alt="Screenshot 2023-08-16 at 1 22 35 PM" src="https://github.com/woocommerce/facebook-for-woocommerce/assets/33723519/4279db4f-af45-4138-a4e2-3618432e6182">

**After:**

<img width="453" alt="Screenshot 2023-08-16 at 1 22 13 PM" src="https://github.com/woocommerce/facebook-for-woocommerce/assets/33723519/a7d88511-0851-46e2-80ad-3ce826cdc749">


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install and Activate the plugin
2. Switch to the branch in this PR
3. Go to WooCommerce > Status > Scheduled Actions > Pending
4. Run wc_facebook_regenerate_feed action
5. Go to wp-content/uploads/facebook_for_woocommerce folder
6. Open the product feed csv file
7. Verify you see variable products along with all other products

### Changelog entry

> Fix - Changes property access of product id from private to public
