### PR TITLE
Adds warning if private properties are accessed outside its class.

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -134,6 +134,23 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 		$this->init_admin();
 	}
 
+	/**
+	 * __get method for backward compatibility.
+	 *
+	 * @param string $key property name
+	 * @return mixed
+	 * @since x.x.x
+	 */
+	public function __get( $key ) {
+		// Add warning for private properties.
+		if ( in_array( $key, array( 'configuration_detection', 'fb_categories' ), true ) ) {
+			/* translators: %s property name. */
+			_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is private and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), 'x.x.x' );
+			return $this->$key;
+		}
+
+		return null;
+	}
 
 	/**
 	 * Initializes the plugin.

--- a/facebook-commerce-messenger-chat.php
+++ b/facebook-commerce-messenger-chat.php
@@ -46,6 +46,23 @@ if ( ! class_exists( 'WC_Facebookcommerce_MessengerChat' ) ) :
 			add_action( 'wp_footer', array( $this, 'inject_messenger_chat_plugin' ) );
 		}
 
+		/**
+		 * __get method for backward compatibility.
+		 *
+		 * @param string $key property name
+		 * @return mixed
+		 * @since x.x.x
+		 */
+		public function __get( $key ) {
+			// Add warning for private properties.
+			if ( in_array( $key, array( 'page_id', 'jssdk_version' ), true ) ) {
+				/* translators: %s property name. */
+				_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is private and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), 'x.x.x' );
+				return $this->$key;
+			}
+
+			return null;
+		}
 
 		/**
 		 * Outputs the Facebook Messenger chat script.

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -386,6 +386,24 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	}
 
 	/**
+	 * __get method for backward compatibility.
+	 *
+	 * @param string $key property name
+	 * @return mixed
+	 * @since x.x.x
+	 */
+	public function __get( $key ) {
+		// Add warning for private properties.
+		if ( in_array( $key, array( 'events_tracker', 'messenger_chat', 'background_processor' ), true ) ) {
+			/* translators: %s property name. */
+			_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is private and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), 'x.x.x' );
+			return $this->$key;
+		}
+
+		return null;
+	}
+
+	/**
 	 * Initialises Facebook Pixel and its settings.
 	 *
 	 * @return bool

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -121,7 +121,7 @@ class Admin {
 		// Add warning for private properties.
 		if ( 'product_sets' === $key ) {
 			/* translators: %s property name. */
-			_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is private and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), 'x.x.x' );
+			_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is protected and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), 'x.x.x' );
 			return $this->$key;
 		}
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -111,6 +111,24 @@ class Admin {
 	}
 
 	/**
+	 * __get method for backward compatibility.
+	 *
+	 * @param string $key property name
+	 * @return mixed
+	 * @since x.x.x
+	 */
+	public function __get( $key ) {
+		// Add warning for private properties.
+		if ( 'product_sets' === $key ) {
+			/* translators: %s property name. */
+			_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is private and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), 'x.x.x' );
+			return $this->$key;
+		}
+
+		return null;
+	}
+
+	/**
 	 * Change custom taxonomy tip text
 	 *
 	 * @since 2.3.0

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -54,6 +54,24 @@ class Enhanced_Catalog_Attribute_Fields {
 		$this->category_handler = facebook_for_woocommerce()->get_facebook_category_handler();
 	}
 
+	/**
+	 * __get method for backward compatibility.
+	 *
+	 * @param string $key property name
+	 * @return mixed
+	 * @since x.x.x
+	 */
+	public function __get( $key ) {
+		// Add warning for private properties.
+		if ( in_array( $key, array( 'page_type', 'term', 'product', 'category_handler' ), true ) ) {
+			/* translators: %s property name. */
+			_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is private and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), 'x.x.x' );
+			return $this->$key;
+		}
+
+		return null;
+	}
+
 	public static function render_hidden_input_can_show_attributes() {
 		?>
 		<input type="hidden" id="<?php echo esc_attr( self::FIELD_CAN_SHOW_ENHANCED_ATTRIBUTES_ID ); ?>"

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -118,7 +118,7 @@ class ProductValidator {
 		// Add warning for private properties.
 		if ( 'facebook_product' === $key ) {
 			/* translators: %s property name. */
-			_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is private and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), 'x.x.x' );
+			_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is protected and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), 'x.x.x' );
 			return $this->$key;
 		}
 

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -108,6 +108,24 @@ class ProductValidator {
 	}
 
 	/**
+	 * __get method for backward compatibility.
+	 *
+	 * @param string $key property name
+	 * @return mixed
+	 * @since x.x.x
+	 */
+	public function __get( $key ) {
+		// Add warning for private properties.
+		if ( 'facebook_product' === $key ) {
+			/* translators: %s property name. */
+			_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is private and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), 'x.x.x' );
+			return $this->$key;
+		}
+
+		return null;
+	}
+
+	/**
 	 * Validate whether the product should be synced to Facebook.
 	 *
 	 * @throws ProductExcludedException If product should not be synced.

--- a/includes/fbbackground.php
+++ b/includes/fbbackground.php
@@ -28,6 +28,24 @@ class WC_Facebookcommerce_Background_Process extends WP_Background_Process {
 		}
 
 		/**
+		 * __get method for backward compatibility.
+		 *
+		 * @param string $key property name
+		 * @return mixed
+		 * @since x.x.x
+		 */
+		public function __get( $key ) {
+			// Add warning for private properties.
+			if ( 'commerce' === $key ) {
+				/* translators: %s property name. */
+				_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is private and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), 'x.x.x' );
+				return $this->$key;
+			}
+
+			return null;
+		}
+
+		/**
 		 * @var string
 		 */
 		protected $action = 'fb_commerce_background_process';

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -120,6 +120,24 @@ class WC_Facebook_Product {
 		}
 	}
 
+	/**
+	 * __get method for backward compatibility.
+	 *
+	 * @param string $key property name
+	 * @return mixed
+	 * @since x.x.x
+	 */
+	public function __get( $key ) {
+		// Add warning for private properties.
+		if ( in_array( $key, array( 'fb_description', 'gallery_urls', 'fb_use_parent_image', 'main_description', 'sync_short_description' ), true ) ) {
+			/* translators: %s property name. */
+			_doing_it_wrong( __FUNCTION__, sprintf( esc_html__( 'The %s property is private and should not be accessed outside its class.', 'facebook-for-woocommerce' ), esc_html( $key ) ), 'x.x.x' );
+			return $this->$key;
+		}
+
+		return null;
+	}
+
 	public function exists() {
 		return ( $this->woo_product !== null && $this->woo_product !== false );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We defined some private properties to eliminate dynamic property warnings in #2606. In the recent dev call, the team discussed and decided to display a warning if the private properties are accessed outside its class. This PR displays the warning with help of `__get` and `_doing_it_wrong` functions.

Related to #2606.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Checkout this branch
2. Set WP_DEBUG and WP_DEBUG_LOG to true
3. Access private properties by adding the following block of code under admin_notices() function in facebook-for-woocommerce.php file
```
$wcprod = new WC_Product();
$accessprivate = new WC_Facebook_Product($wcprod->get_id());
print_r('Hello1');
print_r($accessprivate->fb_description);
print_r($accessprivate->gallery_urls);
print_r($accessprivate->fb_use_parent_image);
print_r($accessprivate->main_description);
print_r($accessprivate->sync_short_description); 
print_r('Hello2');
$fbcom = new WC_Facebookcommerce();
print_r($fbcom->configuration_detection);
print_r($fbcom->fb_categories);
print_r('Hello3');
$integ = new WC_Facebookcommerce_Integration($fbcom);
print_r($integ->events_tracker);
print_r($integ->messenger_chat);
print_r($integ->background_processor);
print_r('Hello4');
print_r((new WooCommerce\Facebook\Admin)->product_sets);
print_r('Hello5');
print_r((new WooCommerce\Facebook\ProductSync\ProductValidator($integ, $wcprod))->facebook_product);
print_r('Hello6');
print_r((new WC_Facebookcommerce_Background_Process($integ))->commerce);
print_r('Hello7');
$enh = new WooCommerce\Facebook\Admin\Enhanced_Catalog_Attribute_Fields("Page");
print_r($enh->page_type);
print_r($enh->term);
print_r($enh->product);
print_r($enh->category_handler);
print_r('Hello8');
$settings = [
	'fb_page_id' => 'abc123',
	'facebook_jssdk_version' => '1.2.3',
];
$messen = new WC_Facebookcommerce_MessengerChat($settings);
print_r($messen->page_id);
print_r($messen->jssdk_version);
```
5. Verify you see the PHP notices in debug.log and in header of admin page. 

```
[17-Aug-2023 14:49:40 UTC] PHP Notice:  Function __get was called <strong>incorrectly</strong>. The fb_description property is private and should not be accessed outside its class. Please see <a href="https://wordpress.org/documentation/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version x.x.x.) in /var/www/html/wp-includes/functions.php on line 5905
[17-Aug-2023 14:49:40 UTC] PHP Notice:  Function __get was called <strong>incorrectly</strong>. The gallery_urls property is private and should not be accessed outside its class. Please see <a href="https://wordpress.org/documentation/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version x.x.x.) in /var/www/html/wp-includes/functions.php on line 5905
```

### Changelog entry

> Tweak - Displays warnings on accessing private/protected properties incorrectly.
