### PR TITLE
Fixed AddToCart duplication when other plugins clone cart

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -563,6 +563,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
+			$cart = WC()->cart;
+			// Check if we're dealing with cloned cart
+			if (!isset($cart->cart_contents[ $cart_item_key ])) {
+				return;
+			}
+
 			$product = wc_get_product( $variation_id ?: $product_id );
 
 			// bail if invalid product or error

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -565,7 +565,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			$cart = WC()->cart;
 			// Check if we're dealing with cloned cart
-			if (!isset($cart->cart_contents[ $cart_item_key ])) {
+			if ( ! isset( $cart->cart_contents[ $cart_item_key ] ) ) {
 				return;
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Other plugins often clone Woocommerce cart to do various "on the fly" calculations and now this causes duplication of the AddToCart server events.

This fixes it once and forever ;)

fixes #2544


### Screenshots:
How it looks before fix:
<img width="2012" alt="Screenshot 2023-09-16 at 2 19 38 PM" src="https://github.com/woocommerce/facebook-for-woocommerce/assets/1125900/739c6ddf-d764-4125-a836-ff1406bb91b1">



### Detailed test instructions:
#### How to reproduce in tests
```
$cart = clone WC()->cart;
$cart->add_to_cart( $product_id, $qty, $variation_id, $variation )
```

#### Real-life test
Install this plugin and `woo-stripe-payment` as an example. Observe the following stack traces:

```
2023-09-16T17:51:06+00:00 DEBUG AddToCart: #0 /wp-includes/class-wp-hook.php(312): WC_Facebookcommerce_EventsTracker->inject_add_to_cart_event()
#1 /wp-includes/class-wp-hook.php(334): WP_Hook->apply_filters()
#2 /wp-includes/plugin.php(517): WP_Hook->do_action()
#3 /wp-content/plugins/woocommerce/includes/class-wc-cart.php(1279): do_action()
#4 /wp-content/plugins/woo-stripe-payment/includes/controllers/class-wc-stripe-controller-cart.php(275): WC_Cart->add_to_cart()
#5 /wp-includes/rest-api/class-wp-rest-server.php(1188): WC_Stripe_Controller_Cart->cart_calculation()
#6 /wp-includes/rest-api/class-wp-rest-server.php(1035): WP_REST_Server->respond_to_request()
#7 /wp-includes/rest-api/class-wp-rest-server.php(447): WP_REST_Server->dispatch()
#8 /wp-includes/rest-api.php(418): WP_REST_Server->serve_request()
#9 /wp-content/plugins/woo-stripe-payment/includes/class-wc-stripe-rest-api.php(159): rest_api_loaded()
#10 /wp-includes/class-wp-hook.php(310): WC_Stripe_Rest_API->process_frontend_request()
#11 /wp-includes/class-wp-hook.php(334): WP_Hook->apply_filters()
#12 /wp-includes/plugin.php(517): WP_Hook->do_action()
#13 /wp-content/plugins/woocommerce/includes/class-wc-ajax.php(96): do_action()
#14 /wp-includes/class-wp-hook.php(310): WC_AJAX::do_wc_ajax()
#15 /wp-includes/class-wp-hook.php(334): WP_Hook->apply_filters()
#16 /wp-includes/plugin.php(517): WP_Hook->do_action()
#17 /wp-includes/template-loader.php(13): do_action()
#18 /wp-blog-header.php(19): require_once('/var/www/html/u...')
#19 /index.php(17): require('/var/www/html/u...')
#20 {main}
```

### Changelog entry

> Fix - AddToCart duplication when other plugins clone cart