### PR TITLE
Add filter for FB product image size.

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -233,7 +233,7 @@ class WC_Facebook_Product {
 		 *
 		 * @param string $size The image size. e.g. 'full', 'medium', 'thumbnail'.
 		 */
-		$image_size 			  = apply_filters( 'facebook_for_woocommerce_fb_product_image_size', 'full' );
+		$image_size               = apply_filters( 'facebook_for_woocommerce_fb_product_image_size', 'full' );
 		$product_image_url        = wp_get_attachment_image_url( $this->woo_product->get_image_id(), $image_size ); ;
 		$parent_product_image_url = null;
 		$custom_image_url         = $this->woo_product->get_meta( self::FB_PRODUCT_IMAGE );

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -226,7 +226,15 @@ class WC_Facebook_Product {
 
 		$image_urls = array();
 
-		$product_image_url        = wp_get_attachment_url( $this->woo_product->get_image_id() );
+		/**
+		 * Filters the FB product image size.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string $size The image size. e.g. 'full', 'medium', 'thumbnail'.
+		 */
+		$image_size 			  = apply_filters( 'facebook_for_woocommerce_fb_product_image_size', 'full' );
+		$product_image_url        = wp_get_attachment_image_url( $this->woo_product->get_image_id(), $image_size ); ;
 		$parent_product_image_url = null;
 		$custom_image_url         = $this->woo_product->get_meta( self::FB_PRODUCT_IMAGE );
 
@@ -234,7 +242,7 @@ class WC_Facebook_Product {
 
 			if ( $parent_product = wc_get_product( $this->woo_product->get_parent_id() ) ) {
 
-				$parent_product_image_url = wp_get_attachment_url( $parent_product->get_image_id() );
+				$parent_product_image_url = wp_get_attachment_image_url( $parent_product->get_image_id(), $image_size );
 			}
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a filter to update the image image size sent to FB.

Closes #2503.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1. This assumes you have FB for WooCommerce connected to your FB catalog.
2. Checkout this branch
3.  Use the `facebook_for_woocommerce_fb_product_image_size` filter as follow:
```
add_filter('facebook_for_woocommerce_fb_product_image_size', function () {
	return 'thumbnail';
});

```
4. Create/update a product and sync the change to your FB catalog, verify that the image uploaded is the correct size.


### Changelog entry

> Add - Filter the size of the  Facebook product image.
