### PR TITLE
Release 3.0.34 - merge release into trunk

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 3.0.34 - 2023-10-05 =
+* Add - Filter the size of the Facebook product image.
+* Fix - AddToCart duplication when other plugins clone cart.
+* Tweak - WC 8.2 compatibility.
+
 = 3.0.33 - 2023-09-05 =
 * Dev - Updates PHP unit tests matrix in git workflow and versions of dev dependencies in composer.
 * Fix - Issues with Facebook Sync status display while product filtering in admin.

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,12 +11,12 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.0.33
+ * Version: 3.0.34
  * Requires at least: 5.6
  * Text Domain: facebook-for-woocommerce
  * Tested up to: 6.3
  * WC requires at least: 5.4
- * WC tested up to: 8.1
+ * WC tested up to: 8.2
  *
  * @package FacebookCommerce
  */
@@ -44,7 +44,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '3.0.33'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '3.0.34'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.4.0';

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -229,7 +229,7 @@ class WC_Facebook_Product {
 		/**
 		 * Filters the FB product image size.
 		 *
-		 * @since x.x.x
+		 * @since 3.0.34
 		 *
 		 * @param string $size The image size. e.g. 'full', 'medium', 'thumbnail'.
 		 */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.0.33",
+  "version": "3.0.34",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.0.33",
+  "version": "3.0.34",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -39,6 +39,11 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
+= 3.0.34 - 2023-10-05 =
+* Add - Filter the size of the Facebook product image.
+* Fix - AddToCart duplication when other plugins clone cart.
+* Tweak - WC 8.2 compatibility.
+
 = 3.0.33 - 2023-09-05 =
 * Dev - Updates PHP unit tests matrix in git workflow and versions of dev dependencies in composer.
 * Fix - Issues with Facebook Sync status display while product filtering in admin.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 6.3
-Stable tag: 3.0.33
+Stable tag: 3.0.34
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later


### PR DESCRIPTION
We have released https://github.com/woocommerce/facebook-for-woocommerce/releases/tag/3.0.34.

In this PR, we merge the release branch into trunk.