### PR TITLE
Update docs domain name to Woo.com

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woocommerce.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woo.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/.github/ISSUE_TEMPLATE/1-Bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-Bug-report.md
@@ -26,7 +26,7 @@ assignees: ''
 <!-- Describe what should happen instead of what is currently happening. -->
 
 ## 🗃 Logs
-<!-- Please include logs, details about your WordPress environment (from [**WooCommerce Status Report**](https://docs.woocommerce.com/document/understanding-the-woocommerce-system-status-report/)), and any other relevant information about your site. -->
+<!-- Please include logs, details about your WordPress environment (from [**WooCommerce Status Report**](https://woo.com/document/understanding-the-woocommerce-system-status-report/)), and any other relevant information about your site. -->
 
 <details>
 	<!-- paste WooCommerce Status Report or logs here -->

--- a/.github/ISSUE_TEMPLATE/2-Support-question.md
+++ b/.github/ISSUE_TEMPLATE/2-Support-question.md
@@ -11,7 +11,7 @@ We’re happy to help with this question! Our support team works in our help des
 
 ## 📖 Read documentation
 
-The [Facebook for WooCommerce documentation](https://docs.woocommerce.com/document/facebook-for-woocommerce/) will help you set up the extension, use its features, and answer frequently asked questions. 
+The [Facebook for WooCommerce documentation](https://woo.com/document/facebook-for-woocommerce/) will help you set up the extension, use its features, and answer frequently asked questions. 
 
 ## 👩‍💻 Check forums
 

--- a/.github/ISSUE_TEMPLATE/2-Support-question.md
+++ b/.github/ISSUE_TEMPLATE/2-Support-question.md
@@ -19,4 +19,4 @@ The [Facebook for WooCommerce forums](https://wordpress.org/support/plugin/faceb
 
 ## 🗣 Contact support
 
-Our support team would be happy to help answer your questions! [Click here to get in touch with support.](https://woocommerce.com/my-account/create-a-ticket/)
+Our support team would be happy to help answer your questions! [Click here to get in touch with support.](https://woo.com/my-account/contact-support/)

--- a/.github/ISSUE_TEMPLATE/3-Feedback-idea.md
+++ b/.github/ISSUE_TEMPLATE/3-Feedback-idea.md
@@ -9,9 +9,9 @@ assignees: ''
 
 ## Feature requests
 
-If you have an idea for how we could improve Facebook for WooCommerce, please let us know by [contacting our support team](https://woocommerce.com/my-account/create-a-ticket/)! We'd love to learn more about the problem you're facing and how Facebook for WooCommerce could help solve it.
+If you have an idea for how we could improve Facebook for WooCommerce, please let us know by [contacting our support team](https://woo.com/my-account/create-a-ticket/)! We'd love to learn more about the problem you're facing and how Facebook for WooCommerce could help solve it.
 
-Check the [Facebook for WooCommerce ideas board](https://ideas.woocommerce.com/forums/133476-woocommerce?category_id=398356) to see and vote on ideas.
+Check the [Facebook for WooCommerce feature requests](https://woo.com/feature-requests/facebook/) to see and vote on ideas.
 
 ## Developers
 

--- a/.github/ISSUE_TEMPLATE/3-Feedback-idea.md
+++ b/.github/ISSUE_TEMPLATE/3-Feedback-idea.md
@@ -9,7 +9,7 @@ assignees: ''
 
 ## Feature requests
 
-If you have an idea for how we could improve Facebook for WooCommerce, please let us know by [contacting our support team](https://woo.com/my-account/create-a-ticket/)! We'd love to learn more about the problem you're facing and how Facebook for WooCommerce could help solve it.
+If you have an idea for how we could improve Facebook for WooCommerce, please let us know by [contacting our support team](https://woo.com/my-account/contact-support/)! We'd love to learn more about the problem you're facing and how Facebook for WooCommerce could help solve it.
 
 Check the [Facebook for WooCommerce feature requests](https://woo.com/feature-requests/facebook/) to see and vote on ideas.
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -52,5 +52,5 @@ jobs:
                     1. [ ] Wait for a while, and the zip file should be able to download from: [https://downloads.wordpress.org/plugin/facebook-for-woocommerce.x.x.x.zip](https://downloads.wordpress.org/plugin/facebook-for-woocommerce.x.x.x.zip)
             1. [ ] Close the release milestone.
             1. [ ] Publish any documentation updates relating to the release:
-               - [ ] [User documentation](https://docs.woocommerce.com/document/facebook-for-woocommerce)
-               - [ ] [Any changes to privacy/tracking](https://woocommerce.com/usage-tracking/)
+               - [ ] [User documentation](https://woo.com/document/facebook-for-woocommerce)
+               - [ ] [Any changes to privacy/tracking](https://woo.com/usage-tracking/)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the development repository for the Facebook for WooCommerce plugin.
 
 - [WooCommerce.com product page](https://woocommerce.com/products/facebook)
 - [WordPress.org plugin page](https://wordpress.org/plugins/facebook-for-woocommerce/)
-- [User documentation](https://docs.woocommerce.com/document/facebook-for-woocommerce)
+- [User documentation](https://woo.com/document/facebook-for-woocommerce)
 
 ## Support
 The best place to get support is the [WordPress.org Facebook for WooCommerce forum](https://wordpress.org/support/plugin/facebook-for-woocommerce/).

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 This is the development repository for the Facebook for WooCommerce plugin.
 
-- [WooCommerce.com product page](https://woocommerce.com/products/facebook)
+- [Woo.com product page](https://woo.com/products/facebook)
 - [WordPress.org plugin page](https://wordpress.org/plugins/facebook-for-woocommerce/)
 - [User documentation](https://woo.com/document/facebook-for-woocommerce)
 
 ## Support
 The best place to get support is the [WordPress.org Facebook for WooCommerce forum](https://wordpress.org/support/plugin/facebook-for-woocommerce/).
 
-If you have a WooCommerce.com account, you can [start a chat or open a ticket on WooCommerce.com](https://woocommerce.com/my-account/create-a-ticket/).
+If you have a Woo.com account, you can [search for help or submit a help request on Woo.com](https://woo.com/my-account/contact-support/).
 
 ### Logging
 The plugin offers logging that can help debug various problems. You can enable debug mode in the main plugin settings panel under the `Enable debug mode` section.

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -710,7 +710,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	 * @return string
 	 */
 	public function get_documentation_url() {
-		return 'https://docs.woocommerce.com/document/facebook-for-woocommerce/';
+		return 'https://woo.com/document/facebook-for-woocommerce/';
 	}
 
 

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -734,7 +734,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	 * @return string
 	 */
 	public function get_sales_page_url() {
-		return 'https://woocommerce.com/products/facebook/';
+		return 'https://woo.com/products/facebook/';
 	}
 
 

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class for adding diagnostic info to WooCommerce Tracker snapshot.
  *
- * See https://woocommerce.com/usage-tracking/ for more information.
+ * See https://woo.com/usage-tracking/ for more information.
  *
  * @since 2.3.4
  */

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "facebook-for-woocommerce",
   "version": "3.1.2",
   "author": "Facebook",
-  "homepage": "https://woocommerce.com/products/facebook/",
+  "homepage": "https://woo.com/products/facebook/",
   "license": "GPL-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update the old WooCommerce.com → the new Woo.com in several places, especially for documentation links (pcShBQ-1cw-p2).

Also updates some text and URLs regarding support requests.

Also changes the `homepage` in `package.json`, shouldn't be an issue should it?
**Note**: I wonder if we should also change the `author` there to Woo / WooCommerce.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. No real code changes (only in `get_sales_page_url()` which is never actually used in favor of the `get_reviews_url()` value; [base method](https://github.com/woocommerce/facebook-for-woocommerce/blob/39793867e27e0a30f02243e85ccfaf54d51af6fd/includes/Framework/Plugin.php#L734-L736) & [child overwriting method](https://github.com/woocommerce/facebook-for-woocommerce/blob/76ab385f0d98378a23092c7fcc9bec476648e013/class-wc-facebookcommerce.php#L748-L750)).
2. Double check all new URLs actually go to a page (connect.woocommerce.com doesn't seem to be redirecting, for example).


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Doc - Use new Woo.com domain.