### PR TITLE
Remove unneeded "After deploy" steps in `prepare-release.yml` file

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,5 +1,5 @@
-name: 'Prepare New Release'
-run-name:  Prepare New Release `${{ github.event.inputs.type }}/${{ github.event.inputs.version }}` from by @${{ github.actor }}
+name: "Prepare New Release"
+run-name: Prepare New Release `${{ github.event.inputs.type }}/${{ github.event.inputs.version }}` from by @${{ github.actor }}
 
 # **What it does**: Does release preparation: creates the release branch and the PR with a checklist.
 # **Why we have it**: To support devs automating a few manual steps and to leave a nice reference for consumers.
@@ -9,17 +9,16 @@ on:
     inputs:
       ## In the future we could infer that version from the changelog, or bump it via major|minor|patch.
       version:
-        description: 'Version number to be released'
+        description: "Version number to be released"
         required: true
       type:
-        description: 'Type of the release (release|hotfix)'
+        description: "Type of the release (release|hotfix)"
         required: true
-        default: 'release'
+        default: "release"
       wp-version:
-        description: 'WordPress tested up to'
+        description: "WordPress tested up to"
       wc-version:
-        description: 'WooCommerce tested up to'
-
+        description: "WooCommerce tested up to"
 
 jobs:
   PrepareRelease:
@@ -36,7 +35,7 @@ jobs:
           type: ${{ github.event.inputs.type }}
           wp-version: ${{ github.event.inputs.wp-version }}
           wc-version: ${{ github.event.inputs.wc-version }}
-          main-branch: 'trunk'
+          main-branch: "trunk"
           post-steps: |
             ### After deploy
             1. [ ] Confirm the release deployed correctly to [WPORG](https://wordpress.org/plugins/facebook-for-woocommerce/).

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -39,10 +39,6 @@ jobs:
           main-branch: 'trunk'
           post-steps: |
             ### After deploy
-            1. [ ] Update documentation
-               - [ ] Publish any new required docs
-               - [ ] Update triggers/rules/actions listing pages
-            1. [ ] Mark related ideas complete on ideas board
             1. [ ] Confirm the release deployed correctly to [WPORG](https://wordpress.org/plugins/facebook-for-woocommerce/).
                - [ ] Ensure you can download and install the latest release from WPORG and WCCOM.
                - [ ] We've had an issue where the release tag (e.g. 2.6.1) wasn't present in the svn `tags/` folder.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In PR https://github.com/woocommerce/grow/pull/89, there is an update to the prepare-release.yml file. This made some of our custom "after deploy" post steps redundant.

In this PR, we remove the custom "after deploy" post steps in our extension repo.

### Detailed test instructions:

We can test this in the next release by following the steps here: https://github.com/woocommerce/facebook-for-woocommerce/wiki/Build-&-Release#release-basics

There should not be redundant or duplicated "After deploy" steps.

### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.

### Changelog entry

>
-->