### PR TITLE
Tweak - insert pixel-event-placeholder element via vanilla JS 

### DIFF
--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -161,10 +161,8 @@ class WC_Facebookcommerce_Pixel {
 				fbq( 'track', 'PageView', <?php echo json_encode( self::build_params( [], 'PageView' ), JSON_PRETTY_PRINT | JSON_FORCE_OBJECT ); ?> );
 
 				document.addEventListener( 'DOMContentLoaded', function() {
-					jQuery && jQuery( function( $ ) {
-						// Insert placeholder for events injected when a product is added to the cart through AJAX.
-						$( document.body ).append( '<div class=\"wc-facebook-pixel-event-placeholder\"></div>' );
-					} );
+					// Insert placeholder for events injected when a product is added to the cart through AJAX.
+					document.body.insertAdjacentHTML( 'beforeend', '<div class=\"wc-facebook-pixel-event-placeholder\"></div>' );
 				}, false );
 
 			</script>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Currently, this part of code is the only thing stopping me from completely dropping jQuery from the website. Other things can be solved via filters, but this small part can't and will always make the theme throw an exception.

I consider this a fairly non-breaking and transparent change that only enhances the range of supported themes. 


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:

1. Visit any page that has Pixel installed.
2. Check if the Pixel's placeholder tag is appended to the website's body.
3. Check console for any errors


### Changelog entry

> Tweak - insert pixel-event-placeholder element via vanilla JS 
