### PR TITLE
Remove mentions of shops.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,8 @@ Get the Official Facebook for WooCommerce plugin for two powerful ways to help g
 
 == Description ==
 
-This is the official Facebook for WooCommerce plugin that connects your WooCommerce website to Facebook. With this plugin, you can install the Facebook pixel, upload your online store catalog, enabling you to easily run dynamic ads.
+This is the official Facebook for WooCommerce plugin that connects your WooCommerce website to Facebook. With this plugin, you can install the Facebook pixel, and upload your online store catalog, enabling you to easily run dynamic ads.
+
 
 Marketing on Facebook helps your business build lasting relationships with people, find new customers, and increase sales for your online store. With this Facebook ad extension, reaching the people who matter most to your business is simple. This extension will track the results of your advertising across devices. It will also help you:
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ Get the Official Facebook for WooCommerce plugin for two powerful ways to help g
 
 == Description ==
 
-This is the official Facebook for WooCommerce plugin that connects your WooCommerce website to Facebook. With this plugin, you can install the Facebook pixel, upload your online store catalog, and create a shop on your Facebook page, enabling you to easily run dynamic ads.
+This is the official Facebook for WooCommerce plugin that connects your WooCommerce website to Facebook. With this plugin, you can install the Facebook pixel, upload your online store catalog, enabling you to easily run dynamic ads.
 
 Marketing on Facebook helps your business build lasting relationships with people, find new customers, and increase sales for your online store. With this Facebook ad extension, reaching the people who matter most to your business is simple. This extension will track the results of your advertising across devices. It will also help you:
 


### PR DESCRIPTION
In this PR we change the description and don't mention FB shops anymore. 

We want to remove this bit:
<img width="654" alt="image" src="https://github.com/woocommerce/facebook-for-woocommerce/assets/17271089/a58f307b-94ef-497f-b391-3f6d212a0067">


### Additional details:
This is just a description change. No code is affected. 

Tweak - Update the readme to reflect that shops are not supported.
