### PR TITLE
Check if this is WooCommerce product before processing

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1629,16 +1629,18 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		$fb_product     = new \WC_Facebook_Product( $post->ID );
 		$fb_product_item_id  = null;
 		$should_sync    = true;
-		$no_sync_reason = '';
 
-		if ( $fb_product->woo_product instanceof \WC_Product ) {
-			try {
-				facebook_for_woocommerce()->get_product_sync_validator( $fb_product->woo_product )->validate();
-			} catch ( \Exception $e ) {
-				$should_sync    = false;
-				$no_sync_reason = $e->getMessage();
-			}
+		// Bail if this is not a WooCommerce product.
+		if ( ! $fb_product->woo_product instanceof \WC_Product ) {
+			return;
 		}
+
+		try {
+			facebook_for_woocommerce()->get_product_sync_validator( $fb_product->woo_product )->validate();
+		} catch ( \Exception $e ) {
+			$should_sync    = false;
+		}
+
 		if( $should_sync ) {
 			if ( $fb_product->woo_product->is_type( 'variable' ) ) {
 				$fb_product_item_id = $this->get_product_fbid( self::FB_PRODUCT_GROUP_ID, $post->ID, $fb_product->woo_product );
@@ -1646,6 +1648,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 				$fb_product_item_id = $this->get_product_fbid( self::FB_PRODUCT_ITEM_ID, $post->ID, $fb_product->woo_product );
 			}
 		}
+
 		if ( $fb_product_item_id ) {
 			$this->display_success_message(
 				'Created product  <a href="https://facebook.com/' . $fb_product_item_id .

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -315,7 +315,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 				add_action( 'add_meta_boxes', 'WooCommerce\Facebook\Admin\Product_Sync_Meta_Box::register', 10, 1 );
 
-				add_action( 'add_meta_boxes', [ $this, 'display_batch_api_completed' ], 10, 2 );
+				add_action( 'add_meta_boxes_product', [ $this, 'display_batch_api_completed' ], 10, 2 );
 
 				add_action(
 					'wp_ajax_ajax_fb_toggle_visibility',
@@ -1614,21 +1614,20 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 
 	/**
 	 * Displays Batch API completed message on simple_product_publish.
-	 * This is called by the hook `add_meta_boxes` because that is sufficient time
+	 * This is called by the hook `add_meta_boxes_product` because that is sufficient time
 	 * to retrieve product_item_id for the product item created via batch API.
 	 *
 	 * Some sanity checks are added before displaying the message after publish
 	 *  - product_item_id : if exists, means product was created else not and don't display
 	 *  - should_sync: Don't display if the product is not supposed to be synced.
 	 *
-	 * @param string $post_type Wordpress Post type
 	 * @param WP_Post $post Wordpress Post
 	 * @return void
 	 */
-	public function display_batch_api_completed( string $post_type, WP_Post $post ) {
-		$fb_product     = new \WC_Facebook_Product( $post->ID );
-		$fb_product_item_id  = null;
-		$should_sync    = true;
+	public function display_batch_api_completed( $post ) {
+		$fb_product         = new \WC_Facebook_Product( $post->ID );
+		$fb_product_item_id = null;
+		$should_sync        = true;
 
 		// Bail if this is not a WooCommerce product.
 		if ( ! $fb_product->woo_product instanceof \WC_Product ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2672 .

Check if we are dealing with WooCommerce product before processing.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

I can't reproduce the 2672 so really hard to tell.

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Fatal Error on order screens.
