### PR TITLE
Release/3.1.10 - `trunk` to `develop`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 3.1.8 - 2024-01-03 =
+* Fix - Fatal Error on order screens.
+
 = 3.1.7 - 2024-01-03 =
 * Add - Create/Update products sync to facebook with Batch API.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 3.1.10 - 2024-02-14 =
+* Tweak - WC 8.6 compatibility.
+
 = 3.1.9 - 2024-01-09 =
 * Tweak - Changed minimum WC version to 6.4.
 * Tweak - WC 8.5 compatibility.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 3.1.9 - 2024-01-09 =
+* Tweak - Changed minimum WC version to 6.4.
+* Tweak - WC 8.5 compatibility.
+
 = 3.1.8 - 2024-01-03 =
 * Fix - Fatal Error on order screens.
 

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,12 +11,12 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.1.9
+ * Version: 3.1.10
  * Requires at least: 5.6
  * Text Domain: facebook-for-woocommerce
  * Tested up to: 6.4
  * WC requires at least: 6.4
- * WC tested up to: 8.5
+ * WC tested up to: 8.6
  *
  * @package FacebookCommerce
  */
@@ -44,7 +44,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '3.1.9'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '3.1.10'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.4.0';

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,12 +11,12 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.1.8
+ * Version: 3.1.9
  * Requires at least: 5.6
  * Text Domain: facebook-for-woocommerce
  * Tested up to: 6.4
- * WC requires at least: 5.4
- * WC tested up to: 8.3
+ * WC requires at least: 6.4
+ * WC tested up to: 8.5
  *
  * @package FacebookCommerce
  */
@@ -44,7 +44,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '3.1.8'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '3.1.9'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.4.0';

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,7 +11,7 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.1.7
+ * Version: 3.1.8
  * Requires at least: 5.6
  * Text Domain: facebook-for-woocommerce
  * Tested up to: 6.4
@@ -44,7 +44,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '3.1.7'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '3.1.8'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.4.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.1.9",
+  "version": "3.1.10",
   "author": "Facebook",
   "homepage": "https://woo.com/products/facebook/",
   "license": "GPL-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.1.8",
+  "version": "3.1.9",
   "author": "Facebook",
   "homepage": "https://woo.com/products/facebook/",
   "license": "GPL-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.1.7",
+  "version": "3.1.8",
   "author": "Facebook",
   "homepage": "https://woo.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 6.4
-Stable tag: 3.1.7
+Stable tag: 3.1.8
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later
@@ -39,6 +39,9 @@ When opening a bug on GitHub, please give us as many details as possible.
 * Current version of Facebook-for-WooCommerce, WooCommerce, Wordpress, PHP
 
 == Changelog ==
+
+= 3.1.8 - 2024-01-03 =
+* Fix - Fatal Error on order screens.
 
 = 3.1.7 - 2024-01-03 =
 * Add - Create/Update products sync to facebook with Batch API.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 6.4
-Stable tag: 3.1.9
+Stable tag: 3.1.10
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later
@@ -39,6 +39,9 @@ When opening a bug on GitHub, please give us as many details as possible.
 * Current version of Facebook-for-WooCommerce, WooCommerce, Wordpress, PHP
 
 == Changelog ==
+
+= 3.1.10 - 2024-02-14 =
+* Tweak - WC 8.6 compatibility.
 
 = 3.1.9 - 2024-01-09 =
 * Tweak - Changed minimum WC version to 6.4.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, shop, catalog, advertise, pixel, product
 Requires at least: 4.4
 Tested up to: 6.4
-Stable tag: 3.1.8
+Stable tag: 3.1.9
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later
@@ -39,6 +39,10 @@ When opening a bug on GitHub, please give us as many details as possible.
 * Current version of Facebook-for-WooCommerce, WooCommerce, Wordpress, PHP
 
 == Changelog ==
+
+= 3.1.9 - 2024-01-09 =
+* Tweak - Changed minimum WC version to 6.4.
+* Tweak - WC 8.5 compatibility.
 
 = 3.1.8 - 2024-01-03 =
 * Fix - Fatal Error on order screens.


### PR DESCRIPTION
This PR merges the changes from [release v3.1.10](https://github.com/woocommerce/facebook-for-woocommerce/releases/tag/3.1.10) back into `develop`.