### PR TITLE
Add video syncs to fbproduct

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -291,13 +291,15 @@ class WC_Facebook_Product {
 			return $video_urls;
 		}
 		foreach ( $attached_videos as $video ) {
-			$url = $video->guid;
-			array_push(
-				$video_urls,
-				array(
-					'url' => $url,
-				)
-			);
+			$url = wp_get_attachment_url( $video->ID );
+			if ( $url ) {
+				array_push(
+					$video_urls,
+					array(
+						'url' => $url,
+					)
+				);
+			}
         }
 
 		return $video_urls;

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -277,6 +277,33 @@ class WC_Facebook_Product {
 		return $image_urls;
 	}
 
+	/**
+	 * Gets a list of video URLs to use for this product in Facebook sync.
+	 *
+	 * @return array
+	 */
+	public function get_all_video_urls() {
+
+		$video_urls = array();
+
+		$attached_videos = get_attached_media( 'video', $this->id );
+		if ( empty( $attached_videos ) ) {
+			return $video_urls;
+		}
+		foreach ( $attached_videos as $video ) {
+			$url = $video->guid;
+			array_push(
+				$video_urls,
+				array(
+					'url' => $url,
+				)
+			);
+        }
+
+		return $video_urls;
+	}
+
+
 
 	/**
 	 * Gets the list of additional image URLs for the product from the complete list of image URLs.
@@ -591,6 +618,8 @@ class WC_Facebook_Product {
 		}
 		$image_urls = $this->get_all_image_urls();
 
+		$video_urls = $this->get_all_video_urls();
+
 		// Replace WordPress sanitization's ampersand with a real ampersand.
 		$product_url = str_replace(
 			'&amp%3B',
@@ -633,6 +662,9 @@ class WC_Facebook_Product {
 			);
 			$product_data   = $this->add_sale_price( $product_data, true );
 			$gpc_field_name = 'google_product_category';
+			if ( ! empty( $video_urls ) ) {
+				$product_data['video'] = $video_urls;
+			}
 		} else {
 			$product_data = array(
 				'name'                  => WC_Facebookcommerce_Utils::clean_string( $this->get_title() ),
@@ -659,6 +691,10 @@ class WC_Facebook_Product {
 				'availability'          => $this->is_in_stock() ? 'in stock' : 'out of stock',
 				'visibility'            => Products::is_product_visible( $this->woo_product ) ? \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_VISIBLE : \WC_Facebookcommerce_Integration::FB_SHOP_PRODUCT_HIDDEN,
 			);
+
+			if ( self::PRODUCT_PREP_TYPE_NORMAL !== $type_to_prepare_for && ! empty( $video_urls ) ) {
+				$product_data['video'] = $video_urls;
+			}
 			$product_data   = $this->add_sale_price( $product_data );
 			$gpc_field_name = 'category';
 		}//end if


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Along with syncing images, I would also like to sync videos to the facebook catalog.
Although woo-commerce natively doesn't support product videos, but you can insert/attach a product video in the description.


Currently the video syncing is only supported by [batch-api](https://developers.facebook.com/docs/marketing-api/reference/product-catalog/items_batch/) / feed upload so this has to be merged after https://github.com/woocommerce/facebook-for-woocommerce/pull/2654

This pull requests adds the following
* Extracts video links from product description (no native support for video / video-gallerys)

<!--- Optional --->

### 2 sets of flows are affected
* items batch and feed support flow support

### Tests
* Integration tests are updated and CI passing in forked repo - https://github.com/rahulraina7/facebook-for-woocommerce/actions/runs/6556265345
* **E2E Tests**
   - Single Product Update
       * Go to individual product. Upload a video in description
       * Click Publish->Update
       * Outcome : Video Synced to facebook
   - Batch API Update
      * Disconnect from facebook
      * Connect back and create a new catalog
      * Products are synced with batch API flow
      * Outcomes : New catalog created on facebook, with Videos synced at product level