### PR TITLE
Update test bootstrap.php to resolve notice

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,7 +41,7 @@ tests_add_filter( 'muplugins_loaded', function () {
 	load_plugins();
 } );
 
-tests_add_filter( 'setup_theme', function () {
+tests_add_filter( 'init', function () {
 	install_woocommerce();
 } );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates  bootstrap.php to run install_woocommerce on the init hook to resolve the notice.


Closes #2669.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:

1. Confirm tests pass without triggering a notice using the latest version of WooCommerce


### Changelog entry

> Tweak - Test environment setup to resolve notice
