### PR TITLE
Update middleware URL.

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -34,13 +34,13 @@ class Connection {
 	const OAUTH_URL = 'https://facebook.com/dialog/oauth';
 
 	/** @var string WooCommerce connection proxy URL */
-	const PROXY_URL = 'https://connect.woocommerce.com/auth/facebook/';
+	const PROXY_URL = 'https://api.woocommerce.com/integrations/auth/facebook/';
 
 	/** @var string WooCommerce connection for APP Store login URL */
-	const APP_STORE_LOGIN_URL = 'https://connect.woocommerce.com/app-store-login/facebook/';
+	const APP_STORE_LOGIN_URL = 'https://api.woocommerce.com/integrations/app-store-login/facebook/';
 
 	/** @var string WooCommerce connection authentication URL */
-	const CONNECTION_AUTHENTICATION_URL = 'https://connect.woocommerce.com/auth/facebookcommerce/';
+	const CONNECTION_AUTHENTICATION_URL = 'https://api.woocommerce.com/integrations/auth/facebookcommerce/';
 
 	/** @var string the Standard Auth type */
 	const AUTH_TYPE_STANDARD = 'standard';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The connect.woocommerce.com server is due to be retired. The api.woocommerce.com server now provides the connect service. The base URL will now be api.woocommerce.com/integrations. All other endpoints should now be accessible from the base URL.

Closes #2694 .


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

- [ ] Complete the Facebook for WooCommerce smoke tests with no issues: https://github.com/woocommerce/facebook-for-woocommerce/wiki/Smoke-tests


### Changelog entry

> Tweak - Replace the middleware URL from connect.woocommerce.com to api.woocommerce.com/integrations
