### PR TITLE
Fix deprecation warnings with PHP 8.2.

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -1693,7 +1693,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 						include_once 'includes/fbproductfeed.php';
 					}
 
-					$this->fbproductfeed = new \WC_Facebook_Product_Feed( $this->get_product_catalog_id() );
+					$this->fbproductfeed = new \WC_Facebook_Product_Feed();
 				}
 
 				$status = $this->fbproductfeed->is_upload_complete( $this->settings );

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -191,6 +191,9 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var WC_Facebookcommerce_Background_Process instance. */
 	private $background_processor;
 
+	/** @var WC_Facebook_Product_Feed instance. */
+	private $fbproductfeed;
+
 	/**
 	 * Init and hook in the integration.
 	 *

--- a/includes/Admin/Tasks/Setup.php
+++ b/includes/Admin/Tasks/Setup.php
@@ -78,7 +78,7 @@ class Setup extends Task {
 	 * @return string
 	 */
 	public function get_parent_id() {
-		if ( is_callable( 'parent::get_parent_id' ) ) {
+		if ( method_exists( get_parent_class( $this ), 'get_parent_id' ) ) {
 			return parent::get_parent_id();
 		}
 

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -34,19 +34,6 @@ class WC_Facebook_Product_Feed {
 
 	private $has_default_product_count = 0;
 	private $no_default_product_count  = 0;
-	private $facebook_catalog_id;
-	private $feed_id;
-
-	/**
-	 * WC_Facebook_Product_Feed constructor.
-	 *
-	 * @param string|null $facebook_catalog_id Facebook catalog ID, if any
-	 * @param string|null $feed_id Facebook feed ID, if any
-	 */
-	public function __construct( $facebook_catalog_id = null, $feed_id = null ) {
-		$this->facebook_catalog_id = $facebook_catalog_id;
-		$this->feed_id             = $feed_id;
-	}
 
 	/**
 	 * Generates the product catalog feed.

--- a/includes/fbproductfeed.php
+++ b/includes/fbproductfeed.php
@@ -34,6 +34,8 @@ class WC_Facebook_Product_Feed {
 
 	private $has_default_product_count = 0;
 	private $no_default_product_count  = 0;
+	private $facebook_catalog_id;
+	private $feed_id;
 
 	/**
 	 * WC_Facebook_Product_Feed constructor.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Fixes deprecation warnings with PHP 8.2 and above.

Closes #2635.


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:

1. Enable debug and debug logging.
2. Activate and connect Facebook for WooCommerce
3. Navigate to Marketing > Facebook for WooCommerce. There should be no deprecation warnings.
4. Navigate to Tools > Scheduled Actions
5. Run the Pending wc_facebook_regenerate_feed action. There should be no deprecation warnings.


### Changelog entry

> Fix - Deprecation warnings with PHP 8.2.