### PR TITLE
Check if condition is set before setting a default value.

### DIFF
--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -729,8 +729,14 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		 * @return array
 		 */
 		public static function normalize_product_data_for_items_batch( $data ) {
-			// Allowed values are 'refurbished', 'used', and 'new', but the plugin has always used the latter.
-			$data['condition'] = 'new';
+			/*
+			 * To avoid overriding the condition value, we check if the value is set or is not one of
+			 * the allowed values before setting it to 'new'. Allowed values are 'refurbished', 'used', and 'new'.
+			 */
+			if ( ! isset( $data['condition'] ) || ! in_array( $data['condition'], [ 'refurbished', 'used', 'new' ], true ) ) {
+				$data['condition'] = 'new';
+			}
+
 			// Attributes other than size, color, pattern, or gender need to be included in the additional_variant_attributes field.
 			if ( isset( $data['custom_data'] ) && is_array( $data['custom_data'] ) ) {
 				$attributes = [];

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -733,7 +733,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 			 * To avoid overriding the condition value, we check if the value is set or is not one of
 			 * the allowed values before setting it to 'new'. Allowed values are 'refurbished', 'used', and 'new'.
 			 */
-			if ( ! isset( $data['condition'] ) || ! in_array( $data['condition'], [ 'refurbished', 'used', 'new' ], true ) ) {
+			if ( ! isset( $data['condition'] ) || ! in_array( $data['condition'], array( 'refurbished', 'used', 'new' ), true ) ) {
 				$data['condition'] = 'new';
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In #2700, the reporter uses the `facebook_for_woocommerce_integration_prepare_product` filter to modify the condition. but we default this value to `new` when we normalize the data. This PR adds a check to avoid defaulting the condition value to `new` if the value value has been set and is valid.

Closes #2700 .

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Use the `facebook_for_woocommerce_integration_prepare_product` filter to set a condition value in your theme function.php. And confirm the value isn't overriden

### Changelog entry

> Tweak - Check if condition is set before setting a default value.
