### PR TITLE
Add Messenger deprecation warning notices

### DIFF
--- a/assets/css/facebook.css
+++ b/assets/css/facebook.css
@@ -306,3 +306,7 @@
 	vertical-align: middle !important;
 	line-height: 28px !important;
 }
+
+div#message:has(a[href*="facebook_messenger_deprecation_warning"]) {
+	border-left-color: #dba617 !important;
+}

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -90,6 +90,7 @@ class WC_Facebook_Loader {
 
 		add_action( 'admin_notices', array( $this, 'add_plugin_notices' ) ); // admin_init is too early for the get_current_screen() function.
 		add_action( 'admin_notices', array( $this, 'admin_notices' ), 15 );
+		add_action( 'admin_notices', array( $this, 'maybe_show_messenger_deprecation_notice' ), 14 );
 
 		// If the environment check fails, initialize the plugin.
 		if ( $this->is_environment_compatible() ) {
@@ -292,6 +293,24 @@ class WC_Facebook_Loader {
 					)
 				);
 			}
+		}
+
+	}
+
+	/**
+	 * Adds warning notice that Facebook Messenger will be deprecated if the setting is enabled.
+	 *
+	 * @since x.x.x
+	 */
+	public function maybe_show_messenger_deprecation_notice() {
+		// Display the notice on the Facebook for WooCommerce settings pages (except Messenger settings, which has a static notice).
+		$notice_slug                   = 'facebook_messenger_deprecation_warning';
+		$is_facebook_admin             = isset( $_GET['page'] ) && 'wc-facebook' === $_GET['page'];
+		$is_messenger_settings         = isset( $_GET['tab'] ) && 'messenger' === $_GET['tab'];
+		$has_deprecation_notice_queued = class_exists( 'WC_Admin_Notices' ) && \WC_Admin_Notices::has_notice( $notice_slug );
+
+		if( $is_facebook_admin && ! $is_messenger_settings &&  $has_deprecation_notice_queued ) {
+			\WC_Admin_Notices::output_custom_notices();
 		}
 	}
 

--- a/includes/Admin/Settings_Screens/Messenger.php
+++ b/includes/Admin/Settings_Screens/Messenger.php
@@ -158,20 +158,29 @@ class Messenger extends Abstract_Settings_Screen {
 
 
 	/**
-	 * Gets the upcoming deprecation warning message.
+	 * Gets the upcoming deprecation warning notice.
 	 *
 	 * @since x.x.x
 	 *
 	 * @return string
 	 */
 	public function get_deprecation_warning() {
+		return '<div class="notice notice-warning"><p>' . self::get_deprecation_message() . '</p></div>';
+	}
+
+	/**
+	 * Gets the upcoming deprecation warning message with documentation link.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string
+	 */
+	public static function get_deprecation_message() {
 		return sprintf(
-			/* translators: Placeholders: %1$s - notice <div><p> tag, %2$s - <a> tag, %3$s - </a> tag, %4$s - </p></div> tags */
-			__( '%1$s%2$sMeta plans to discontinue the Chat Plugin%3$s, so Messenger will be removed from Facebook for WooCommerce by May, 2024. %4$s', 'facebook-for-woocommerce' ),
-			'<div class="notice notice-warning"><p>',
+			/* translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag */
+			__( '%1$sMeta plans to discontinue the Chat Plugin%2$s, so Messenger will be removed from Facebook for WooCommerce by May, 2024.', 'facebook-for-woocommerce' ),
 			'<a href="https://href.li/?https://www.facebook.com/business/help/1524587524402327" target="_blank">',
-			'</a>',
-			'</p></div>'
+			'</a>'
 		);
 	}
 

--- a/includes/Admin/Settings_Screens/Messenger.php
+++ b/includes/Admin/Settings_Screens/Messenger.php
@@ -33,9 +33,10 @@ class Messenger extends Abstract_Settings_Screen {
 	 * Connection constructor.
 	 */
 	public function __construct() {
-		$this->id    = self::ID;
-		$this->label = __( 'Messenger', 'facebook-for-woocommerce' );
-		$this->title = __( 'Messenger', 'facebook-for-woocommerce' );
+		$this->id          = self::ID;
+		$this->label       = __( 'Messenger', 'facebook-for-woocommerce' );
+		$this->title       = __( 'Messenger', 'facebook-for-woocommerce' );
+		$this->description = $this->get_deprecation_warning();
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 		add_action( 'woocommerce_admin_field_messenger_locale', array( $this, 'render_locale_field' ) );
 		add_action( 'woocommerce_admin_field_messenger_greeting', array( $this, 'render_greeting_field' ) );
@@ -153,6 +154,25 @@ class Messenger extends Abstract_Settings_Screen {
 		}
 		$settings[] = array( 'type' => 'sectionend' );
 		return $settings;
+	}
+
+
+	/**
+	 * Gets the upcoming deprecation warning message.
+	 *
+	 * @since x.x.x
+	 *
+	 * @return string
+	 */
+	public function get_deprecation_warning() {
+		return sprintf(
+			/* translators: Placeholders: %1$s - notice <div><p> tag, %2$s - <a> tag, %3$s - </a> tag, %4$s - </p></div> tags */
+			__( '%1$s%2$sMeta plans to discontinue the Chat Plugin%3$s, so Messenger will be removed from Facebook for WooCommerce by May, 2024. %4$s', 'facebook-for-woocommerce' ),
+			'<div class="notice notice-warning"><p>',
+			'<a href="https://href.li/?https://www.facebook.com/business/help/1524587524402327" target="_blank">',
+			'</a>',
+			'</p></div>'
+		);
 	}
 
 

--- a/includes/Admin/Settings_Screens/Messenger.php
+++ b/includes/Admin/Settings_Screens/Messenger.php
@@ -178,7 +178,7 @@ class Messenger extends Abstract_Settings_Screen {
 	public static function get_deprecation_message() {
 		return sprintf(
 			/* translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag */
-			__( '️<strong>Facebook for WooCommerce</strong>: %1$sMeta plans to discontinue the Chat Plugin%2$s; Messenger functionality will be removed by May, 2024.', 'facebook-for-woocommerce' ),
+			__( '️<strong>Facebook for WooCommerce</strong>: Since %1$sMeta plans to discontinue the Chat Plugin%2$s, the Messenger feature will be removed by May, 2024.', 'facebook-for-woocommerce' ),
 			'<a href="https://href.li/?https://www.facebook.com/business/help/1524587524402327" target="_blank">',
 			'</a>'
 		);

--- a/includes/Admin/Settings_Screens/Messenger.php
+++ b/includes/Admin/Settings_Screens/Messenger.php
@@ -179,7 +179,7 @@ class Messenger extends Abstract_Settings_Screen {
 		return sprintf(
 			/* translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag */
 			__( '️<strong>Facebook for WooCommerce</strong>: Since %1$sMeta plans to discontinue the Chat Plugin%2$s, the Messenger feature will be removed by May, 2024.', 'facebook-for-woocommerce' ),
-			'<a href="https://href.li/?https://www.facebook.com/business/help/1524587524402327" target="_blank">',
+			'<a href="https://www.facebook.com/business/help/1524587524402327" target="_blank">',
 			'</a>'
 		);
 	}

--- a/includes/Admin/Settings_Screens/Messenger.php
+++ b/includes/Admin/Settings_Screens/Messenger.php
@@ -178,7 +178,7 @@ class Messenger extends Abstract_Settings_Screen {
 	public static function get_deprecation_message() {
 		return sprintf(
 			/* translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag */
-			__( '%1$sMeta plans to discontinue the Chat Plugin%2$s, so Messenger will be removed from Facebook for WooCommerce by May, 2024.', 'facebook-for-woocommerce' ),
+			__( '️<strong>Facebook for WooCommerce</strong>: %1$sMeta plans to discontinue the Chat Plugin%2$s; Messenger functionality will be removed by May, 2024.', 'facebook-for-woocommerce' ),
 			'<a href="https://href.li/?https://www.facebook.com/business/help/1524587524402327" target="_blank">',
 			'</a>'
 		);

--- a/includes/Admin/Settings_Screens/Messenger.php
+++ b/includes/Admin/Settings_Screens/Messenger.php
@@ -179,7 +179,7 @@ class Messenger extends Abstract_Settings_Screen {
 		return sprintf(
 			/* translators: Placeholders: %1$s - <a> tag, %2$s - </a> tag */
 			__( '️<strong>Facebook for WooCommerce</strong>: Since %1$sMeta plans to discontinue the Chat Plugin%2$s, the Messenger feature will be removed by May, 2024.', 'facebook-for-woocommerce' ),
-			'<a href="https://www.facebook.com/business/help/1524587524402327" target="_blank">',
+			'<a href="https://www.facebook.com/business/help/1661027437357021" target="_blank">',
 			'</a>'
 		);
 	}

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -41,6 +41,7 @@ class Lifecycle extends Framework\Lifecycle {
 			'2.0.4',
 			'2.4.0',
 			'2.5.0',
+			'3.1.13'
 		);
 	}
 
@@ -306,5 +307,19 @@ class Lifecycle extends Framework\Lifecycle {
 		 * The Feed class will reschedule new generation with proper cadence.
 		 */
 		as_unschedule_all_actions( Products\Feed::GENERATE_FEED_ACTION );
+	}
+
+	protected function upgrade_to_3_1_13() {
+		$notice_slug          = 'facebook_messenger_deprecation_warning';
+		$is_messenger_enabled = get_option( \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER, 'no' ) === 'yes';
+
+		// Add Messenger deprecation notice.
+		if ( $is_messenger_enabled && class_exists( 'WC_Admin_Notices' ) ) {
+			\WC_Admin_Notices::add_custom_notice(
+				$notice_slug,
+				Admin\Settings_Screens\Messenger::get_deprecation_message()
+			);
+
+		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

[Meta will be sunsetting the Chat plugin on May 9, 2024](https://www.facebook.com/business/help/1524587524402327):
![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/228780/1bf5668e-d365-4952-ba8f-5a89870ce647)

This PR is part of a two step process to remove the corresponding Messenger feature from the Facebook for WooCommerce extension (pcTzPI-OC-p2).

Step 1 (this PR) is to display a warning notice to all Facebook for WooCommerce users that currently have the Messenger feature enabled, and to show the same warning notice on the Messenger settings page in case any users navigate there with the intention to enable the feature:
![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/228780/344ac4d5-7c59-4f77-93df-49b6d8661a47)

Step 2 (PR for late April) will fully remove the feature.

Related to ##2622.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

Yellow notice on Messenger settings page:
![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/228780/acfac517-0f34-4d18-a100-6c985ec9003c)

Yellow dismissible notice on Facebook for WooCommerce pages (added for users with the feature enabled):
![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/228780/5af46f17-4952-47b3-ab8d-5301436bf5f1)


Default theme color dismissible notice on wp-admin pages (added for users with the feature enabled):
![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/228780/6fc7344f-b110-4bed-a81b-e55fa7fdedb0)



### Detailed test instructions:
###### Fixed notice:
1. On the PR branch, navigate to Marketing > Facebook > Messenger tab.
2. Confirm that the yellow non-dismissible notice is available (regardless of whether messenger is enabled or disabled).

###### Dismissible notice on stores with the feature enabled:
1. Enable the Messenger feature (Marketing > Facebook > Messenger tab).
3. Simulate a plugin upgrade: in `facebook-for-woocommerce.php`, update the header block `Version` and the `const PLUGIN_VERSION` values to `3.1.13`.
4. Load the `Plugins` page to confirm that the version has been updated to `3.1.13`.
5. The default-themed dismissible notice should be displayed.
6. Navigate to any Facebook extension custom page (e.g., Advertise or Connection).
7. The yellow dismissible notice should be displayed.
8. Navigate to the Messenger settings page.
9. Only the yellow FIXED notice should be displayed.
10. Navigate to any other page and dismiss the notice.
11. Confirm the dismissible notice no longer appears on any wp-admin pages (Plugins, Facebook > Advertise, etc).


###### No dismissible notice on stores with feature disabled:
1. Revert versions in `facebook-for-woocommerce.php` to `3.1.12`.
2. Change the version in `wp_options` records: 
```sql 
SELECT *  FROM `wp_options` WHERE `option_name` LIKE '%facebook%' AND `option_value` LIKE '%3.1.13%'
# OR
UPDATE `wp_options` SET `option_value`='3.1.12' WHERE `option_value`='3.1.13';
DELETE FROM `wp_options` WHERE `option_name`= 'wc_facebook_for_woocommerce_lifecycle_events';
```
👉🏻  Note that the `wc_facebook_for_woocommerce_lifecycle_events` record can be deleted entirely
3. Remove dismissed usermeta:
```sql
DELETE FROM `wp_usermeta` WHERE meta_key='dismissed_facebook_messenger_deprecation_warning_notice';
```
4. Disable the messenger feature on the store.
5. Simulate a plugin upgrade: in `facebook-for-woocommerce.php`, update the header block `Version` and the `const PLUGIN_VERSION` values to `3.1.13`.
6. Confirm the dismissible notice doesn't appear on any wp-admin pages (Plugins, Facebook > Advertise, etc).


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Messenger feature deprecation notices.