### PR TITLE
Remove facebook_messenger_deprecation_warning notice on deactivation.

### DIFF
--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -85,6 +85,7 @@ class WC_Facebook_Loader {
 	protected function __construct() {
 
 		register_activation_hook( __FILE__, array( $this, 'activation_check' ) );
+		register_deactivation_hook( __FILE__, array( $this, 'maybe_remove_messenger_deprecation_notice' ) );
 
 		add_action( 'admin_init', array( $this, 'check_environment' ) );
 
@@ -314,6 +315,19 @@ class WC_Facebook_Loader {
 		}
 	}
 
+	/**
+	 * Removes facebook_messenger_deprecation_warning notice if it exists.
+	 *
+	 * @since x.x.x
+	 * @return void
+	 */
+	public function maybe_remove_messenger_deprecation_notice() {
+		$notice_slug = 'facebook_messenger_deprecation_warning';
+		if( class_exists( 'WC_Admin_Notices' ) && \WC_Admin_Notices::has_notice( $notice_slug ) ) {
+			\WC_Admin_Notices::remove_notice( $notice_slug );
+		}
+	}
+
 
 	/**
 	 * Determines if the required plugins are compatible.
@@ -381,7 +395,6 @@ class WC_Facebook_Loader {
 
 		return defined( 'WC_VERSION' ) && version_compare( WC_VERSION, self::MINIMUM_WC_VERSION, '>=' );
 	}
-
 
 	/**
 	 * Deactivates the plugin.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds deactivation hook to handle removing the notice when the plugin is deactivated

Closes #2710 .


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:


https://github.com/woocommerce/facebook-for-woocommerce/assets/4209011/4b0ea25c-95a3-47c7-88e0-15feebedadc3



### Detailed test instructions:

1. Enable the Messenger feature (Marketing > Facebook > Messenger tab).
2. Simulate a plugin upgrade: in facebook-for-woocommerce.php, update the header block Version and the const PLUGIN_VERSION values to 3.1.13.
3. Load the Plugins page to confirm that the version has been updated to 3.1.13.
4. The default-themed dismissible notice should be displayed.
5. Navigate to any Facebook extension custom page (e.g., Advertise or Connection).
6. The yellow dismissible notice should be displayed.
7. Navigate to the Messenger settings page.
8. Only the yellow FIXED notice should be displayed.
9. Navigate to any other page and dismiss the notice.
10. Confirm the dismissible notice no longer appears on any wp-admin pages (Plugins, Facebook > Advertise, etc).

If already on v3.1.13, you can trigger the dismissable notice by running the following SQL statements:

``` SQL
UPDATE `wp_options` SET `option_value`='3.1.12' WHERE `option_value`='3.1.13';
DELETE FROM `wp_options` WHERE `option_name`= 'wc_facebook_for_woocommerce_lifecycle_events';
```

### Changelog entry

> Fix - Remove facebook_messenger_deprecation_warning notice on deactivation.
