### PR TITLE
Release 3.1.14 - merge release into trunk

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,10 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 3.1.14 - 2024-04-03 =
+* Fix - Remove facebook_messenger_deprecation_warning notice on deactivation.
+* Tweak - Insert pixel-event-placeholder element via vanilla JS.
+* Tweak - WC 8.8 compatibility.
+
 = 3.1.13 - 2024-03-27 =
 * Add - Messenger feature deprecation notices.
 

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,12 +11,12 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.1.13
+ * Version: 3.1.14
  * Requires at least: 5.6
  * Text Domain: facebook-for-woocommerce
  * Tested up to: 6.5
  * WC requires at least: 6.4
- * WC tested up to: 8.7
+ * WC tested up to: 8.8
  *
  * @package FacebookCommerce
  */
@@ -44,7 +44,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '3.1.13'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '3.1.14'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.4.0';
@@ -318,7 +318,7 @@ class WC_Facebook_Loader {
 	/**
 	 * Removes facebook_messenger_deprecation_warning notice if it exists.
 	 *
-	 * @since x.x.x
+	 * @since 3.1.14
 	 * @return void
 	 */
 	public function maybe_remove_messenger_deprecation_notice() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.1.13",
+  "version": "3.1.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.1.13",
+  "version": "3.1.14",
   "author": "Facebook",
   "homepage": "https://woo.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,11 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
+= 3.1.14 - 2024-04-03 =
+* Fix - Remove facebook_messenger_deprecation_warning notice on deactivation.
+* Tweak - Insert pixel-event-placeholder element via vanilla JS.
+* Tweak - WC 8.8 compatibility.
+
 = 3.1.13 - 2024-03-27 =
 * Add - Messenger feature deprecation notices.
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, woocommerce, marketing, product catalog feed, pixel
 Requires at least: 4.4
 Tested up to: 6.5
-Stable tag: 3.1.13
+Stable tag: 3.1.14
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later


### PR DESCRIPTION
We have released https://github.com/woocommerce/facebook-for-woocommerce/releases/tag/3.1.14.

In this PR, we merge the release branch into trunk branch.
