### PR TITLE
Adds WooCommerce as a dependency to the plugin header

### DIFF
--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -14,6 +14,7 @@
  * Version: 3.2.0
  * Requires at least: 5.6
  * Text Domain: facebook-for-woocommerce
+ * Requires Plugins: woocommerce
  * Tested up to: 6.5
  * WC requires at least: 6.4
  * WC tested up to: 8.8


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2732.

In this PR, we add WooCommerce as a dependency using the `Requires Plugins` header.

### Screenshots:

#### Screenshot 1
![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/179533/3039b973-2dc3-4eb2-879b-0eff35d1a41f)

#### Screenshot 2
![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/179533/608715eb-e003-4b34-bca4-2563aeb51172)



### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Install and activate Facebook for WooCommerce plugin without WooCommerce activated.
2. Verify an error notice is displayed with message: `This plugin is active but may not function correctly because required plugins are missing or inactive.` (Screenshot 1)
3. Activate WooCommerce. Verify the dependencies are displayed in the plugin screen (Screenshot 2)


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Adds WooCommerce as a dependency to the plugin header
