### PR TITLE
Remove 3.1.13 update step from lifecycle

### DIFF
--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -310,6 +310,11 @@ class Lifecycle extends Framework\Lifecycle {
 		as_unschedule_all_actions( Products\Feed::GENERATE_FEED_ACTION );
 	}
 
+	/**
+	 * Upgrades to version 3.1.13 adding a notice about upcoming Messenger deprecation.
+	 *
+	 * @since 3.1.13
+	 */
 	protected function upgrade_to_3_1_13() {
 		$notice_slug          = 'facebook_messenger_deprecation_warning';
 		$is_messenger_enabled = get_option( \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER, 'no' ) === 'yes';
@@ -325,7 +330,7 @@ class Lifecycle extends Framework\Lifecycle {
 	}
 
 	/**
-	 * Removes the messenger deprecation notice on upgrade to 3.2.0.
+	 * Removes the messenger settings and deprecation notice on upgrade to 3.2.0.
 	 *
 	 * @since 3.2.0
 	 */

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -41,7 +41,6 @@ class Lifecycle extends Framework\Lifecycle {
 			'2.0.4',
 			'2.4.0',
 			'2.5.0',
-			'3.1.13',
 			'3.2.0'
 		);
 	}
@@ -311,26 +310,8 @@ class Lifecycle extends Framework\Lifecycle {
 	}
 
 	/**
-	 * Upgrades to version 3.1.13 adding a notice about upcoming Messenger deprecation.
-	 *
-	 * @since 3.1.13
-	 */
-	protected function upgrade_to_3_1_13() {
-		$notice_slug          = 'facebook_messenger_deprecation_warning';
-		$is_messenger_enabled = get_option( \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER, 'no' ) === 'yes';
-
-		// Add Messenger deprecation notice.
-		if ( $is_messenger_enabled && class_exists( 'WC_Admin_Notices' ) ) {
-			\WC_Admin_Notices::add_custom_notice(
-				$notice_slug,
-				Admin\Settings_Screens\Messenger::get_deprecation_message()
-			);
-
-		}
-	}
-
-	/**
 	 * Removes the messenger settings and deprecation notice on upgrade to 3.2.0.
+	 * Note: deprecation notice upgrade step removed in 3.2.1.
 	 *
 	 * @since 3.2.0
 	 */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

As reported in the forums: https://wordpress.org/support/topic/php-fatal-error-uncaught-error-class-woocommerce/

If a merchant has Facebook for WooCommerce < 3.1.13 **and Messenger enabled**, and then updates directly to ≥ 3.2.0, an error is triggered during the update lifecycle process due to a class that was removed in 3.2.0 being referenced in the update step for 3.1.13.

This PR removes the 3.1.13 update step altogether, as it just added an notice warning about the upcoming May 2024 deprecation of the Facebook Messenger chat plugin. Since we're now past that date, there's no reason to even consider it. It is mentioned in the 3.2.0 update method, however, since it's possible that users that update < 3.1.13 → 3.1.13-3.1.15 will have the deprecation notice, so updating again to ≥ 3.2.0 should still remove it.


### Detailed test instructions:
**To reproduce:**
1. Install and activate v3.2.0.
2. In `include/Lifecycle.php`, set `$is_messenger_enabled = true;` to force the condition.
3. Downgrade the version in `facebook-for-woocommerce.php` to `3.1.11` in the docs and the version constant:
```PHP 
# Line 14
 * Version: 3.1.11
# Line 48
	const PLUGIN_VERSION = '3.1.11'; // WRCS: DEFINED_VERSION.
```
4. Update the FB version DB options:
```SQL
UPDATE `wp_options` SET `option_value` = '3.1.11' WHERE `option_name` = 'wc_facebook_for_woocommerce_version';
UPDATE `wp_options` SET `option_value` = '[]' WHERE `option_name` = 'wc_facebook_for_woocommerce_lifecycle_events';

SELECT * FROM `wp_options` WHERE option_name IN ('wc_facebook_for_woocommerce_version', 'wc_facebook_for_woocommerce_lifecycle_events');
```
5. Confirm the version is `3.1.11`:
![image](https://github.com/woocommerce/facebook-for-woocommerce/assets/228780/749b39bf-b13e-47a3-869e-f4084f097d7f)
6. Revert the values from step 3 to `3.2.0` 
7. Confirm the error in WP Admin:
```
Fatal error: Uncaught Error: Class "WooCommerce\Facebook\Admin\Settings_Screens\Messenger" not found in /var/www/html/wp-content/plugins/facebook-for-woocommerce/includes/Lifecycle.php:321
```

**To confirm fix:**
1. Checkout this PR branch.
2. Repeat steps 3 - 6 above. (Note that step 2 isn't necessary as the code is no longer present).
3. Confirm version is updated to 3.2.0 correctly.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Direct upgrade path from < 3.1.13 to ≥ 3.2.0.
