### PR TITLE
Revert woo.com → woocommerce.com in URLs

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woo.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at support@woocommerce.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/.github/ISSUE_TEMPLATE/1-Bug-report.md
+++ b/.github/ISSUE_TEMPLATE/1-Bug-report.md
@@ -26,7 +26,7 @@ assignees: ''
 <!-- Describe what should happen instead of what is currently happening. -->
 
 ## 🗃 Logs
-<!-- Please include logs, details about your WordPress environment (from [**WooCommerce Status Report**](https://woo.com/document/understanding-the-woocommerce-system-status-report/)), and any other relevant information about your site. -->
+<!-- Please include logs, details about your WordPress environment (from [**WooCommerce Status Report**](https://woocommerce.com/document/understanding-the-woocommerce-system-status-report/)), and any other relevant information about your site. -->
 
 <details>
 	<!-- paste WooCommerce Status Report or logs here -->

--- a/.github/ISSUE_TEMPLATE/2-Support-question.md
+++ b/.github/ISSUE_TEMPLATE/2-Support-question.md
@@ -11,7 +11,7 @@ We’re happy to help with this question! Our support team works in our help des
 
 ## 📖 Read documentation
 
-The [Facebook for WooCommerce documentation](https://woo.com/document/facebook-for-woocommerce/) will help you set up the extension, use its features, and answer frequently asked questions. 
+The [Facebook for WooCommerce documentation](https://woocommerce.com/document/facebook-for-woocommerce/) will help you set up the extension, use its features, and answer frequently asked questions. 
 
 ## 👩‍💻 Check forums
 
@@ -19,4 +19,4 @@ The [Facebook for WooCommerce forums](https://wordpress.org/support/plugin/faceb
 
 ## 🗣 Contact support
 
-Our support team would be happy to help answer your questions! [Click here to get in touch with support.](https://woo.com/my-account/contact-support/)
+Our support team would be happy to help answer your questions! [Click here to get in touch with support.](https://woocommerce.com/my-account/contact-support/)

--- a/.github/ISSUE_TEMPLATE/3-Feedback-idea.md
+++ b/.github/ISSUE_TEMPLATE/3-Feedback-idea.md
@@ -9,9 +9,9 @@ assignees: ''
 
 ## Feature requests
 
-If you have an idea for how we could improve Facebook for WooCommerce, please let us know by [contacting our support team](https://woo.com/my-account/contact-support/)! We'd love to learn more about the problem you're facing and how Facebook for WooCommerce could help solve it.
+If you have an idea for how we could improve Facebook for WooCommerce, please let us know by [contacting our support team](https://woocommerce.com/my-account/contact-support/)! We'd love to learn more about the problem you're facing and how Facebook for WooCommerce could help solve it.
 
-Check the [Facebook for WooCommerce feature requests](https://woo.com/feature-requests/facebook/) to see and vote on ideas.
+Check the [Facebook for WooCommerce feature requests](https://woocommerce.com/feature-requests/facebook/) to see and vote on ideas.
 
 ## Developers
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -47,5 +47,5 @@ jobs:
                     1. [ ] Wait for a while, and the zip file should be able to download from: [https://downloads.wordpress.org/plugin/facebook-for-woocommerce.x.x.x.zip](https://downloads.wordpress.org/plugin/facebook-for-woocommerce.x.x.x.zip)
             1. [ ] Close the release milestone.
             1. [ ] Publish any documentation updates relating to the release:
-               - [ ] [User documentation](https://woo.com/document/facebook-for-woocommerce)
-               - [ ] [Any changes to privacy/tracking](https://woo.com/usage-tracking/)
+               - [ ] [User documentation](https://woocommerce.com/document/facebook-for-woocommerce)
+               - [ ] [Any changes to privacy/tracking](https://woocommerce.com/usage-tracking/)

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 This is the development repository for the Facebook for WooCommerce plugin.
 
-- [Woo.com product page](https://woo.com/products/facebook)
+- [WooCommerce.com product page](https://woocommerce.com/products/facebook/)
 - [WordPress.org plugin page](https://wordpress.org/plugins/facebook-for-woocommerce/)
-- [User documentation](https://woo.com/document/facebook-for-woocommerce)
+- [User documentation](https://woocommerce.com/document/facebook-for-woocommerce/)
 
 ## Support
 The best place to get support is the [WordPress.org Facebook for WooCommerce forum](https://wordpress.org/support/plugin/facebook-for-woocommerce/).
 
-If you have a Woo.com account, you can [search for help or submit a help request on Woo.com](https://woo.com/my-account/contact-support/).
+If you have a woocommerce.com account, you can [search for help or submit a help request on woocommerce.com](https://woocommerce.com/my-account/contact-support/).
 
 ### Logging
 The plugin offers logging that can help debug various problems. You can enable debug mode in the main plugin settings panel under the `Enable debug mode` section.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is the development repository for the Facebook for WooCommerce plugin.
 ## Support
 The best place to get support is the [WordPress.org Facebook for WooCommerce forum](https://wordpress.org/support/plugin/facebook-for-woocommerce/).
 
-If you have a woocommerce.com account, you can [search for help or submit a help request on woocommerce.com](https://woocommerce.com/my-account/contact-support/).
+If you have a WooCommerce.com account, you can [search for help or submit a help request on WooCommerce.com](https://woocommerce.com/my-account/contact-support/).
 
 ### Logging
 The plugin offers logging that can help debug various problems. You can enable debug mode in the main plugin settings panel under the `Enable debug mode` section.

--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -709,7 +709,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	 * @return string
 	 */
 	public function get_documentation_url() {
-		return 'https://woo.com/document/facebook-for-woocommerce/';
+		return 'https://woocommerce.com/document/facebook-for-woocommerce/';
 	}
 
 
@@ -733,7 +733,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 	 * @return string
 	 */
 	public function get_sales_page_url() {
-		return 'https://woo.com/products/facebook/';
+		return 'https://woocommerce.com/products/facebook/';
 	}
 
 

--- a/includes/Utilities/Tracker.php
+++ b/includes/Utilities/Tracker.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class for adding diagnostic info to WooCommerce Tracker snapshot.
  *
- * See https://woo.com/usage-tracking/ for more information.
+ * See https://woocommerce.com/usage-tracking/ for more information.
  *
  * @since 2.3.4
  */

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "facebook-for-woocommerce",
   "version": "3.2.0",
   "author": "Facebook",
-  "homepage": "https://woo.com/products/facebook/",
+  "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Revert the `woo.com` → `woocommerce.com` in several places, especially for documentation links (pb0Spc-5mO-p2).

Also changes the `homepage` in `package.json`. Still unclear whether the author should be "Woo" instead of "Facebook".


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. No real code changes (only in `get_sales_page_url()` and `get_documentation_url()`).
2. Double check all new URLs actually go to a page.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Revert to woocommerce.com domain.