### PR TITLE
Fix excluded categories in product sets check

### DIFF
--- a/assets/js/admin/product-sets-admin.js
+++ b/assets/js/admin/product-sets-admin.js
@@ -60,7 +60,7 @@ function hasExcludedCategories( selectedCategories, excludedCategoryIDs ) {
 	let counter = 0;
 
 	for ( let i = 0; i < excludedCategoryIDs.length; i++ ) {
-		if ( excludedCategoryIDs.includes( excludedCategoryIDs[i] ) ) counter++;
+		if ( selectedCategories.includes( excludedCategoryIDs[i] ) ) counter++;
 	}
 
 	return counter > 0;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2741 .

This PR fixes an errant JavaScript check that checks for each excluded category within the list of excluded categories itself, instead of within the list of categories selected for the given product set.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:
See the test instructions for #2741. The only difference is that Product Sets that have no excluded categories should be saved without a JavaScript notice.


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Fix - Incorrect alert for Product Sets without excluded categories.
