### PR TITLE
Release 3.2.2 - merge release into trunk

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** Facebook for WooCommerce Changelog ***
 
+= 3.2.2 - 2024-05-14 =
+* Fix - Incorrect alert for Product Sets without excluded categories.
+* Tweak - WC 8.9 compatibility.
+
 = 3.2.1 - 2024-05-07 =
 * Fix - Defer only AddToCart events if applicable.
 * Fix - Direct upgrade path from < 3.1.13 to ≥ 3.2.0.

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -11,13 +11,13 @@
  * Description: Grow your business on Facebook! Use this official plugin to help sell more of your products using Facebook. After completing the setup, you'll be ready to create ads that promote your products and you can also create a shop section on your Page where customers can browse your products on Facebook.
  * Author: Facebook
  * Author URI: https://www.facebook.com/
- * Version: 3.2.1
+ * Version: 3.2.2
  * Requires at least: 5.6
  * Text Domain: facebook-for-woocommerce
  * Requires Plugins: woocommerce
  * Tested up to: 6.5
  * WC requires at least: 6.4
- * WC tested up to: 8.8
+ * WC tested up to: 8.9
  *
  * @package FacebookCommerce
  */
@@ -45,7 +45,7 @@ class WC_Facebook_Loader {
 	/**
 	 * @var string the plugin version. This must be in the main plugin file to be automatically bumped by Woorelease.
 	 */
-	const PLUGIN_VERSION = '3.2.1'; // WRCS: DEFINED_VERSION.
+	const PLUGIN_VERSION = '3.2.2'; // WRCS: DEFINED_VERSION.
 
 	// Minimum PHP version required by this plugin.
 	const MINIMUM_PHP_VERSION = '7.4.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-for-woocommerce",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "author": "Facebook",
   "homepage": "https://woocommerce.com/products/facebook/",
   "license": "GPL-2.0",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: facebook, automattic, woothemes
 Tags: facebook, woocommerce, marketing, product catalog feed, pixel
 Requires at least: 4.4
 Tested up to: 6.5
-Stable tag: 3.2.1
+Stable tag: 3.2.2
 Requires PHP: 5.6 or greater
 MySQL: 5.6 or greater
 License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,10 @@ When opening a bug on GitHub, please give us as many details as possible.
 
 == Changelog ==
 
+= 3.2.2 - 2024-05-14 =
+* Fix - Incorrect alert for Product Sets without excluded categories.
+* Tweak - WC 8.9 compatibility.
+
 = 3.2.1 - 2024-05-07 =
 * Fix - Defer only AddToCart events if applicable.
 * Fix - Direct upgrade path from < 3.1.13 to ≥ 3.2.0.


### PR DESCRIPTION
We have released https://github.com/woocommerce/facebook-for-woocommerce/releases/tag/3.2.2.

In this PR, we merge the release branch into trunk branch.
