### PR TITLE
Update FB GRAPH API version to v20.0

### DIFF
--- a/includes/API.php
+++ b/includes/API.php
@@ -33,7 +33,7 @@ class API extends Base {
 
 	public const GRAPH_API_URL = 'https://graph.facebook.com/';
 
-	public const API_VERSION = 'v17.0';
+	public const API_VERSION = 'v20.0';
 
 	/** @var string URI used for the request */
 	protected $request_uri = self::GRAPH_API_URL . self::API_VERSION;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Update Facebook Marketing API to v20.0

The endpoints we use have not changed, so the application should behave as it used to without any additional changes.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.



### Detailed test instructions:
1. Use https://github.com/woocommerce/facebook-for-woocommerce/wiki/Smoke-tests for testing instructions
Make sure that logging is enabled in the plugin. After the tests, inspect the logs for errors.
The use of v20 API will be clearly visible in the endpoint URL:

<img width="833" alt="Screenshot 2024-05-22 at 14 59 53" src="https://github.com/woocommerce/facebook-for-woocommerce/assets/4209011/a19b9e36-a1f4-4f45-842f-a6beebee1788">



### Additional information:

I created a related PR to update the api.woocommerce.com/integrations bridge. This will need to be reviewed to ensure that the connection flow also works:

https://github.com/Automattic/woocommerce-connect-server/pull/2487

### Changelog entry

> Tweak - Bump Marketing API version to v20.0
