### PR TITLE
Remove/clean up messenger references

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -86,18 +86,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 	/** @var string the scheduled resync offset setting ID */
 	const SETTING_SCHEDULED_RESYNC_OFFSET = 'scheduled_resync_offset';
 
-	/** @var string the "enable messenger" setting ID */
-	const SETTING_ENABLE_MESSENGER = 'wc_facebook_enable_messenger';
-
-	/** @var string the messenger locale setting ID */
-	const SETTING_MESSENGER_LOCALE = 'wc_facebook_messenger_locale';
-
-	/** @var string the messenger greeting setting ID */
-	const SETTING_MESSENGER_GREETING = 'wc_facebook_messenger_greeting';
-
-	/** @var string the messenger color HEX setting ID */
-	const SETTING_MESSENGER_COLOR_HEX = 'wc_facebook_messenger_color_hex';
-
 	/** @var string the "debug mode" setting ID */
 	const SETTING_ENABLE_DEBUG_MODE = 'wc_facebook_enable_debug_mode';
 

--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -2472,64 +2472,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		return $mode;
 	}
 
-	/**
-	 * Gets the configured Facebook messenger locale.
-	 *
-	 * @since 1.10.0
-	 * @deprecated 3.2.0
-	 *
-	 * @return string
-	 */
-	public function get_messenger_locale() {
-		$this->messenger_doing_it_wrong();
-		return 'en_US';
-	}
-
-	/**
-	 * Gets the configured Facebook messenger greeting.
-	 *
-	 * @since 1.10.0
-	 * @deprecated 3.2.0
-	 *
-	 * @return string
-	 */
-	public function get_messenger_greeting() {
-		$this->messenger_doing_it_wrong();
-		return Helper::str_truncate(
-			__( "Hi! We're here to answer any questions you may have.", 'facebook-for-woocommerce' ),
-			$this->get_messenger_greeting_max_characters(),
-			''
-		);
-	}
-
-	/**
-	 * Gets the maximum number of characters allowed in the messenger greeting.
-	 *
-	 * @since 1.10.0
-	 * @deprecated 3.2.0
-	 *
-	 * @return int
-	 */
-	public function get_messenger_greeting_max_characters() {
-		$this->messenger_doing_it_wrong();
-		return 80;
-	}
-
-	/**
-	 * Gets the configured Facebook messenger color hex.
-	 *
-	 * This is used to style the messenger UI.
-	 *
-	 * @since 1.10.0
-	 * @deprecated 3.2.0
-	 *
-	 * @return string
-	 */
-	public function get_messenger_color_hex() {
-		$this->messenger_doing_it_wrong();
-		return '#0084ff';
-	}
-
 	/** Setter methods ************************************************************************************************/
 
 
@@ -2693,32 +2635,6 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
  	public function is_legacy_feed_file_generation_enabled() {
  		return 'yes' === get_option( self::OPTION_LEGACY_FEED_FILE_GENERATION_ENABLED, 'yes' );
  	}
-
-	/**
-	 * Determines whether the Facebook messenger is enabled.
-	 *
-	 * @since 1.10.0
-	 * @deprecated 3.2.0
-	 *
-	 * @return bool
-	 */
-	public function is_messenger_enabled() {
-		$this->messenger_doing_it_wrong();
-		return false;
-	}
-
-	/**
-	 * Show _doing_it_wrong for any deprecated public Messenger-related methods.
-	 *
-	 * @since 3.2.0
-	 */
-	private function messenger_doing_it_wrong() {
-		_doing_it_wrong(
-			__FUNCTION__,
-			esc_html__( 'The Facebook Messenger chat plugin was deprecated in May 2024.', 'facebook-for-woocommerce' ),
-			'3.2.0'
-		);
-	}
 
 	/**
 	 * Determines whether debug mode is enabled.

--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -22,6 +22,18 @@ defined( 'ABSPATH' ) or exit;
  */
 class Lifecycle extends Framework\Lifecycle {
 
+	/** @var string the "enable messenger" setting ID */
+	const SETTING_ENABLE_MESSENGER = 'wc_facebook_enable_messenger';
+
+	/** @var string the messenger locale setting ID */
+	const SETTING_MESSENGER_LOCALE = 'wc_facebook_messenger_locale';
+
+	/** @var string the messenger greeting setting ID */
+	const SETTING_MESSENGER_GREETING = 'wc_facebook_messenger_greeting';
+
+	/** @var string the messenger color HEX setting ID */
+	const SETTING_MESSENGER_COLOR_HEX = 'wc_facebook_messenger_color_hex';
+
 
 	/**
 	 * Lifecycle constructor.
@@ -119,10 +131,10 @@ class Lifecycle extends Framework\Lifecycle {
 			'fb_page_id'                                  => \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PAGE_ID,
 			'fb_pixel_id'                                 => \WC_Facebookcommerce_Integration::SETTING_FACEBOOK_PIXEL_ID,
 			'fb_pixel_use_pii'                            => \WC_Facebookcommerce_Integration::SETTING_ENABLE_ADVANCED_MATCHING,
-			'is_messenger_chat_plugin_enabled'            => \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER,
-			'msger_chat_customization_locale'             => \WC_Facebookcommerce_Integration::SETTING_MESSENGER_LOCALE,
-			'msger_chat_customization_greeting_text_code' => \WC_Facebookcommerce_Integration::SETTING_MESSENGER_GREETING,
-			'msger_chat_customization_theme_color_code'   => \WC_Facebookcommerce_Integration::SETTING_MESSENGER_COLOR_HEX,
+			'is_messenger_chat_plugin_enabled'            => self::SETTING_ENABLE_MESSENGER,
+			'msger_chat_customization_locale'             => self::SETTING_MESSENGER_LOCALE,
+			'msger_chat_customization_greeting_text_code' => self::SETTING_MESSENGER_GREETING,
+			'msger_chat_customization_theme_color_code'   => self::SETTING_MESSENGER_COLOR_HEX,
 		);
 
 		foreach ( $settings as $old_index => $new_index ) {
@@ -208,11 +220,11 @@ class Lifecycle extends Framework\Lifecycle {
 				'excluded_product_category_ids' => \WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_CATEGORY_IDS,
 				'excluded_product_tag_ids'      => \WC_Facebookcommerce_Integration::SETTING_EXCLUDED_PRODUCT_TAG_IDS,
 				'product_description_mode'      => \WC_Facebookcommerce_Integration::SETTING_PRODUCT_DESCRIPTION_MODE,
-				'enable_messenger'              => \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER,
-				'messenger_locale'              => \WC_Facebookcommerce_Integration::SETTING_MESSENGER_LOCALE,
-				'messenger_greeting'            => \WC_Facebookcommerce_Integration::SETTING_MESSENGER_GREETING,
-				'messenger_color_hex'           => \WC_Facebookcommerce_Integration::SETTING_MESSENGER_COLOR_HEX,
-				'enable_debug_mode'             => \WC_Facebookcommerce_Integration::SETTING_ENABLE_DEBUG_MODE,
+				'enable_messenger'              => self::SETTING_ENABLE_MESSENGER,
+				'messenger_locale'              => self::SETTING_MESSENGER_LOCALE,
+				'messenger_greeting'            => self::SETTING_MESSENGER_GREETING,
+				'messenger_color_hex'           => self::SETTING_MESSENGER_COLOR_HEX,
+				'enable_debug_mode'             => self::SETTING_ENABLE_DEBUG_MODE,
 			);
 			foreach ( $settings_map as $old_name => $new_name ) {
 				if ( ! empty( $settings[ $old_name ] ) ) {
@@ -323,10 +335,10 @@ class Lifecycle extends Framework\Lifecycle {
 		}
 
 		// Delete all messenger options
-		delete_option( \WC_Facebookcommerce_Integration::SETTING_ENABLE_MESSENGER );
-		delete_option( \WC_Facebookcommerce_Integration::SETTING_MESSENGER_LOCALE );
-		delete_option( \WC_Facebookcommerce_Integration::SETTING_MESSENGER_GREETING );
-		delete_option( \WC_Facebookcommerce_Integration::SETTING_MESSENGER_COLOR_HEX );
+		delete_option( self::SETTING_ENABLE_MESSENGER );
+		delete_option( self::SETTING_MESSENGER_LOCALE );
+		delete_option( self::SETTING_MESSENGER_GREETING );
+		delete_option( self::SETTING_MESSENGER_COLOR_HEX );
 	}
 
 }

--- a/tests/Unit/WCFacebookCommerceIntegrationTest.php
+++ b/tests/Unit/WCFacebookCommerceIntegrationTest.php
@@ -2771,16 +2771,6 @@ class WCFacebookCommerceIntegrationTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests is messenger enabled returns the doing it wrong message
-	 *
-	 * @expectedIncorrectUsage messenger_doing_it_wrong
-	 */
-	public function test_is_messenger_enabled_doing_it_wrong() {
-		$result = $this->integration->is_messenger_enabled();
-		$this->assertFalse( $result );
-	}
-
-	/**
 	 * Tests is debug mode enabled returns default value.
 	 *
 	 * @return void


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Closes #2724.

This PR removes (nearly) all Messenger-related code to complete the process of Messgenger teprecation.


### Detailed test instructions:


1. Unit tests pass `vendor/bin/phpunit` (I get 3 skipped).
2. Plugin works as usual with no errors
    1. Activate/deactivate plugin.
    2. Connect to a Facebook page. [Smoke Test](https://github.com/woocommerce/facebook-for-woocommerce/wiki/Smoke-tests#connect-to-facebook-business-account-1)
    3. Product sync works [Smoke Test](https://github.com/woocommerce/facebook-for-woocommerce/wiki/Smoke-tests#product-sync-1).
    4. New product sync works [Smoke Test](https://github.com/woocommerce/facebook-for-woocommerce/wiki/Smoke-tests#new-simple-product-1).
3. Test upgrade paths still work.
    1. Use a fresh WC install.
    3. Install [Facebook for WooCommerce 1.11.4 ](https://downloads.wordpress.org/plugin/facebook-for-woocommerce.1.11.4.zip) and activate.
    4. Close any open browser windows, delete facebook directory, install Facebook for WooCommerce repo, swap to this branch, rebuild.
    5. Reopen `/wp-admin/plugins.php` and confirm current version `3.2.3` and no errors.
4. Specifically test Messenger-related upgrade path.
    1. Use fresh WC install.
    6. Checkout repo, [switch to branch <3.2.0](https://github.com/woocommerce/facebook-for-woocommerce/tree/3.1.15)
    7. Build and activate plugin, connect to Facebook page. Enable Messenger at `/wp-admin/admin.php?page=wc-facebook&tab=messenger`
    8. Checkout PR branch. 
    9. Visit plugins page, confirm v3.2.3 shows, and no errors in logs.
    10. Confirm all [Messenger related options](https://github.com/woocommerce/facebook-for-woocommerce/blob/fa6b2e1519442475c86ed8b558fdfa4b7f615b75/includes/Lifecycle.php#L25-L35) were removed correctly
    ```sql
    SELECT *  FROM `wp_options` WHERE `option_name` LIKE '%facebook%messenger%';
    ```



<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Tweak - Fully remove Facebook Messenger code references.
