### PR TITLE
Add filter facebook_for_woocommerce_fb_product_description on get_fb_description

### DIFF
--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -436,8 +436,15 @@ class WC_Facebook_Product {
 				$description = $post_title;
 			}
 		}
-
-		return $description;
+		/**
+		 * Filters the FB product description.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param string  $description Facebook product description.
+		 * @param int     $id          WooCommerce Product ID.
+		 */
+		return apply_filters( 'facebook_for_woocommerce_fb_product_description', $description, $this->id );
 	}
 
 	/**

--- a/includes/fbproduct.php
+++ b/includes/fbproduct.php
@@ -391,53 +391,50 @@ class WC_Facebook_Product {
 	}
 
 	public function get_fb_description() {
+		$description = '';
+
 		if ( $this->fb_description ) {
-			return $this->fb_description;
+			$description = $this->fb_description;
 		}
 
-		$description = get_post_meta(
-			$this->id,
-			self::FB_PRODUCT_DESCRIPTION,
-			true
-		);
-
-		if ( $description ) {
-			return $description;
+		if ( empty( $description ) ) {
+			// Try to get description from post meta
+			$description = get_post_meta(
+				$this->id,
+				self::FB_PRODUCT_DESCRIPTION,
+				true
+			);
 		}
 
-		if ( WC_Facebookcommerce_Utils::is_variation_type( $this->woo_product->get_type() ) ) {
-
+		// Check if the product type is a variation and no description is found yet
+		if ( empty( $description ) && WC_Facebookcommerce_Utils::is_variation_type( $this->woo_product->get_type() ) ) {
 			$description = WC_Facebookcommerce_Utils::clean_string( $this->woo_product->get_description() );
 
-			if ( $description ) {
-				return $description;
-			}
-			if ( $this->main_description ) {
-				return $this->main_description;
+			// Fallback to main description
+			if ( empty( $description ) && $this->main_description ) {
+				$description = $this->main_description;
 			}
 		}
 
-		$post = $this->get_post_data();
+		// If no description is found from meta or variation, get from post
+		if ( empty( $description ) ) {
+			$post         = $this->get_post_data();
+			$post_content = WC_Facebookcommerce_Utils::clean_string( $post->post_content );
+			$post_excerpt = WC_Facebookcommerce_Utils::clean_string( $post->post_excerpt );
+			$post_title   = WC_Facebookcommerce_Utils::clean_string( $post->post_title );
 
-		$post_content = WC_Facebookcommerce_Utils::clean_string(
-			$post->post_content
-		);
-		$post_excerpt = WC_Facebookcommerce_Utils::clean_string(
-			$post->post_excerpt
-		);
-		$post_title   = WC_Facebookcommerce_Utils::clean_string(
-			$post->post_title
-		);
+			// Prioritize content, then excerpt, then title
+			if ( ! empty( $post_content ) ) {
+				$description = $post_content;
+			}
 
-		// Sanitize description
-		if ( $post_content ) {
-			$description = $post_content;
-		}
-		if ( $this->sync_short_description || ( $description == '' && $post_excerpt ) ) {
-			$description = $post_excerpt;
-		}
-		if ( $description == '' ) {
-			$description = $post_title;
+			if ( $this->sync_short_description || ( empty( $description ) && ! empty( $post_excerpt ) ) ) {
+				$description = $post_excerpt;
+			}
+
+			if ( empty( $description ) ) {
+				$description = $post_title;
+			}
 		}
 
 		return $description;

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+
+class fbproductTest extends WP_UnitTestCase {
+	private $parent_fb_product;
+
+	/**
+	 * Test it gets description from post meta.
+	 * @return void
+	 */
+	public function test_get_fb_description_from_post_meta() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		$facebook_product = new \WC_Facebook_Product( $product );
+		$facebook_product->set_description( 'fb description' );
+		$description = $facebook_product->get_fb_description();
+
+		$this->assertEquals( $description, 'fb description');
+	}
+
+	/**
+	 * Test it gets description from parent product if it is a variation.
+	 * @return void
+	 */
+	public function test_get_fb_description_variable_product() {
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$variable_product->set_description('parent description');
+		$variable_product->save();
+
+		$parent_fb_product = new \WC_Facebook_Product($variable_product);
+		$variation         = wc_get_product($variable_product->get_children()[0]);
+
+		$facebook_product = new \WC_Facebook_Product( $variation, $parent_fb_product );
+		$description      = $facebook_product->get_fb_description();
+		$this->assertEquals( $description, 'parent description' );
+
+		$variation->set_description( 'variation description' );
+		$variation->save();
+
+		$description = $facebook_product->get_fb_description();
+		$this->assertEquals( $description, 'variation description' );
+	}
+
+	/**
+	 * Tests that if no description is found from meta or variation, it gets description from post
+	 *
+	 * @return void
+	 */
+	public function test_get_fb_description_from_post_content() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		// Gets description from title
+		$facebook_product = new \WC_Facebook_Product( $product );
+		$description      = $facebook_product->get_fb_description();
+
+		$this->assertEquals( $description, get_post( $product->get_id() )->post_title );
+
+		// Gets description from excerpt (product short description)
+		$product->set_short_description( 'short description' );
+		$product->save();
+
+		$description = $facebook_product->get_fb_description();
+		$this->assertEquals( $description, get_post( $product->get_id() )->post_excerpt );
+
+		// Gets description from content (product description)
+		$product->set_description( 'product description' );
+		$product->save();
+
+		$description = $facebook_product->get_fb_description();
+		$this->assertEquals( $description, get_post( $product->get_id() )->post_content );
+
+		// Gets description from excerpt ignoring content when short mode is set
+		add_option(
+			WC_Facebookcommerce_Integration::SETTING_PRODUCT_DESCRIPTION_MODE,
+			WC_Facebookcommerce_Integration::PRODUCT_DESCRIPTION_MODE_SHORT
+		);
+
+		$facebook_product = new \WC_Facebook_Product( $product );
+		$description      = $facebook_product->get_fb_description();
+		$this->assertEquals( $description, get_post( $product->get_id() )->post_excerpt );
+	}
+}

--- a/tests/Unit/fbproductTest.php
+++ b/tests/Unit/fbproductTest.php
@@ -80,4 +80,27 @@ class fbproductTest extends WP_UnitTestCase {
 		$description      = $facebook_product->get_fb_description();
 		$this->assertEquals( $description, get_post( $product->get_id() )->post_excerpt );
 	}
+
+	/**
+	 * Test it filters description.
+	 * @return void
+	 */
+	public function test_filter_fb_description() {
+		$product = WC_Helper_Product::create_simple_product();
+		$facebook_product = new \WC_Facebook_Product( $product );
+		$facebook_product->set_description( 'fb description' );
+
+		add_filter( 'facebook_for_woocommerce_fb_product_description', function( $description ) {
+			return 'filtered description';
+		});
+
+		$description = $facebook_product->get_fb_description();
+		$this->assertEquals( $description, 'filtered description' );
+
+		remove_all_filters( 'facebook_for_woocommerce_fb_product_description' );
+
+		$description = $facebook_product->get_fb_description();
+		$this->assertEquals( $description, 'fb description' );
+
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2756

Adds filter `facebook_for_woocommerce_fb_product_description` to allow filtering the return of `get_fb_description`

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical. -> I have fixed the linting errors on the modified function only

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

With a site connected to Facebook:
1. Add the filter to modify the product description, for example:
  ```
  add_filter( 'facebook_for_woocommerce_fb_product_description', function( $description ) {
	return $description . ' filtered';
});
  ```
2. sync the products 
3. View your catalog on Facebook and check the description is filtered


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Filter facebook_for_woocommerce_fb_product_description
