### PR TITLE
Remove deprecated FILTER_SANITIZE_STRING usage.

### DIFF
--- a/includes/Framework/Helper.php
+++ b/includes/Framework/Helper.php
@@ -137,10 +137,10 @@ class Helper {
 	 * @return string
 	 */
 	public static function str_to_ascii( $string ) {
-		// strip ASCII chars 32 and under
-		$string = filter_var( $string, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_LOW );
-		// strip ASCII chars 127 and higher
-		return filter_var( $string, FILTER_SANITIZE_STRING, FILTER_FLAG_STRIP_HIGH );
+		// Strip ASCII chars 32 and under
+		$string = preg_replace('/[\x00-\x1F]/', '', $string);
+		// Strip ASCII chars 127 and higher
+		return preg_replace('/[\x7F-\xFF]/', '', $string);
 	}
 
 

--- a/includes/Framework/Helper.php
+++ b/includes/Framework/Helper.php
@@ -138,9 +138,9 @@ class Helper {
 	 */
 	public static function str_to_ascii( $string ) {
 		// Strip ASCII chars 32 and under
-		$string = preg_replace('/[\x00-\x1F]/', '', $string);
+		$string = preg_replace( '/[\x00-\x1F]/', '', $string );
 		// Strip ASCII chars 127 and higher
-		return preg_replace('/[\x7F-\xFF]/', '', $string);
+		return preg_replace( '/[\x7F-\xFF]/', '', $string );
 	}
 
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove deprecated FILTER_SANITIZE_STRING usage.

Closes #2588.

`str_truncate`, `str_exists`, `str_truncate` and other related string helper methods in the `WooCommerce\Facebook\Framework\Helper` class had a fallback for cases where the `mbstring` PHP extension was not available. This fallback `str_to_ascii` method would throw a deprecate warning notice because of its use of the FILTER_SANITIZE_STRING constant.

I have considered removing the `self::multibyte_loaded() ` check and falling back on the WP core polyfill. But some mb functions do not have polyfills in the core like `mb_strpos`. This will require including and loading something like https://github.com/symfony/polyfill-mbstring. 

We can look at this when we work on the cleanup task: https://github.com/woocommerce/facebook-for-woocommerce/issues/2705. 


Here, I re-implement str_ascii without filter_var. This keeps printable ASCII chars, stripping out everything from 0-31 and 127-255,.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:

To reproduce:

1. Ensure your local server has PHP 8.1 or higher.
2. Enable WP_DEBUG and WP_DEBUG_LOG
3. Change this line to return false: https://github.com/woocommerce/facebook-for-woocommerce/blob/f8b103d9e86a202d8341cccaff01f744e3275972/includes/Framework/Helper.php#L155
4. Configure Facebook for WooCommerce, notice the deprecation warning notices in your log file

Check out this branch.

You can try to sync a product by editing it; for example, no warning notice should be thrown.




### Changelog entry

>Fix - Remove deprecated FILTER_SANITIZE_STRING usage.
