### PR TITLE
Update/phpcs config

### DIFF
--- a/includes/API/Catalog/Product_Group/Products/Read/Request.php
+++ b/includes/API/Catalog/Product_Group/Products/Read/Request.php
@@ -54,6 +54,4 @@ class Request extends API\Request {
 
 		return 'ads_management';
 	}
-
-
 }

--- a/includes/API/Catalog/Product_Group/Products/Read/Response.php
+++ b/includes/API/Catalog/Product_Group/Products/Read/Response.php
@@ -42,6 +42,4 @@ class Response extends API\Response {
 
 		return $product_item_ids;
 	}
-
-
 }

--- a/includes/API/Catalog/Product_Item/Find/Request.php
+++ b/includes/API/Catalog/Product_Item/Find/Request.php
@@ -60,6 +60,4 @@ class Request extends API\Request {
 
 		return array( 'fields' => 'id,product_group{id}' );
 	}
-
-
 }

--- a/includes/API/Catalog/Send_Item_Updates/Request.php
+++ b/includes/API/Catalog/Send_Item_Updates/Request.php
@@ -123,6 +123,4 @@ class Request extends API\Request {
 			'item_type'    => 'PRODUCT_ITEM',
 		);
 	}
-
-
 }

--- a/includes/API/FBE/Configuration/Read/Response.php
+++ b/includes/API/FBE/Configuration/Read/Response.php
@@ -18,7 +18,7 @@ class Response extends API\Response {
 	 * @return boolean
 	 */
 	public function is_ig_shopping_enabled(): bool {
-		return ! ! $this->response_data['ig_shopping']['enabled'] ?? false;
+		return (bool) $this->response_data['ig_shopping']['enabled'] ?? false;
 	}
 
 	/**
@@ -27,6 +27,6 @@ class Response extends API\Response {
 	 * @return boolean
 	 */
 	public function is_ig_cta_enabled(): bool {
-		return ! ! $this->response_data['ig_cta']['enabled'];
+		return (bool) $this->response_data['ig_cta']['enabled'];
 	}
 }

--- a/includes/API/FBE/Configuration/Update/Request.php
+++ b/includes/API/FBE/Configuration/Update/Request.php
@@ -52,6 +52,4 @@ class Request extends Configuration\Request {
 				),
 		);
 	}
-
-
 }

--- a/includes/API/Pixel/Events/Request.php
+++ b/includes/API/Pixel/Events/Request.php
@@ -90,6 +90,4 @@ class Request extends API\Request {
 		 */
 		return apply_filters( 'wc_facebook_api_pixel_event_request_data', $data, $this );
 	}
-
-
 }

--- a/includes/API/Request.php
+++ b/includes/API/Request.php
@@ -81,7 +81,7 @@ class Request extends JSONRequest {
 	 * @since 2.1.0
 	 */
 	public function mark_retry() {
-		$this->retry_count++;
+		++$this->retry_count;
 	}
 
 

--- a/includes/API/Traits/Idempotent_Request.php
+++ b/includes/API/Traits/Idempotent_Request.php
@@ -40,6 +40,4 @@ trait Idempotent_Request {
 
 		return $this->idempotency_key;
 	}
-
-
 }

--- a/includes/API/Traits/Rate_Limited_Response.php
+++ b/includes/API/Traits/Rate_Limited_Response.php
@@ -118,6 +118,4 @@ trait Rate_Limited_Response {
 
 		return ! empty( $usage_data['estimated_time_to_regain_access'] ) ? (int) $usage_data['estimated_time_to_regain_access'] : null;
 	}
-
-
 }

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -266,7 +266,6 @@ class Enhanced_Catalog_Attribute_Fields {
 				// string
 				$this->render_text_field( $attr_id, $attribute, $placeholder );
 		}
-
 	}
 
 	private function render_select_field( $attr_id, $attribute ) {

--- a/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
+++ b/includes/Admin/Enhanced_Catalog_Attribute_Fields.php
@@ -89,20 +89,20 @@ class Enhanced_Catalog_Attribute_Fields {
 	public function render( $category_id ) {
 		$all_attributes             = $this->category_handler->get_attributes_with_fallback_to_parent_category( $category_id );
 		$all_attributes_with_values = array_map(
-			function( $attribute ) use ( $category_id ) {
+			function ( $attribute ) use ( $category_id ) {
 				return array_merge( $attribute, array( 'value' => $this->get_value( $attribute['key'], $category_id ) ) );
 			},
 			$all_attributes
 		);
 		$recommended_attributes     = array_filter(
 			$all_attributes_with_values,
-			function( $attr ) {
+			function ( $attr ) {
 				return $attr['recommended'];
 			}
 		);
 		$optional_attributes        = array_filter(
 			$all_attributes_with_values,
-			function( $attr ) {
+			function ( $attr ) {
 				return ! $attr['recommended'];
 			}
 		);
@@ -117,7 +117,7 @@ class Enhanced_Catalog_Attribute_Fields {
 					$this->extract_attribute( $optional_attributes, 'size' ),
 					$this->extract_attribute( $optional_attributes, 'gender' ),
 				),
-				function( $attr ) {
+				function ( $attr ) {
 					return ! is_null( $attr );
 				}
 			);

--- a/includes/Admin/Notes/SettingsMoved.php
+++ b/includes/Admin/Notes/SettingsMoved.php
@@ -11,8 +11,8 @@ namespace WooCommerce\Facebook\Admin\Notes;
 
 defined( 'ABSPATH' ) || exit;
 
-use \Automattic\WooCommerce\Admin\Notes\Note;
-use \Automattic\WooCommerce\Admin\Notes\NoteTraits;
+use Automattic\WooCommerce\Admin\Notes\Note;
+use Automattic\WooCommerce\Admin\Notes\NoteTraits;
 
 /**
  * SettingsMoved class.

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -271,8 +271,8 @@ class Product_Categories {
 
 		if (
 			empty( $category_id ) ||
-			$category_handler->is_category( $category_id ) &&
-			$category_handler->is_root_category( $category_id )
+			( $category_handler->is_category( $category_id ) &&
+			$category_handler->is_root_category( $category_id ) )
 		) {
 			// show nothing
 			?>
@@ -314,8 +314,8 @@ class Product_Categories {
 
 		if (
 			empty( $category_id ) ||
-			$category_handler->is_category( $category_id ) &&
-			$category_handler->is_root_category( $category_id )
+			( $category_handler->is_category( $category_id ) &&
+			$category_handler->is_root_category( $category_id ) )
 		) {
 			// show nothing
 			return;

--- a/includes/Admin/Product_Categories.php
+++ b/includes/Admin/Product_Categories.php
@@ -377,7 +377,7 @@ class Product_Categories {
 		$google_product_category_id = wc_clean( Helper::get_posted_value( self::FIELD_GOOGLE_PRODUCT_CATEGORY_ID ) );
 
 		\WooCommerce\Facebook\Product_Categories::update_google_product_category_id( $term_id, $google_product_category_id );
-		$this->save_enhanced_catalog_attributes( $term_id, $tt_id, $taxonomy );
+		$this->save_enhanced_catalog_attributes( $term_id );
 
 		$term = get_term( $term_id, $taxonomy );
 
@@ -423,11 +423,9 @@ class Product_Categories {
 	 *
 	 * @since 2.1.0
 	 *
-	 * @param int    $term_id term ID.
-	 * @param int    $tt_id term taxonomy ID.
-	 * @param string $taxonomy Taxonomy slug.
+	 * @param int $term_id term ID.
 	 */
-	public function save_enhanced_catalog_attributes( $term_id, $tt_id, $taxonomy ) {
+	public function save_enhanced_catalog_attributes( $term_id ) {
 		$enhanced_catalog_attributes = \WooCommerce\Facebook\Products::get_enhanced_catalog_attributes_from_request();
 
 		foreach ( $enhanced_catalog_attributes as $key => $value ) {

--- a/includes/Admin/Product_Sets.php
+++ b/includes/Admin/Product_Sets.php
@@ -118,7 +118,7 @@ class Product_Sets {
 		$wc_product_cats = empty( $_POST[ $this->categories_field ] ) ? '' : wc_clean( wp_unslash( $_POST[ $this->categories_field ] ) ); //phpcs:ignore
 		if ( ! empty( $wc_product_cats ) ) {
 			$wc_product_cats = array_map(
-				function( $item ) {
+				function ( $item ) {
 					return absint( $item );
 				},
 				$wc_product_cats

--- a/includes/Admin/Product_Sets.php
+++ b/includes/Admin/Product_Sets.php
@@ -114,7 +114,7 @@ class Product_Sets {
 	 * @param int $term_id Term ID.
 	 * @param int $tt_id Term taxonomy ID.
 	 */
-	public function save_custom_field( $term_id, $tt_id ) {
+	public function save_custom_field( $term_id, $tt_id ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
 		$wc_product_cats = empty( $_POST[ $this->categories_field ] ) ? '' : wc_clean( wp_unslash( $_POST[ $this->categories_field ] ) ); //phpcs:ignore
 		if ( ! empty( $wc_product_cats ) ) {
 			$wc_product_cats = array_map(

--- a/includes/Admin/Product_Sets.php
+++ b/includes/Admin/Product_Sets.php
@@ -149,7 +149,12 @@ class Product_Sets {
 	 */
 	protected function get_field( $term_id = '' ) {
 		$saved_items  = get_term_meta( $term_id, $this->categories_field, true );
-		$product_cats = get_terms( 'product_cat', array( 'hide_empty' => 0 ) );
+		$product_cats = get_terms(
+			array(
+				'taxonomy'   => 'product_cat',
+				'hide_empty' => false,
+			)
+		);
 		?>
 		<div class="select2 updating-message"><p></p></div>
 		<select

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -67,8 +67,8 @@ class Products {
 		);
 		if (
 			empty( $category_id ) ||
-			$category_handler->is_category( $category_id ) &&
-			$category_handler->is_root_category( $category_id )
+			( $category_handler->is_category( $category_id ) &&
+			$category_handler->is_root_category( $category_id ) )
 		) {
 			// show nothing
 			return;

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -210,7 +210,7 @@ class Products {
 		<div id="variable-product-not-ready-notice" style="display:none;">
 			<p>
 			<?php
-			echo sprintf(
+			printf(
 				/* translators: Placeholders %1$s - strong opening tag, %2$s - strong closing tag */
 				esc_html__( 'To sell this product on Instagram, at least one variation must be synced to Facebook. You can control variation sync on the %1$sVariations%2$s tab with the %1$sFacebook Sync%2$s setting.', 'facebook-for-woocommerce' ),
 				'<strong>',

--- a/includes/Admin/Products.php
+++ b/includes/Admin/Products.php
@@ -170,7 +170,7 @@ class Products {
 	 */
 	public static function get_available_product_attribute_names( \WC_Product $product ) {
 		return array_map(
-			function( $attribute ) use ( $product ) {
+			function ( $attribute ) use ( $product ) {
 				return wc_attribute_label( $attribute->get_name(), $product );
 			},
 			Products_Handler::get_available_product_attributes( $product )

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -302,7 +302,7 @@ class Settings {
 		// ensure no bogus values are added via filter
 		$screens = array_filter(
 			$screens,
-			function( $value ) {
+			function ( $value ) {
 				return $value instanceof Abstract_Settings_Screen;
 			}
 		);

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -362,7 +362,7 @@ class Settings {
 					'order'  => $order,
 				)
 			);
-			$order++;
+			++$order;
 		}
 	}
 }

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -177,7 +177,9 @@ class Settings {
 			$crumbs = array(
 				__( 'Facebook for WooCommerce', 'facebook-for-woocommerce' ),
 			);
+			//phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			if ( ! empty( $_GET['tab'] ) ) {
+				//phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				switch ( $_GET['tab'] ) {
 					case Connection::ID:
 						$crumbs[] = __( 'Connection', 'facebook-for-woocommerce' );

--- a/includes/ExternalVersionUpdate/Update.php
+++ b/includes/ExternalVersionUpdate/Update.php
@@ -101,5 +101,4 @@ class Update {
 			return false;
 		}
 	}
-
 }

--- a/includes/Framework/Api/Base.php
+++ b/includes/Framework/Api/Base.php
@@ -680,6 +680,7 @@ abstract class Base {
 		if ( ! Helper::str_starts_with( $url, 'https://' ) ) {
 			return;
 		}
+		//phpcs:ignore: WordPress.WP.AlternativeFunctions.curl_curl_setopt
 		curl_setopt( $handle, CURLOPT_SSLVERSION, 6 );
 	}
 

--- a/includes/Framework/Api/Response.php
+++ b/includes/Framework/Api/Response.php
@@ -30,5 +30,4 @@ interface Response {
 	 * @return string the request, safe for logging/displaying
 	 */
 	public function to_string_safe();
-
 }

--- a/includes/Framework/Utilities/BackgroundJobHandler.php
+++ b/includes/Framework/Utilities/BackgroundJobHandler.php
@@ -656,8 +656,8 @@ abstract class BackgroundJobHandler extends AsyncRequest {
 				// process the item
 				$this->process_item( $item, $job );
 
-				$processed++;
-				$job->progress++;
+				++$processed;
+				++$job->progress;
 
 				// update job progress
 				$job = $this->update_job( $job );

--- a/includes/Jobs/CleanupSkyvergeFrameworkJobOptions.php
+++ b/includes/Jobs/CleanupSkyvergeFrameworkJobOptions.php
@@ -57,5 +57,4 @@ class CleanupSkyvergeFrameworkJobOptions {
 			LIMIT 500"
 		);
 	}
-
 }

--- a/includes/Jobs/DeleteProductsFromFBCatalog.php
+++ b/includes/Jobs/DeleteProductsFromFBCatalog.php
@@ -125,5 +125,4 @@ class DeleteProductsFromFBCatalog extends AbstractChainedJob {
 	public function get_batch_size(): int {
 		return 25;
 	}
-
 }

--- a/includes/Jobs/DeleteProductsFromFBCatalog.php
+++ b/includes/Jobs/DeleteProductsFromFBCatalog.php
@@ -57,7 +57,6 @@ class DeleteProductsFromFBCatalog extends AbstractChainedJob {
 		);
 
 		return array_map( 'intval', $products );
-
 	}
 
 	/**

--- a/includes/Jobs/DeleteProductsFromFBCatalog.php
+++ b/includes/Jobs/DeleteProductsFromFBCatalog.php
@@ -16,7 +16,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class DeleteProductsFromFBCatalog extends AbstractChainedJob {
 
-	use BatchQueryOffset, LoggingTrait;
+	use BatchQueryOffset;
+	use LoggingTrait;
 
 	/**
 	 * Called before starting the job.

--- a/includes/Jobs/ResetAllProductsFBSettings.php
+++ b/includes/Jobs/ResetAllProductsFBSettings.php
@@ -116,5 +116,4 @@ class ResetAllProductsFBSettings extends AbstractChainedJob {
 	public function get_batch_size(): int {
 		return 25;
 	}
-
 }

--- a/includes/Jobs/ResetAllProductsFBSettings.php
+++ b/includes/Jobs/ResetAllProductsFBSettings.php
@@ -57,7 +57,6 @@ class ResetAllProductsFBSettings extends AbstractChainedJob {
 		);
 
 		return array_map( 'intval', $products );
-
 	}
 
 	/**

--- a/includes/Jobs/ResetAllProductsFBSettings.php
+++ b/includes/Jobs/ResetAllProductsFBSettings.php
@@ -16,7 +16,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class ResetAllProductsFBSettings extends AbstractChainedJob {
 
-	use BatchQueryOffset, LoggingTrait;
+	use BatchQueryOffset;
+	use LoggingTrait;
 
 	/**
 	 * Called before starting the job.

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -347,10 +347,8 @@ class ProductValidator {
 
 			// Variable product has no variations with sync enabled so it shouldn't be synced.
 			throw $invalid_exception;
-		} else {
-			if ( 'no' === $this->product->get_meta( self::SYNC_ENABLED_META_KEY ) ) {
+		} elseif ( 'no' === $this->product->get_meta( self::SYNC_ENABLED_META_KEY ) ) {
 				throw $invalid_exception;
-			}
 		}
 	}
 

--- a/includes/ProductSync/ProductValidator.php
+++ b/includes/ProductSync/ProductValidator.php
@@ -443,5 +443,4 @@ class ProductValidator {
 			throw new ProductInvalidException( __( 'Too many attributes selected for product. Use 4 or less.', 'facebook-for-woocommerce' ) );
 		}
 	}
-
 }

--- a/includes/Products/Sync/Background.php
+++ b/includes/Products/Sync/Background.php
@@ -118,8 +118,8 @@ class Background extends BackgroundJobHandler {
 				facebook_for_woocommerce()->log( "Background sync error: {$e->getMessage()}" );
 			}
 
-			$processed++;
-			$job->progress++;
+			++$processed;
+			++$job->progress;
 			// update job progress
 			$job = $this->update_job( $job );
 			// job limits reached

--- a/includes/Utilities/DebugTools.php
+++ b/includes/Utilities/DebugTools.php
@@ -120,5 +120,4 @@ class DebugTools {
 		facebook_for_woocommerce()->job_manager->delete_all_products->queue_start();
 		return esc_html__( 'Delete products from Facebook catalog job started!', 'facebook-for-woocommerce' );
 	}
-
 }

--- a/includes/Utilities/DebugTools.php
+++ b/includes/Utilities/DebugTools.php
@@ -78,7 +78,6 @@ class DebugTools {
 		$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '%wc_facebook_background_product_sync%'" );
 
 		return __( 'Background sync jobs have been deleted.', 'facebook-for-woocommerce' );
-
 	}
 
 	/**
@@ -93,7 +92,6 @@ class DebugTools {
 		facebook_for_woocommerce()->get_connection_handler()->disconnect();
 
 		return esc_html__( 'Cleared all Facebook settings!', 'facebook-for-woocommerce' );
-
 	}
 
 	/**
@@ -106,7 +104,6 @@ class DebugTools {
 	public function reset_all_product_fb_settings() {
 		facebook_for_woocommerce()->job_manager->reset_all_product_fb_settings->queue_start();
 		return esc_html__( 'Reset products Facebook settings job started!', 'facebook-for-woocommerce' );
-
 	}
 
 	/**

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -189,6 +189,4 @@ class WC_Facebook_WPML_Injector {
 			<?php
 		}
 	}
-
-
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,7 +16,7 @@
 		<exclude name="Squiz.Commenting.FileComment.Missing"/>
 
 		<!-- Rules related to comments. We will come back to implementing these rules-->
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found"/>
 		<exclude name="Generic.Commenting.DocComment.MissingShort"/>
 		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar"/>
 		<exclude name="Squiz.Commenting.FunctionComment.Missing"/>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -25,6 +25,9 @@
 		<exclude name="Squiz.Commenting.FileComment.MissingPackageTag"/>
 		<exclude name="WooCommerce.Commenting.CommentHooks.MissingSinceComment"/>
 		<exclude name="WooCommerce.Commenting.CommentHooks.MissingHookComment"/>
+
+		<!-- Exceptions can be escaped before outputting not when thrown -->
+		<exclude name="WordPress.Security.EscapeOutput.ExceptionNotEscaped"/>
 	</rule>
 
 	<!-- Set the appropriate text domain. -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -37,6 +37,15 @@
 		</properties>
 	</rule>
 
+	<!-- Add manage_woocommerce to accepted user capabilities -->
+	<rule ref="WordPress.WP.Capabilities">
+		<properties>
+			<property name="custom_capabilities" type="array">
+				<element value="manage_woocommerce"/>
+			</property>
+		</properties>
+	</rule>
+
 	<!-- Check the main PHP file and everything in /includes -->
 	<arg name="extensions" value="php"/>
 	<file>.</file>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2772

- Changes Generic.Arrays.DisallowShortArraySyntax to Universal.Arrays.DisallowShortArraySyntax
- Adds `manage_woocommerce` to accepted user capabilities to WordPress.WP.Capabilities
- Adds an exclusion for WordPress.Security.EscapeOutput.ExceptionNotEscaped
- Some automatic fixes

There are still 3 warnings and files ignoring the linter. Not new.
About the warnings, I believe the ones about the GET parameter could be ignored but I would like someone that knows the plugin better to confirm.

Please check the changelog format is correct.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. npm run lint:php


### Additional details:

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Dev - Updated `phpcs` ruleset.
