### PR TITLE
fix undefined SETTING_ENABLE_DEBUG_MODE

### DIFF
--- a/includes/Lifecycle.php
+++ b/includes/Lifecycle.php
@@ -224,7 +224,7 @@ class Lifecycle extends Framework\Lifecycle {
 				'messenger_locale'              => self::SETTING_MESSENGER_LOCALE,
 				'messenger_greeting'            => self::SETTING_MESSENGER_GREETING,
 				'messenger_color_hex'           => self::SETTING_MESSENGER_COLOR_HEX,
-				'enable_debug_mode'             => self::SETTING_ENABLE_DEBUG_MODE,
+				'enable_debug_mode'             => \WC_Facebookcommerce_Integration::SETTING_ENABLE_DEBUG_MODE,
 			);
 			foreach ( $settings_map as $old_name => $new_name ) {
 				if ( ! empty( $settings[ $old_name ] ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is something that escaped our attention in this PR: https://github.com/woocommerce/facebook-for-woocommerce/pull/2754.  The constant SETTING_ENABLE_DEBUG_MODE should not be called from self. but from WC_Facebookcommerce_Integration.

Closes #2278.


- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

<!--- Optional --->


### Detailed test instructions:
 
Upgrade the plugin from version 1, and no errors should occur.


### Changelog entry

> Fix - Update failing due to undefined constant error in Lifecycle
