### PR TITLE
Use get_title() for content_name to match catalog name.

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -583,7 +583,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				'event_name'  => 'AddToCart',
 				'custom_data' => array(
 					'content_ids'  => wp_json_encode( \WC_Facebookcommerce_Utils::get_fb_content_ids( $product ) ),
-					'content_name' => $product->get_name(),
+					'content_name' => $product->get_title(),
 					'content_type' => 'product',
 					'contents'     => wp_json_encode(
 						array(
@@ -655,7 +655,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 				$params = array(
 					'content_ids'  => wp_json_encode( \WC_Facebookcommerce_Utils::get_fb_content_ids( $product ) ),
-					'content_name' => $product->get_name(),
+					'content_name' => $product->get_title(),
 					'content_type' => 'product',
 					'contents'     => wp_json_encode(
 						array(
@@ -846,7 +846,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 				if ( $product ) {
 					$product_ids[]   = \WC_Facebookcommerce_Utils::get_fb_content_ids( $product );
-					$product_names[] = $product->get_name();
+					$product_names[] = $product->get_title();
 
 					if ( 'product_group' !== $content_type && $product->is_type( 'variable' ) ) {
 						$content_type = 'product_group';
@@ -1061,7 +1061,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 					if ( isset( $item['data'] ) && $item['data'] instanceof \WC_Product ) {
 
-						$product_names[] = $item['data']->get_name();
+						$product_names[] = $item['data']->get_title();
 					}
 				}
 			}

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -517,7 +517,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			$event_data = array(
 				'event_name'  => 'ViewContent',
 				'custom_data' => array(
-					'content_name'     => $product->get_title(),
+					'content_name'     => \WC_Facebookcommerce_Utils::clean_string( $product->get_title() ),
 					'content_ids'      => wp_json_encode( \WC_Facebookcommerce_Utils::get_fb_content_ids( $product ) ),
 					'content_type'     => $content_type,
 					'contents'         => wp_json_encode(
@@ -583,7 +583,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				'event_name'  => 'AddToCart',
 				'custom_data' => array(
 					'content_ids'  => wp_json_encode( \WC_Facebookcommerce_Utils::get_fb_content_ids( $product ) ),
-					'content_name' => $product->get_title(),
+					'content_name' => \WC_Facebookcommerce_Utils::clean_string( $product->get_title() ),
 					'content_type' => 'product',
 					'contents'     => wp_json_encode(
 						array(
@@ -655,7 +655,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 				$params = array(
 					'content_ids'  => wp_json_encode( \WC_Facebookcommerce_Utils::get_fb_content_ids( $product ) ),
-					'content_name' => $product->get_title(),
+					'content_name' => \WC_Facebookcommerce_Utils::clean_string( $product->get_title() ),
 					'content_type' => 'product',
 					'contents'     => wp_json_encode(
 						array(
@@ -846,7 +846,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 				if ( $product ) {
 					$product_ids[]   = \WC_Facebookcommerce_Utils::get_fb_content_ids( $product );
-					$product_names[] = $product->get_title();
+					$product_names[] = \WC_Facebookcommerce_Utils::clean_string( $product->get_title() );
 
 					if ( 'product_group' !== $content_type && $product->is_type( 'variable' ) ) {
 						$content_type = 'product_group';

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -1061,7 +1061,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 					if ( isset( $item['data'] ) && $item['data'] instanceof \WC_Product ) {
 
-						$product_names[] = $item['data']->get_title();
+						$product_names[] = \WC_Facebookcommerce_Utils::clean_string( $item['data']->get_title() );
 					}
 				}
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We received a report ( #2774 ) pointing out inconsistencies in populating the content_name property in events we send to Meta, sometimes using `get_title()` vs `get_name()`. I have looked into this and found that `get_title()` applies the `woocommerce_product_title` filter to the product name prop. This may result in different values being sent to Facebook. I also find that [we use get_title for the catalog data](https://github.com/woocommerce/facebook-for-woocommerce/blob/df03a97e449b242c1ef59ddc70eac2de966cc3e8/includes/fbproduct.php#L657), so I propose we use the get_title method

Closes #2774.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:


1. Use the `woocommerce_product_title` filter. E.g.:

```
function custom_woocommerce_product_title_prefix( $title, $product ) {
    // Add the prefix "Special: " to the product title
    $title = 'Special: ' . $title;

    return $title;
}
add_filter( 'woocommerce_product_title', 'custom_woocommerce_product_title_prefix', 10, 2 );

```

2. Using the FB pixel helper browser extension, visit a product and confirm that the ViewContent event fires and all the details are confirmed.
3. Repeat this with the addToCart, Checkout and Purchase Events


### Additional details:



### Changelog entry

> Update - Use get_title() for content_name to match catalog name.
