### PR TITLE
Redoing how we fetch access tokens from WooCommerce Connect Server.

### DIFF
--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -36,6 +36,8 @@ class Connection {
 	/** @var string WooCommerce connection proxy URL */
 	const PROXY_URL = 'https://api.woocommerce.com/integrations/auth/facebook/';
 
+	const PROXY_TOKEN_EXCHANGE_URL = 'https://api.woocommerce.com/integrations/exchange/facebook/';
+
 	/** @var string WooCommerce connection for APP Store login URL */
 	const APP_STORE_LOGIN_URL = 'https://api.woocommerce.com/integrations/app-store-login/facebook/';
 
@@ -47,6 +49,8 @@ class Connection {
 
 	/** @var string the action callback for the connection */
 	const ACTION_CONNECT = 'wc_facebook_connect';
+
+	const ACTION_EXCHANGE = 'wc_facebook_exchange';
 
 	/** @var string the action callback for the disconnection */
 	const ACTION_DISCONNECT = 'wc_facebook_disconnect';
@@ -246,14 +250,43 @@ class Connection {
 			if ( empty( $_GET['nonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_GET['nonce'] ) ), self::ACTION_CONNECT ) ) {
 				throw new ApiException( 'Invalid nonce' );
 			}
-			$is_error                 = ! empty( $_GET['err'] ) ? true : false;
-			$error_code               = ! empty( $_GET['err_code'] ) ? stripslashes( wc_clean( wp_unslash( $_GET['err_code'] ) ) ) : '';
-			$merchant_access_token    = ! empty( $_GET['merchant_access_token'] ) ? wc_clean( wp_unslash( $_GET['merchant_access_token'] ) ) : '';
-			$system_user_access_token = ! empty( $_GET['system_user_access_token'] ) ? wc_clean( wp_unslash( $_GET['system_user_access_token'] ) ) : '';
-			$system_user_id           = ! empty( $_GET['system_user_id'] ) ? wc_clean( wp_unslash( $_GET['system_user_id'] ) ) : '';
+
+			$is_error   = ! empty( $_GET['err'] ) ? true : false;
+			$error_code = ! empty( $_GET['err_code'] ) ? stripslashes( wc_clean( wp_unslash( $_GET['err_code'] ) ) ) : '';
 			if ( $is_error && $error_code ) {
 				throw new ConnectApiException( $error_code );
 			}
+
+			$facebook_auth_code = $_GET['code'] ?? '';
+			if ( empty( $facebook_auth_code ) ) {
+				throw new ApiException( 'Facebook auth code is missing.' );
+			}
+
+			$response = wp_safe_remote_get(
+				self::PROXY_TOKEN_EXCHANGE_URL,
+				[
+					'nonce'                => wp_create_nonce( self::ACTION_EXCHANGE ),
+					'code'                 => $facebook_auth_code,
+					'external_business_id' => $this->get_external_business_id(),
+					'type'                 => self::AUTH_TYPE_STANDARD,
+				]
+			);
+
+			if ( is_wp_error( $response ) ) {
+				throw new ApiException( 'WooCommerce Connect Server token exchange has failed.' );
+			}
+
+			$token_data = json_decode( wp_remote_retrieve_body( $response ), true );
+
+			// Check that request was initiated from the server.
+			if ( ! wp_verify_nonce( $token_data['nonce'] ?? '', self::ACTION_EXCHANGE ) ) {
+				throw new ApiException( 'Exchange nonce is not valid.' );
+			}
+
+			$merchant_access_token    = ! empty( $token_data['merchant_access_token'] ) ? wc_clean( wp_unslash( $token_data['merchant_access_token'] ) ) : '';
+			$system_user_access_token = ! empty( $token_data['system_user_access_token'] ) ? wc_clean( wp_unslash( $token_data['system_user_access_token'] ) ) : '';
+			$system_user_id           = ! empty( $token_data['system_user_id'] ) ? wc_clean( wp_unslash( $token_data['system_user_id'] ) ) : '';
+
 			if ( ! $merchant_access_token ) {
 				throw new ApiException( 'Access token is missing' );
 			}

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -34,9 +34,9 @@ class Connection {
 	const OAUTH_URL = 'https://facebook.com/dialog/oauth';
 
 	/** @var string WooCommerce connection proxy URL */
-	const PROXY_URL = 'https://api.woocommerce.com/integrations/auth/facebook/';
+	const PROXY_URL = 'https://api.woocommerce.com/integrations/v2/auth/facebook/';
 
-	const PROXY_TOKEN_EXCHANGE_URL = 'https://api.woocommerce.com/integrations/exchange/facebook/';
+	const PROXY_TOKEN_EXCHANGE_URL = 'https://api.woocommerce.com/integrations/v2/exchange/facebook/';
 
 	/** @var string WooCommerce connection for APP Store login URL */
 	const APP_STORE_LOGIN_URL = 'https://api.woocommerce.com/integrations/app-store-login/facebook/';

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -34,15 +34,15 @@ class Connection {
 	const OAUTH_URL = 'https://facebook.com/dialog/oauth';
 
 	/** @var string WooCommerce connection proxy URL */
-	const PROXY_URL = 'https://wcs.jurassic.tube/integrations/v2/auth/facebook/';
+	const PROXY_URL = 'https://api.woocommerce.com/integrations/v2/auth/facebook/';
 
-	const PROXY_TOKEN_EXCHANGE_URL = 'https://wcs.jurassic.tube/integrations/v2/exchange/facebook/';
+	const PROXY_TOKEN_EXCHANGE_URL = 'https://api.woocommerce.com/integrations/v2/exchange/facebook/';
 
 	/** @var string WooCommerce connection for APP Store login URL */
-	const APP_STORE_LOGIN_URL = 'https://wcs.jurassic.tube/integrations/app-store-login/facebook/';
+	const APP_STORE_LOGIN_URL = 'https://api.woocommerce.com/integrations/app-store-login/facebook/';
 
 	/** @var string WooCommerce connection authentication URL */
-	const CONNECTION_AUTHENTICATION_URL = 'https://wcs.jurassic.tube/integrations/auth/facebookcommerce/';
+	const CONNECTION_AUTHENTICATION_URL = 'https://api.woocommerce.com/integrations/auth/facebookcommerce/';
 
 	/** @var string the Standard Auth type */
 	const AUTH_TYPE_STANDARD = 'standard';

--- a/includes/Handlers/Connection.php
+++ b/includes/Handlers/Connection.php
@@ -34,15 +34,15 @@ class Connection {
 	const OAUTH_URL = 'https://facebook.com/dialog/oauth';
 
 	/** @var string WooCommerce connection proxy URL */
-	const PROXY_URL = 'https://api.woocommerce.com/integrations/v2/auth/facebook/';
+	const PROXY_URL = 'https://wcs.jurassic.tube/integrations/v2/auth/facebook/';
 
-	const PROXY_TOKEN_EXCHANGE_URL = 'https://api.woocommerce.com/integrations/v2/exchange/facebook/';
+	const PROXY_TOKEN_EXCHANGE_URL = 'https://wcs.jurassic.tube/integrations/v2/exchange/facebook/';
 
 	/** @var string WooCommerce connection for APP Store login URL */
-	const APP_STORE_LOGIN_URL = 'https://api.woocommerce.com/integrations/app-store-login/facebook/';
+	const APP_STORE_LOGIN_URL = 'https://wcs.jurassic.tube/integrations/app-store-login/facebook/';
 
 	/** @var string WooCommerce connection authentication URL */
-	const CONNECTION_AUTHENTICATION_URL = 'https://api.woocommerce.com/integrations/auth/facebookcommerce/';
+	const CONNECTION_AUTHENTICATION_URL = 'https://wcs.jurassic.tube/integrations/auth/facebookcommerce/';
 
 	/** @var string the Standard Auth type */
 	const AUTH_TYPE_STANDARD = 'standard';
@@ -258,11 +258,11 @@ class Connection {
 			}
 
 			$facebook_auth_code = $_GET['code'] ?? '';
-			$state			  	= $_GET['state'] ?? '';
 			if ( empty( $facebook_auth_code ) ) {
 				throw new ApiException( 'Facebook auth code is missing.' );
 			}
 
+			$state = $_GET['state'] ?? '';
 			if ( empty( $state ) ) {
 				throw new ApiException( 'Missing state query parameter.' );
 			}
@@ -276,7 +276,7 @@ class Connection {
 				) );
 
 			$request_url = self::PROXY_TOKEN_EXCHANGE_URL . $parameters_string;
-			$response = wp_safe_remote_get(
+			$response    = wp_safe_remote_get(
 				$request_url,
 				array(
 					'timeout' => 60,
@@ -298,9 +298,9 @@ class Connection {
 				throw new ApiException( 'Exchange nonce is not valid.' );
 			}
 
-			$merchant_access_token    = ! empty( $token_data['merchant_access_token'] ) ? wc_clean( wp_unslash( $token_data['merchant_access_token'] ) ) : '';
-			$system_user_access_token = ! empty( $token_data['system_user_access_token'] ) ? wc_clean( wp_unslash( $token_data['system_user_access_token'] ) ) : '';
-			$system_user_id           = ! empty( $token_data['system_user_id'] ) ? wc_clean( wp_unslash( $token_data['system_user_id'] ) ) : '';
+			$merchant_access_token    = wc_clean( wp_unslash( $token_data['merchant_access_token']    ?? '' ) ) ;
+			$system_user_access_token = wc_clean( wp_unslash( $token_data['system_user_access_token'] ?? '' ) ) ;
+			$system_user_id           = wc_clean( wp_unslash( $token_data['system_user_id']           ?? '' ) ) ;
 
 			if ( ! $merchant_access_token ) {
 				throw new ApiException( 'Access token is missing' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Must be tested together with https://github.com/Automattic/woocommerce-connect-server/pull/2563.

Refactors how oAuth access tokens are obtained. Instead of taking them from the incoming query string, a call to WooCommerce Connect Sever to exchange the incoming oAuth code for the access token is made.

### Detailed test instructions:

1. Set up a local wcs environment using the `woocommerce-connect-server`'s (https://github.com/Automattic/woocommerce-connect-server/pull/2563) branch.
2. Configure the extension to use your local WooCommerce Connect Server version by search-replacing api.woocommerce.com with your local wcs url through the includes/Handlers/Connection.php file of the plugin.
4. Try to connect your Facebook for WooCommerce plugin to Facebook.


### Changelog entry

> Update - Access Token retrieval procedure.
