### PR TITLE
Removes WooCommerce navigation items

### DIFF
--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -41,13 +41,6 @@ class Settings {
 	private $screens;
 
 	/**
-	 * Whether the new Woo nav should be used.
-	 *
-	 * @var bool
-	 */
-	public $use_woo_nav;
-
-	/**
 	 * Settings constructor.
 	 *
 	 * @param bool $is_connected is the state of the plugin connection to the Facebook Marketing API
@@ -91,9 +84,7 @@ class Settings {
 	public function add_menu_item() {
 		$root_menu_item       = 'woocommerce';
 		$is_marketing_enabled = false;
-		$this->use_woo_nav    = class_exists( WooAdminFeatures::class )
-			&& class_exists( WooAdminMenu::class )
-			&& WooAdminFeatures::is_enabled( 'navigation' );
+
 		if ( Compatibility::is_enhanced_admin_available() ) {
 			if ( class_exists( WooAdminFeatures::class ) ) {
 				$is_marketing_enabled = WooAdminFeatures::is_enabled( 'marketing' );
@@ -115,7 +106,6 @@ class Settings {
 			5
 		);
 		$this->connect_to_enhanced_admin( $is_marketing_enabled ? 'marketing_page_wc-facebook' : 'woocommerce_page_wc-facebook' );
-		$this->register_woo_nav_menu_items();
 
 		if ( $is_marketing_enabled ) {
 			$this->add_fb_product_sets_to_marketing_menu();
@@ -218,13 +208,11 @@ class Settings {
 		$screen = $this->get_screen( $current_tab );
 		?>
 		<div class="wrap woocommerce">
-			<?php if ( ! $this->use_woo_nav ) : ?>
-				<nav class="nav-tab-wrapper woo-nav-tab-wrapper">
-					<?php foreach ( $tabs as $id => $label ) : ?>
-						<a href="<?php echo esc_html( admin_url( 'admin.php?page=' . self::PAGE_ID . '&tab=' . esc_attr( $id ) ) ); ?>" class="nav-tab <?php echo $current_tab === $id ? 'nav-tab-active' : ''; ?>"><?php echo esc_html( $label ); ?></a>
-					<?php endforeach; ?>
-				</nav>
-			<?php endif; ?>
+			<nav class="nav-tab-wrapper woo-nav-tab-wrapper">
+				<?php foreach ( $tabs as $id => $label ) : ?>
+					<a href="<?php echo esc_html( admin_url( 'admin.php?page=' . self::PAGE_ID . '&tab=' . esc_attr( $id ) ) ); ?>" class="nav-tab <?php echo $current_tab === $id ? 'nav-tab-active' : ''; ?>"><?php echo esc_html( $label ); ?></a>
+				<?php endforeach; ?>
+			</nav>
 			<?php facebook_for_woocommerce()->get_message_handler()->show_messages(); ?>
 			<?php if ( $screen ) : ?>
 				<h1 class="screen-reader-text"><?php echo esc_html( $screen->get_title() ); ?></h1>
@@ -332,39 +320,5 @@ class Settings {
 		 * @param array $tabs tab data, as $id => $label
 		 */
 		return (array) apply_filters( 'wc_facebook_admin_settings_tabs', $tabs, $this );
-	}
-
-	/**
-	 * Register nav items for new Woo nav.
-	 *
-	 * @since 2.3.3
-	 */
-	private function register_woo_nav_menu_items() {
-		if ( ! $this->use_woo_nav ) {
-			return;
-		}
-		WooAdminMenu::add_plugin_category(
-			array(
-				'id'         => 'facebook-for-woocommerce',
-				'title'      => __( 'Facebook', 'facebook-for-woocommerce' ),
-				'capability' => 'manage_woocommerce',
-			)
-		);
-		$order = 1;
-		foreach ( $this->get_screens() as $screen_id => $screen ) {
-			$url = $screen instanceof Settings_Screens\Product_Sets
-				? 'edit-tags.php?taxonomy=fb_product_set&post_type=product'
-				: 'wc-facebook&tab=' . $screen->get_id();
-			WooAdminMenu::add_plugin_item(
-				array(
-					'id'     => 'facebook-for-woocommerce-' . $screen->get_id(),
-					'parent' => 'facebook-for-woocommerce',
-					'title'  => $screen->get_label(),
-					'url'    => $url,
-					'order'  => $order,
-				)
-			);
-			++$order;
-		}
 	}
 }

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -11,7 +11,6 @@
 namespace WooCommerce\Facebook\Admin;
 
 use Automattic\WooCommerce\Admin\Features\Features as WooAdminFeatures;
-use Automattic\WooCommerce\Admin\Features\Navigation\Menu as WooAdminMenu;
 use WooCommerce\Facebook\Admin\Settings_Screens;
 use WooCommerce\Facebook\Admin\Settings_Screens\Connection;
 use WooCommerce\Facebook\Framework\Helper;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #2799.

This PR reverts PR: #1802 

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Scan the code for `Automattic\WooCommerce\Admin\Features\Navigation\Menu` class being used.
2. Verify there is no usage of this class.
3. Verify there is no code related to adding WooCommerce nav is present.


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Break - Removes WooCommerce navigation items
