### PR TITLE
Remove Products Set Menu entry.

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -201,13 +201,17 @@ install_wc() {
     # Grab the necessary plugins.
     WC_TMPDIR="${TMPDIR}/woocommerce-${WC_VERSION}"
     rm -rf "${WC_TMPDIR}"
-    git clone --quiet --depth=1 --branch="${WC_VERSION}" https://github.com/woocommerce/woocommerce.git "${WC_TMPDIR}"
+    git clone --quiet --depth=1 --branch="$WC_VERSION" https://github.com/woocommerce/woocommerce.git "$WC_TMPDIR"
+
+    # Install composer for WooCommerce
+    cd "$WC_TMPDIR"/plugins/woocommerce
+    composer install --ignore-platform-reqs --no-interaction --no-dev
+
+  # Symlink woocommerce plugin
     mv "${WC_TMPDIR}"/plugins/woocommerce/* "$WC_DIR"
 	touch "$WC_VERSION_FILE"
 
-    # Install composer for WooCommerce
     cd "${WC_DIR}"
-    composer install --ignore-platform-reqs --no-interaction --no-dev
 
     # Generate feature config for WooCommerce
     GENERATE_FEATURE_CONFIG=bin/generate-feature-config.php

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -105,34 +105,6 @@ class Settings {
 			5
 		);
 		$this->connect_to_enhanced_admin( $is_marketing_enabled ? 'marketing_page_wc-facebook' : 'woocommerce_page_wc-facebook' );
-
-		if ( $is_marketing_enabled ) {
-			$this->add_fb_product_sets_to_marketing_menu();
-		}
-	}
-
-	/**
-	 * Checks for connection and if established adds Facebook Product Sets taxonomy page to the Marketing menu.
-	 *
-	 * @since 2.6.29
-	 */
-	private function add_fb_product_sets_to_marketing_menu() {
-		$is_connected = facebook_for_woocommerce()->get_connection_handler()->is_connected();
-
-		// If a connection is not established, do not add Facebook Product Sets to Marketing menu.
-		if ( ! $is_connected ) {
-			return;
-		}
-
-		add_submenu_page(
-			'woocommerce-marketing',
-			esc_html__( 'Facebook Product Sets', 'facebook-for-woocommerce' ),
-			esc_html__( 'Facebook Product Sets', 'facebook-for-woocommerce' ),
-			'manage_woocommerce',
-			admin_url( self::SUBMENU_PAGE_ID ),
-			'',
-			10
-		);
 	}
 
 	/**

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -107,8 +107,8 @@ class Settings {
 
 		$root_menu_item = $this->root_menu_item();
 
-		if ( $pagenow == 'edit-tags.php' ) {
-			if ( isset( $_GET['taxonomy'] ) && $_GET['taxonomy'] == 'fb_product_set' ) {
+		if ( 'edit-tags.php' == $pagenow ) {
+			if ( isset( $_GET['taxonomy'] ) && 'fb_product_set' == $_GET['taxonomy'] ) {
 				$parent_file  = $root_menu_item;
 				$submenu_file = self::PAGE_ID; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			}

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -107,7 +107,7 @@ class Settings {
 
 		$root_menu_item = $this->root_menu_item();
 
-		if ( 'edit-tags.php' === $pagenow ) {
+		if ( 'edit-tags.php' === $pagenow || 'term.php' === $pagenow ) {
 			if ( isset( $_GET['taxonomy'] ) && 'fb_product_set' === $_GET['taxonomy'] ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$parent_file  = $root_menu_item;
 				$submenu_file = self::PAGE_ID; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -110,7 +110,7 @@ class Settings {
 		if ( $pagenow == 'edit-tags.php' ) {
 			if ( isset( $_GET['taxonomy'] ) && $_GET['taxonomy'] == 'fb_product_set' ) {
 				$parent_file  = $root_menu_item;
-				$submenu_file = self::PAGE_ID;
+				$submenu_file = self::PAGE_ID; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			}
 		}
 

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -118,6 +118,7 @@ class Settings {
 	}
 
 	/**
+	 * Get root menu item.
 	 *
 	 * @since x.x.x
 	 * return string Root menu item slug.
@@ -131,6 +132,7 @@ class Settings {
 	}
 
 	/**
+	 * Check if marketing feature is enabled.
 	 *
 	 * @since x.x.x
 	 * return bool Is marketing enabled.

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -103,12 +103,12 @@ class Settings {
 	 * @return string
 	 */
 	public function set_parent_and_submenu_file( $parent_file ) {
-		global $pagenow, $submenu_file, $current_screen;
+		global $pagenow, $submenu_file;
 
 		$root_menu_item = $this->root_menu_item();
 
-		if ( 'edit-tags.php' == $pagenow ) {
-			if ( isset( $_GET['taxonomy'] ) && 'fb_product_set' == $_GET['taxonomy'] ) {
+		if ( 'edit-tags.php' === $pagenow ) {
+			if ( isset( $_GET['taxonomy'] ) && 'fb_product_set' === $_GET['taxonomy'] ) { //phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				$parent_file  = $root_menu_item;
 				$submenu_file = self::PAGE_ID; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The Products Sets menu entry is redundant. The Product sets tab from the Marketing -> Facebook is enough to access the feature.

The entry has been removed. The file filter has been update to highlight the proper menu item.


- [ ] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:
<img width="1769" alt="image" src="https://github.com/user-attachments/assets/969a536a-bac1-4765-8cb4-44c1a1c4720d">

<!--- Optional --->


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Marketing, Product Sets menu item should not be present
2. Access via Marketing -> Facebook -> Product Sets tab should work.
3. Products Sets functionality should not be broken.


### Additional details:
none

<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Update: Remove Marketing Products Sets menu entry.
