### PR TITLE
Show Settings navigation tabs on Product Sets taxonomy screens

### DIFF
--- a/class-wc-facebookcommerce.php
+++ b/class-wc-facebookcommerce.php
@@ -392,7 +392,7 @@ class WC_Facebookcommerce extends WooCommerce\Facebook\Framework\Plugin {
 				// translators: No items found text
 				'not_found'                  => sprintf( esc_html__( 'No %s found.', 'facebook-for-woocommerce' ), $plural ),
 				// translators: Search label
-				'search_items'               => sprintf( esc_html__( 'Search %s.', 'facebook-for-woocommerce' ), $plural ),
+				'search_items'               => sprintf( esc_html__( 'Search %s', 'facebook-for-woocommerce' ), $plural ),
 				// translators: Text label
 				'separate_items_with_commas' => sprintf( esc_html__( 'Separate %s with commas', 'facebook-for-woocommerce' ), $plural ),
 				// translators: Text label

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -14,7 +14,6 @@ use Automattic\WooCommerce\Admin\Features\Features as WooAdminFeatures;
 use WooCommerce\Facebook\Admin\Settings_Screens;
 use WooCommerce\Facebook\Admin\Settings_Screens\Connection;
 use WooCommerce\Facebook\Framework\Helper;
-use WooCommerce\Facebook\Framework\Plugin\Compatibility;
 use WooCommerce\Facebook\Framework\Plugin\Exception as PluginException;
 
 defined( 'ABSPATH' ) || exit;
@@ -53,7 +52,7 @@ class Settings {
 		add_action( 'wp_loaded', array( $this, 'save' ) );
 		add_filter( 'parent_file', array( $this, 'set_parent_and_submenu_file' ) );
 
-		add_action( 'admin_head', array( $this, 'add_tabs_to_product_sets_taxonomy' ) );
+		add_action( 'all_admin_notices', array( $this, 'add_tabs_to_product_sets_taxonomy' ) );
 	}
 
 	/**
@@ -349,6 +348,7 @@ class Settings {
 	 * @since 3.3.0
 	 */
 	public function add_tabs_to_product_sets_taxonomy() {
+
 		// Only load this on the edit-tags.php page
 		$screen                  = get_current_screen();
 		$is_taxonomy_list_page   = 'edit-tags' === $screen->base;
@@ -361,48 +361,27 @@ class Settings {
 			?>
 				<style>
 					.facebook-for-woocommerce-tabs {
-						margin-top: 20px;
-						margin-bottom: 10px;
-						display: none;
+						margin: 30px 20px 0 20px;
 					}
 					#wpbody-content > .wrap > h1 {
-						margin-top: 65px;
 						font-size: 1.3em;
 						font-weight: 600;
 					}
-					<?php
-					// On the taxonomy list page in mobile view, account for the Screen Options tab.
-					if ( $is_taxonomy_list_page ) :
-						?>
+
 					@media (max-width: 782px) {
 						.facebook-for-woocommerce-tabs {
-								padding-top: 0;
-								position: relative;
-								top: -10px;
-								margin-bottom: -10px;
-							}
+								padding-top: 19px;
+								margin-bottom: -1px;
 						}
-					<?php endif; ?>
+						.edit-tags-php .facebook-for-woocommerce-tabs {
+							clear: both;
+							padding-top: 0;
+							position: relative;
+							top: -10px;
+							margin-bottom: -11px;
+						}
 				</style>
-				<script>
-						document.addEventListener('DOMContentLoaded', function() {
-								// Insert custom tabs into #wpbody
-								let tabs = document.querySelector('nav.facebook-for-woocommerce-tabs');
-								if (tabs) {
-										let wpbody = document.querySelector('#wpbody-content > .wrap');
-										if (wpbody) {		
-											// move tabs to the top of wpbody
-											wpbody.insertBefore(tabs, wpbody.firstChild);
-											tabs.style.display = 'block';
-											let header = wpbody.querySelector('h1');
-											if (header) {
-												header.style.marginTop = '0px';
-											}
-										}
-								}
-						});
-				</script>
-				<?php
+			<?php
 		}
 	}
 }

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -391,7 +391,6 @@ class Settings {
 								if (tabs) {
 										let wpbody = document.querySelector('#wpbody-content > .wrap');
 										if (wpbody) {		
-											// wpbody.querySelector('h1').remove();
 											// move tabs to the top of wpbody
 											wpbody.insertBefore(tabs, wpbody.firstChild);
 											tabs.style.display = 'block';

--- a/includes/Admin/Settings.php
+++ b/includes/Admin/Settings.php
@@ -52,6 +52,8 @@ class Settings {
 		add_action( 'admin_menu', array( $this, 'add_menu_item' ) );
 		add_action( 'wp_loaded', array( $this, 'save' ) );
 		add_filter( 'parent_file', array( $this, 'set_parent_and_submenu_file' ) );
+
+		add_action( 'admin_head', array( $this, 'add_tabs_to_product_sets_taxonomy' ) );
 	}
 
 	/**
@@ -191,19 +193,11 @@ class Settings {
 	 * @since 2.0.0
 	 */
 	public function render() {
-		$tabs        = $this->get_tabs();
-		$current_tab = Helper::get_requested_value( 'tab' );
-		if ( ! $current_tab ) {
-			$current_tab = current( array_keys( $tabs ) );
-		}
-		$screen = $this->get_screen( $current_tab );
+		$current_tab = $this->get_current_tab();
+		$screen      = $this->get_screen( $current_tab );
 		?>
 		<div class="wrap woocommerce">
-			<nav class="nav-tab-wrapper woo-nav-tab-wrapper">
-				<?php foreach ( $tabs as $id => $label ) : ?>
-					<a href="<?php echo esc_html( admin_url( 'admin.php?page=' . self::PAGE_ID . '&tab=' . esc_attr( $id ) ) ); ?>" class="nav-tab <?php echo $current_tab === $id ? 'nav-tab-active' : ''; ?>"><?php echo esc_html( $label ); ?></a>
-				<?php endforeach; ?>
-			</nav>
+			<?php $this->render_tabs( $current_tab ); ?>
 			<?php facebook_for_woocommerce()->get_message_handler()->show_messages(); ?>
 			<?php if ( $screen ) : ?>
 				<h1 class="screen-reader-text"><?php echo esc_html( $screen->get_title() ); ?></h1>
@@ -212,6 +206,40 @@ class Settings {
 			<?php endif; ?>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Render the Facebook for WooCommerce extension navigation tabs.
+	 *
+	 * @since 3.3.0
+	 *
+	 * @param string $current_tab The current tab ID.
+	 */
+	public function render_tabs( $current_tab ) {
+		$tabs = $this->get_tabs();
+		?>
+		<nav class="nav-tab-wrapper woo-nav-tab-wrapper facebook-for-woocommerce-tabs">
+			<?php foreach ( $tabs as $id => $label ) : ?>
+				<a href="<?php echo esc_html( admin_url( 'admin.php?page=' . self::PAGE_ID . '&tab=' . esc_attr( $id ) ) ); ?>" class="nav-tab <?php echo $current_tab === $id ? 'nav-tab-active' : ''; ?>"><?php echo esc_html( $label ); ?></a>
+			<?php endforeach; ?>
+		</nav>
+		<?php
+	}
+
+	/**
+	 * Get the current tab ID.
+	 *
+	 * @since 3.3.0
+	 *
+	 * @return string
+	 */
+	protected function get_current_tab() {
+		$tabs        = $this->get_tabs();
+		$current_tab = Helper::get_requested_value( 'tab' );
+		if ( ! $current_tab ) {
+			$current_tab = current( array_keys( $tabs ) );
+		}
+		return $current_tab;
 	}
 
 
@@ -311,5 +339,71 @@ class Settings {
 		 * @param array $tabs tab data, as $id => $label
 		 */
 		return (array) apply_filters( 'wc_facebook_admin_settings_tabs', $tabs, $this );
+	}
+
+	/**
+	 * Add the Facebook for WooCommerce tabs to the Facebook Product Set taxonomy page.
+	 * Renders the tabs (hidden by default) at the stop of the page,
+	 * then moves them to the correct DOM location with JavaScript and displays them.
+	 *
+	 * @since 3.3.0
+	 */
+	public function add_tabs_to_product_sets_taxonomy() {
+		// Only load this on the edit-tags.php page
+		$screen                  = get_current_screen();
+		$is_taxonomy_list_page   = 'edit-tags' === $screen->base;
+		$is_taxonomy_term_page   = 'term' === $screen->base;
+		$is_taxonomy_page        = $is_taxonomy_list_page || $is_taxonomy_term_page;
+		$is_product_set_taxonomy = 'fb_product_set' === $screen->taxonomy && $is_taxonomy_page;
+
+		if ( $is_product_set_taxonomy ) {
+			$this->render_tabs( Settings_Screens\Product_Sets::ID );
+			?>
+				<style>
+					.facebook-for-woocommerce-tabs {
+						margin-top: 20px;
+						margin-bottom: 10px;
+						display: none;
+					}
+					#wpbody-content > .wrap > h1 {
+						margin-top: 65px;
+						font-size: 1.3em;
+						font-weight: 600;
+					}
+					<?php
+					// On the taxonomy list page in mobile view, account for the Screen Options tab.
+					if ( $is_taxonomy_list_page ) :
+						?>
+					@media (max-width: 782px) {
+						.facebook-for-woocommerce-tabs {
+								padding-top: 0;
+								position: relative;
+								top: -10px;
+								margin-bottom: -10px;
+							}
+						}
+					<?php endif; ?>
+				</style>
+				<script>
+						document.addEventListener('DOMContentLoaded', function() {
+								// Insert custom tabs into #wpbody
+								let tabs = document.querySelector('nav.facebook-for-woocommerce-tabs');
+								if (tabs) {
+										let wpbody = document.querySelector('#wpbody-content > .wrap');
+										if (wpbody) {		
+											// wpbody.querySelector('h1').remove();
+											// move tabs to the top of wpbody
+											wpbody.insertBefore(tabs, wpbody.firstChild);
+											tabs.style.display = 'block';
+											let header = wpbody.querySelector('h1');
+											if (header) {
+												header.style.marginTop = '0px';
+											}
+										}
+								}
+						});
+				</script>
+				<?php
+		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR renders the basic navigation tabs used on "Connection", "Product Sync", and "Advertise" pages, on the "Product Sets" pages as well. 

They're rendered (hidden) at the top of the corresponding list + edit pages, and then moved in the DOM and displayed. Depending on page load speed, they might not be available for short period, but I've seen the tabs flicker on all the other settings pages of the extension as well.

- [x] Do the changed files pass `phpcs` checks? Please remove `phpcs:ignore` comments in changed files and fix any issues, or delete if not practical.

### Screenshots:

**Before**
![image](https://github.com/user-attachments/assets/8ef9de0b-6e7a-45bb-ab81-c01cea9d40fd)

**After**
![image](https://github.com/user-attachments/assets/8ca6687d-dc8a-4f5f-9750-8c5042e3f039)
![image](https://github.com/user-attachments/assets/c91b4ad0-d6a8-433d-8897-fa781855a35a)

**Other Settings Pages (for comparison)**
![image](https://github.com/user-attachments/assets/a6462fac-3719-4d9c-821b-1dab9d9a46c4)


### Detailed test instructions:
<!-- Add detailed instructions for how to test that this PR fixes the issue and confirm that it doesn't break any other features :) -->

1. Connect a store.
2. Navigate around the different sections of the Facebook for WooCommerce extension.
3. Confirm the navigation tabs appear correctly in the different screens related to Product Sets.
4. Try with several browser resolutions (mobile, desktop, etc).
5. Also confirm that the correct menu item is highlighted always (Marketing > Facebook).


<!--
Optional.
Enter a summary of all changes in this Pull Request, which will be added to the changelog if accepted.
Each line should start with change type prefix`(Fix|Add|…) - `, for example:
> Break - A change breaking previous API or functionality.
> Add - A new feature, function or functionality was added.
> Update - Big changes to something that wasn't broken.
> Fix - Took care of something that wasn't working.
> Tweak - Small change, that isn't actually very important.
> Dev - Developer-facing only change.
> Doc - Updated customer or developer facing documentation

If you remove the "Changelog entry" header, the Pull Request title will be used as the changelog entry.

Add the `changelog: none` label if no changelog entry is needed.
-->
### Changelog entry

> Add - Extension navigation tabs on Product Sets screens.
