### PR TITLE
T206230215: Expose Brand to Woocommerce UI

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -860,6 +860,10 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$woo_product->set_price( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) );
 		}
 
+		if ( isset( $_POST[ WC_Facebook_Product::FB_BRAND ] ) ) {
+			$woo_product->set_fb_brand( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_BRAND ] ) ) );
+		}
+
 		if ( isset( $_POST['fb_product_image_source'] ) ) {
 			$product->update_meta_data( Products::PRODUCT_IMAGE_SOURCE_META_KEY, sanitize_key( wp_unslash( $_POST['fb_product_image_source'] ) ) );
 			$product->save_meta_data();
@@ -893,7 +897,7 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 		 */
 		// phpcs:ignore WordPress.Security.NonceVerification.Missing
 		if ( ( ! wp_doing_ajax() || ! isset( $_POST['action'] ) || 'ajax_delete_fb_product' !== $_POST['action'] )
-			 && ! Products::published_product_should_be_synced( $product ) && ! $product->is_type( 'variable' ) ) {
+			&& ! Products::published_product_should_be_synced( $product ) && ! $product->is_type( 'variable' ) ) {
 			return;
 		}
 

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1251,9 +1251,18 @@ class Admin {
 
 				woocommerce_wp_text_input(
 					array(
+						'id'    => \WC_Facebook_Product::FB_BRAND,
+						'label' => __( 'Brand', 'facebook-for-woocommerce' ),
+						'value' => $fb_brand,
+						'class' => 'enable-if-sync-enabled',
+					)
+				);
+
+				woocommerce_wp_text_input(
+					array(
 						'id'          => \WC_Facebook_Product::FB_PRODUCT_PRICE,
 						'label'       => sprintf(
-						 /* translators: Placeholders %1$s - WC currency symbol */
+						/* translators: Placeholders %1$s - WC currency symbol */
 							__( 'Facebook Price (%1$s)', 'facebook-for-woocommerce' ),
 							get_woocommerce_currency_symbol()
 						),


### PR DESCRIPTION
Changes proposed in this Pull Request:

This PR introduces a new feature to the Facebook WooCommerce Plugin, allowing users to add a brand field to their products. With this update, we can seamlessly synchronize the brand field with the Facebook Commerce Manager platform.

<img width="989" alt="Screenshot 2024-10-30 at 18 08 06" src="https://github.com/user-attachments/assets/0efc54f9-88f1-487e-881b-300bd203a3dd">
<img width="527" alt="Screenshot 2024-10-30 at 18 08 36" src="https://github.com/user-attachments/assets/d0cf9ae0-293b-4685-a033-643dc6214a1f">
