### PR TITLE
Add functionality for syncing rich text description to meta

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -860,6 +860,10 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$woo_product->set_price( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_PRICE ] ) ) );
 		}
 
+		if ( isset( $_POST[WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION ] ) ) {
+			$woo_product->set_rich_text_description( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_RICH_TEXT_DESCRIPTION] ) ) );
+		}
+
 		if ( isset( $_POST['fb_product_image_source'] ) ) {
 			$product->update_meta_data( Products::PRODUCT_IMAGE_SOURCE_META_KEY, sanitize_key( wp_unslash( $_POST['fb_product_image_source'] ) ) );
 			$product->save_meta_data();

--- a/includes/fbutils.php
+++ b/includes/fbutils.php
@@ -252,14 +252,14 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 		 * Clean up strings for FB Graph POSTing.
 		 * This function should will:
 		 * 1. Replace newlines chars/nbsp with a real space
-		 * 2. strip_tags()
+		 * 2. strip_tags() if not explicitly stated to not
 		 * 3. trim()
 		 *
 		 * @access public
 		 * @param String string
 		 * @return string
 		 */
-		public static function clean_string( $string ) {
+		public static function clean_string( $string, $strip_html_tags = true ) {
 
 			/**
 			 * Filters whether the shortcodes should be applied for a string when syncing a product or be stripped out.
@@ -280,7 +280,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_Utils' ) ) :
 
 			$string = str_replace( array( '&amp%3B', '&amp;' ), '&', $string );
 			$string = str_replace( array( "\r", '&nbsp;', "\t" ), ' ', $string );
-			$string = wp_strip_all_tags( $string, false ); // true == remove line breaks
+			if ($strip_html_tags){
+				$string = wp_strip_all_tags( $string, false ); // true == remove line breaks
+			}
 			return $string;
 		}
 


### PR DESCRIPTION
Changes proposed in this Pull Request:

This PR introduces a new feature to the Facebook WooCommerce Plugin, allowing users to add rich text descriptions to their products. With this update, we can seamlessly synchronize the rich text description field with the Facebook Commerce Manager platform.

<img width="1244" alt="Screenshot 2024-11-04 at 11 21 23" src="https://github.com/user-attachments/assets/eb1c1fbb-5734-4c27-b710-1e031f1a58e6">
<img width="601" alt="Screenshot 2024-11-04 at 11 22 26" src="https://github.com/user-attachments/assets/a40f84e8-3127-4b62-a87d-c172ab257a98">
<img width="753" alt="Screenshot 2024-11-04 at 11 22 41" src="https://github.com/user-attachments/assets/75063389-5a78-4ae2-a73f-c2a392427472">

