### PR TITLE
T206633739: Expose Brand to Woocommerce UI

### DIFF
--- a/facebook-commerce.php
+++ b/facebook-commerce.php
@@ -865,6 +865,10 @@ class WC_Facebookcommerce_Integration extends WC_Integration {
 			$product->save_meta_data();
 		}
 
+		if ( isset( $_POST[ WC_Facebook_Product::FB_MPN ] ) ) {
+			$woo_product->set_fb_mpn( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_MPN ] ) ) );
+		}
+
 		if ( isset( $_POST[ WC_Facebook_Product::FB_PRODUCT_IMAGE ] ) ) {
 			$woo_product->set_product_image( sanitize_text_field( wp_unslash( $_POST[ WC_Facebook_Product::FB_PRODUCT_IMAGE ] ) ) );
 		}

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -1266,6 +1266,15 @@ class Admin {
 					)
 				);
 
+				woocommerce_wp_text_input(
+					array(
+						'id'    => \WC_Facebook_Product::FB_MPN,
+						'label' => __( 'MPN', 'facebook-for-woocommerce' ),
+						'value' => $fb_mpn,
+						'class' => 'enable-if-sync-enabled',
+					)
+				);
+
 				woocommerce_wp_hidden_input(
 					array(
 						'id'    => \WC_Facebook_Product::FB_REMOVE_FROM_SYNC,


### PR DESCRIPTION
Introducing MPN (Manufacturer Part Number) Support for Facebook WooCommerce Plugin
This PR introduces a new feature to the Facebook WooCommerce Plugin, allowing users to add a Manufacturer Part Number (MPN) field to their products. With this update, we can seamlessly synchronize the MPN field with the Facebook Commerce Manager platform.

<img width="731" alt="Screenshot 2024-11-04 at 15 36 18" src="https://github.com/user-attachments/assets/7d2aa014-c486-4f33-918a-3931babbc1e4">
<img width="761" alt="Screenshot 2024-11-04 at 15 40 50" src="https://github.com/user-attachments/assets/6afe0e3f-0a46-4b9e-b5c9-a90c24f87614">
