### PR TITLE
T208530998: Update catalog link to navigate to correct tab in Commerc…

### DIFF
--- a/includes/Admin/Settings_Screens/Connection.php
+++ b/includes/Admin/Settings_Screens/Connection.php
@@ -159,9 +159,15 @@ class Connection extends Abstract_Settings_Screen {
 		);
 
 		// if the catalog ID is set, update the URL and try to get its name for display
-		if ( $catalog_id = $static_items['catalog']['value'] ) {
-
-			$static_items['catalog']['url'] = "https://facebook.com/products/catalogs/{$catalog_id}";
+		$catalog_id = $static_items['catalog']['value'];
+		$business_id = $static_items['business-manager']['value'];
+		if (!empty($catalog_id)) {
+			if($business_id){
+				$static_items['catalog']['url'] = "https://www.facebook.com/commerce/catalogs/{$catalog_id}/products/?business_id={$business_id}";
+			}
+			else {
+				$static_items['catalog']['url'] = "https://facebook.com/products/catalog/{$catalog_id}";
+			}
 
 			try {
 				$response = facebook_for_woocommerce()->get_api()->get_catalog( $catalog_id );
@@ -169,6 +175,14 @@ class Connection extends Abstract_Settings_Screen {
 					$static_items['catalog']['value'] = $name;
 				}
 			} catch ( ApiException $exception ) {
+				// Log the exception with additional information
+				facebook_for_woocommerce()->log(
+					sprintf(
+						'Connection failed for catalog %s: %s ',
+						$catalogId,
+						$exception->getMessage(),
+					)
+				);
 			}
 		}
 


### PR DESCRIPTION
## Changelog Entry

### Fix
- Update catalog link in Connections tab to navigate to Catalog tab instead of Overview.

### Description
This pull request fixes an issue where the catalog link in the Connections tab navigates to the Overview page instead of the Catalog tab. The fix updates the link to point to the correct location, ensuring that users are directed to the intended page.

### Changes
- Updated the catalog link in the Connections tab to navigate to the Catalog tab.
- Ensured that the link points to the correct location, resolving the navigation issue.

### Screenshots
![Screenshot 2024-11-22 at 13 19 49](https://github.com/user-attachments/assets/5bef12e9-ee25-4ebc-a4f3-b17283c65c9d)
<img width="1716" alt="Screenshot 2024-11-22 at 13 21 24" src="https://github.com/user-attachments/assets/2571da92-7d38-4c95-84ee-690826d54209">


### Detailed Test Instructions
1. Navigate to the Connections tab.
2. Click on the catalog link.
3. Verify that the link directs you to the Catalog tab instead of the Overview page.

### Additional Details
This fix resolves a navigation issue and ensures that users are directed to the correct page when clicking on the catalog link in the Connections tab.